### PR TITLE
feat: Fix store connexion buttons style

### DIFF
--- a/src/components/settings/LibrarySync.tsx
+++ b/src/components/settings/LibrarySync.tsx
@@ -109,72 +109,70 @@ const LibrarySync: React.FC<LibrarySyncProps> = ({
 
       {/* Progress display */}
       {syncProgress && syncProgress.status !== "idle" && (
-        <PanelSectionRow>
-          <div style={{ fontSize: "12px", width: "100%" }}>
-            {/* Status text */}
-            <div style={{ marginBottom: "5px", opacity: 0.9 }}>
-              {t(
-                syncProgress.current_game.label,
-                syncProgress.current_game.values,
-              )}
-            </div>
-
-            {/* Progress bar */}
-            <div
-              style={{
-                width: "100%",
-                height: "4px",
-                backgroundColor: "#333",
-                borderRadius: "2px",
-                overflow: "hidden",
-              }}
-            >
-              <div
-                style={{
-                  width: `${syncProgress.progress_percent}%`,
-                  height: "100%",
-                  backgroundColor:
-                    syncProgress.status === "error"
-                      ? "#ff6b6b"
-                      : syncProgress.status === "complete"
-                      ? "#4caf50"
-                      : syncProgress.current_phase === "artwork"
-                      ? "#ff9800" // Orange for artwork
-                      : "#1a9fff", // Blue for sync
-                  transition: "width 0.3s ease",
-                }}
-              />
-            </div>
-
-            {/* Stats - different based on phase */}
-            <div style={{ marginTop: "5px", opacity: 0.7 }}>
-              {syncProgress.current_phase === "artwork" ? (
-                // Artwork phase: show artwork progress
-                <>
-                  {t("librarySync.artworkDownloaded", {
-                    synced: syncProgress.artwork_synced || 0,
-                    total: syncProgress.artwork_total || 0,
-                  })}
-                </>
-              ) : (
-                // Sync phase: show game progress
-                <>
-                  {t("librarySync.gamesSynced", {
-                    synced: syncProgress.synced_games || 0,
-                    total: syncProgress.total_games || 0,
-                  })}
-                </>
-              )}
-            </div>
-
-            {/* Error message */}
-            {syncProgress.error && (
-              <div style={{ color: "#ff6b6b", marginTop: "5px" }}>
-                Error: {syncProgress.error}
-              </div>
+        <div style={{ fontSize: "12px", width: "100%" }}>
+          {/* Status text */}
+          <div style={{ marginBottom: "5px", opacity: 0.9 }}>
+            {t(
+              syncProgress.current_game.label,
+              syncProgress.current_game.values,
             )}
           </div>
-        </PanelSectionRow>
+
+          {/* Progress bar */}
+          <div
+            style={{
+              width: "100%",
+              height: "4px",
+              backgroundColor: "#333",
+              borderRadius: "2px",
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                width: `${syncProgress.progress_percent}%`,
+                height: "100%",
+                backgroundColor:
+                  syncProgress.status === "error"
+                    ? "#ff6b6b"
+                    : syncProgress.status === "complete"
+                    ? "#4caf50"
+                    : syncProgress.current_phase === "artwork"
+                    ? "#ff9800" // Orange for artwork
+                    : "#1a9fff", // Blue for sync
+                transition: "width 0.3s ease",
+              }}
+            />
+          </div>
+
+          {/* Stats - different based on phase */}
+          <div style={{ marginTop: "5px", opacity: 0.7 }}>
+            {syncProgress.current_phase === "artwork" ? (
+              // Artwork phase: show artwork progress
+              <>
+                {t("librarySync.artworkDownloaded", {
+                  synced: syncProgress.artwork_synced || 0,
+                  total: syncProgress.artwork_total || 0,
+                })}
+              </>
+            ) : (
+              // Sync phase: show game progress
+              <>
+                {t("librarySync.gamesSynced", {
+                  synced: syncProgress.synced_games || 0,
+                  total: syncProgress.total_games || 0,
+                })}
+              </>
+            )}
+          </div>
+
+          {/* Error message */}
+          {syncProgress.error && (
+            <div style={{ color: "#ff6b6b", marginTop: "5px" }}>
+              Error: {syncProgress.error}
+            </div>
+          )}
+        </div>
       )}
 
       {(storeStatus.epic.includes("Error") ||

--- a/src/components/settings/StoreAuthButton.tsx
+++ b/src/components/settings/StoreAuthButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@decky/ui";
+import { DialogButton } from "@decky/ui";
 import React from "react";
 import { Store } from "../../types/store";
 import { FiLogOut } from "react-icons/fi";
@@ -25,49 +25,38 @@ const StoreAuthButton: React.FC<StoreAuthButtonProps> = ({
   return (
     <>
       <style>{`
-        .store-auth-button {
-            border: none;
-            outline: none;
-            color: #fff !important;
-            transition: background-color 0.2s;
-            background-color: #32373D !important;
-        }
         .store-auth-button.connected {
             background-color: #ef4444 !important;
-        }
-        .store-auth-button:focus, .store-auth-button:hover {
-            background-color: #fff !important;
-            color: #000 !important;
-            cursor: pointer;
+            color: #fff;
         }
         .store-auth-button.connected:focus,
         .store-auth-button.connected:hover {
-            background-color: #fff !important;
             color: #ef4444 !important;
+            background-color: #fff !important;
         }
     `}</style>
-      <Button
+      <DialogButton
         className={`store-auth-button ${
           isConnected ? "connected" : "disconnected"
         }`}
         onClick={() => (isConnected ? onLogout(store) : onStartAuth(store))}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "4px 10px",
+          fontSize: "10px",
+          height: "28px",
+          width: "fit-content",
+          minWidth: "unset",
+        }}
       >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "4px",
-            fontSize: "10px",
-          }}
-        >
-          {isConnected ? (
-            <FiLogOut size={12} />
-          ) : (
-            t("storeConnections.authenticate")
-          )}
-        </div>
-      </Button>
+        {isConnected ? (
+          <FiLogOut size={12} />
+        ) : (
+          t("storeConnections.authenticate")
+        )}
+      </DialogButton>
     </>
   );
 };


### PR DESCRIPTION
Before this fix, the login/logout buttons weren't inheriting the overall theme's style.
Now, you can see that if I use "Round", it correctly applies the border-radius.

Edit: 
I took the opportunity to fix the last visual problem; the part that displays the artwork synchronization information was shifted to the right, the problem is fixed.

New link to build for test
https://we.tl/t-tJ5oaM9TqE

<img width="491" height="1022" alt="Copie d&#39;écran_20260125_152014" src="https://github.com/user-attachments/assets/690d796d-4619-4f09-8ef3-13212cbb4550" />


<img width="490" height="960" alt="Copie d&#39;écran_20260125_203720-2" src="https://github.com/user-attachments/assets/81c09041-646f-46df-af7d-74b372c260a9" />