### PR TITLE
Update version to 0.2.2 and fix imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unifideck-decky",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Unified game library for Steam Deck - Epic, GOG, and Steam in one place",
   "type": "module",
   "scripts": {
@@ -17,7 +17,7 @@
     "library"
   ],
   "author": "numan",
-  "license": "MIT",
+  "license": "LGPL-3.0-or-later",
   "devDependencies": {
     "@decky/rollup": "^1.0.0",
     "@rollup/plugin-commonjs": "^21.1.0",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Unifideck",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "author": "numan",
   "flags": [
     "_root"

--- a/src/tabs/TabContainer.ts
+++ b/src/tabs/TabContainer.ts
@@ -6,6 +6,7 @@
  */
 
 import { TabFilter, runFilters, updateUnifideckCache, unifideckGameCache } from './filters';
+import { prefetchCompatByTitles } from './protondb';
 import { gamepadTabbedPageClasses } from '@decky/ui';
 import { call } from '@decky/api';
 import React, { ReactElement } from 'react';
@@ -235,8 +236,6 @@ class TabManager {
                     .map((g: any) => g.title);
                 if (titles.length > 0) {
                     console.log(`[Unifideck] Prefetching compatibility for ${titles.length} games...`);
-                    // Import prefetchCompatByTitles dynamically to avoid circular import
-                    const { prefetchCompatByTitles } = await import('./protondb');
                     // Run in background - don't block tab initialization
                     prefetchCompatByTitles(titles).catch((err: Error) =>
                         console.error('[Unifideck] Compat prefetch error:', err)


### PR DESCRIPTION
- Bump version from 0.2.0 to 0.2.2
- Change license from MIT to LGPL-3.0-or-later
- Fix circular import by moving prefetchCompatByTitles to static import