### PR TITLE
feat: Add Steam restart modal after sync completion

### DIFF
--- a/main.py
+++ b/main.py
@@ -4492,6 +4492,7 @@ class Plugin:
 
             finally:
                 self._is_syncing = False
+                self._cancel_sync = False
 
     async def force_sync_libraries(self, resync_artwork: bool = False) -> Dict[str, Any]:
         """
@@ -5227,6 +5228,7 @@ class Plugin:
 
             finally:
                 self._is_syncing = False
+                self._cancel_sync = False
 
     async def start_background_sync(self) -> Dict[str, Any]:
         """Start background sync service"""

--- a/main.py
+++ b/main.py
@@ -1397,9 +1397,8 @@ class SyncProgress:
         'fetching': (0, 10),
         'checking_installed': (10, 20),
         'syncing': (20, 40),
-        'unifidb_lookup': (40, 47),
-        'metacritic_fetch': (47, 54),
-        'sgdb_lookup': (54, 60),
+        'unifidb_lookup': (40, 50),
+        'sgdb_lookup': (50, 60),
         'checking_artwork': (60, 65),
         'artwork': (65, 95),
         'proton_setup': (95, 98),
@@ -1423,13 +1422,11 @@ class SyncProgress:
         self.artwork_synced = 0
         self.current_phase = "sync"  # "sync" or "artwork"
 
-        # Steam/unifiDB/Metacritic metadata tracking
+        # Steam/unifiDB metadata tracking
         self.steam_total = 0
         self.steam_synced = 0
         self.unifidb_total = 0
         self.unifidb_synced = 0
-        self.metacritic_total = 0
-        self.metacritic_synced = 0
 
         # Lock for thread-safe updates during parallel downloads
         self._lock = asyncio.Lock()
@@ -1476,20 +1473,6 @@ class SyncProgress:
             }
             return self.unifidb_synced
 
-    async def increment_metacritic(self, game_title: str) -> int:
-        """Thread-safe Metacritic metadata counter increment"""
-        async with self._lock:
-            self.metacritic_synced += 1
-            self.current_game = {
-                "label": "sync.fetchingMetacriticData",
-                "values": {
-                    "synced": self.metacritic_synced,
-                    "total": self.metacritic_total,
-                    "game_title": game_title
-                }
-            }
-            return self.metacritic_synced
-
     def _calculate_progress(self) -> int:
         """Calculate progress based on current phase and its percentage allocation.
         
@@ -1505,10 +1488,6 @@ class SyncProgress:
         
         if self.status == 'unifidb_lookup' and self.unifidb_total > 0:
             sub_progress = self.unifidb_synced / self.unifidb_total
-            return int(start_pct + (end_pct - start_pct) * sub_progress)
-        
-        if self.status == 'metacritic_fetch' and self.metacritic_total > 0:
-            sub_progress = self.metacritic_synced / self.metacritic_total
             return int(start_pct + (end_pct - start_pct) * sub_progress)
         
         if self.status == 'syncing' and self.steam_total > 0:
@@ -1531,13 +1510,11 @@ class SyncProgress:
             'artwork_total': self.artwork_total,
             'artwork_synced': self.artwork_synced,
             'current_phase': self.current_phase,
-            # Steam/unifiDB/Metacritic fields
+            # Steam/unifiDB metadata fields
             'steam_total': self.steam_total,
             'steam_synced': self.steam_synced,
             'unifidb_total': self.unifidb_total,
-            'unifidb_synced': self.unifidb_synced,
-            'metacritic_total': self.metacritic_total,
-            'metacritic_synced': self.metacritic_synced
+            'unifidb_synced': self.unifidb_synced
         }
 
 
@@ -4227,64 +4204,6 @@ class Plugin:
                     else:
                         logger.info(f"Sync: No games need unifiDB lookup")
 
-                # === METACRITIC METADATA FETCH ===
-                # Fetch Metacritic scores/data from backend API (sequential with rate limiting)
-                if all_games:
-                    logger.info(f"[SYNC PHASE] Starting Metacritic metadata fetch phase")
-                    metacritic_cache = load_metacritic_metadata_cache()
-                    games_needing_metacritic = [g for g in all_games if g.title]
-
-                    if games_needing_metacritic:
-                        logger.info(f"Sync: Fetching Metacritic metadata for {len(games_needing_metacritic)} games")
-                        self.sync_progress.status = "metacritic_fetch"
-                        self.sync_progress.metacritic_total = len(games_needing_metacritic)
-                        self.sync_progress.metacritic_synced = 0
-                        self.sync_progress.current_game = {
-                            "label": "sync.fetchingMetacriticData",
-                            "values": {}
-                        }
-
-                        # Import Metacritic scraper
-                        try:
-                            from backend.metadata.metacritic import fetch_metacritic_metadata
-                        except ImportError as e:
-                            logger.error(f"Failed to import Metacritic module: {e}")
-                            fetch_metacritic_metadata = None
-
-                        async def fetch_metacritic_for_game(game, index, total):
-                            try:
-                                if fetch_metacritic_metadata is None:
-                                    await self.sync_progress.increment_metacritic(game.title)
-                                    return None
-
-                                # Sequential with 0.5s delay between requests
-                                metacritic_data = await fetch_metacritic_metadata(game.title, timeout=10.0, delay=0.5)
-                                await self.sync_progress.increment_metacritic(game.title)
-                                if metacritic_data:
-                                    logger.debug(f"[Metacritic] Got score for {game.title}: {metacritic_data.get('metascore')}")
-                                    return (game.title.lower(), metacritic_data)
-                                else:
-                                    logger.debug(f"[Metacritic] No data for {game.title}")
-                            except Exception as e:
-                                logger.warning(f"[Metacritic] Error for {game.title}: {e}")
-                                await self.sync_progress.increment_metacritic(game.title)
-                            return None
-
-                        # Fetch sequentially to respect rate limits
-                        new_cache_entries = {}
-                        for idx, game in enumerate(games_needing_metacritic):
-                            result = await fetch_metacritic_for_game(game, idx, len(games_needing_metacritic))
-                            if isinstance(result, tuple) and result is not None:
-                                new_cache_entries[result[0]] = result[1]
-
-                        if new_cache_entries:
-                            logger.info(f"Sync: Fetched Metacritic metadata for {len(new_cache_entries)}/{len(games_needing_metacritic)} games")
-                            metacritic_cache.update(new_cache_entries)
-                            save_metacritic_metadata_cache(metacritic_cache)
-                        else:
-                            logger.warning(f"Sync: Metacritic fetch returned no valid data for {len(games_needing_metacritic)} games")
-                    else:
-                        logger.info(f"Sync: No games need Metacritic lookup")
 
                 if fetch_artwork and self.steamgriddb:
                     logger.info(f"[SYNC PHASE] Starting SGDB lookup and artwork phase")
@@ -4813,64 +4732,6 @@ class Plugin:
                     else:
                         logger.info(f"Force Sync: No games need unifiDB lookup")
 
-                # === METACRITIC METADATA FETCH (Force Sync) ===
-                # Fetch Metacritic scores/data from backend API (sequential with rate limiting)
-                if all_games:
-                    logger.info(f"[FORCE SYNC PHASE] Starting Metacritic metadata fetch phase")
-                    metacritic_cache = load_metacritic_metadata_cache()
-                    games_needing_metacritic = [g for g in all_games if g.title]
-
-                    if games_needing_metacritic:
-                        logger.info(f"Force Sync: Fetching Metacritic metadata for {len(games_needing_metacritic)} games")
-                        self.sync_progress.status = "metacritic_fetch"
-                        self.sync_progress.metacritic_total = len(games_needing_metacritic)
-                        self.sync_progress.metacritic_synced = 0
-                        self.sync_progress.current_game = {
-                            "label": "sync.fetchingMetacriticData",
-                            "values": {}
-                        }
-
-                        # Import Metacritic scraper
-                        try:
-                            from backend.metadata.metacritic import fetch_metacritic_metadata
-                        except ImportError as e:
-                            logger.error(f"Failed to import Metacritic module: {e}")
-                            fetch_metacritic_metadata = None
-
-                        async def fetch_metacritic_for_game(game, index, total):
-                            try:
-                                if fetch_metacritic_metadata is None:
-                                    await self.sync_progress.increment_metacritic(game.title)
-                                    return None
-
-                                # Sequential with 0.5s delay between requests
-                                metacritic_data = await fetch_metacritic_metadata(game.title, timeout=10.0, delay=0.5)
-                                await self.sync_progress.increment_metacritic(game.title)
-                                if metacritic_data:
-                                    logger.debug(f"[Metacritic] Got score for {game.title}: {metacritic_data.get('metascore')}")
-                                    return (game.title.lower(), metacritic_data)
-                                else:
-                                    logger.debug(f"[Metacritic] No data for {game.title}")
-                            except Exception as e:
-                                logger.warning(f"[Metacritic] Error for {game.title}: {e}")
-                                await self.sync_progress.increment_metacritic(game.title)
-                            return None
-
-                        # Fetch sequentially to respect rate limits
-                        new_cache_entries = {}
-                        for idx, game in enumerate(games_needing_metacritic):
-                            result = await fetch_metacritic_for_game(game, idx, len(games_needing_metacritic))
-                            if isinstance(result, tuple) and result is not None:
-                                new_cache_entries[result[0]] = result[1]
-
-                        if new_cache_entries:
-                            logger.info(f"Force Sync: Fetched Metacritic metadata for {len(new_cache_entries)}/{len(games_needing_metacritic)} games")
-                            metacritic_cache.update(new_cache_entries)
-                            save_metacritic_metadata_cache(metacritic_cache)
-                        else:
-                            logger.warning(f"Force Sync: Metacritic fetch returned no valid data for {len(games_needing_metacritic)} games")
-                    else:
-                        logger.info(f"Force Sync: No games need Metacritic lookup")
 
                 if self.steamgriddb:
                     logger.info(f"[FORCE SYNC PHASE] Starting SGDB lookup and artwork phase")
@@ -6008,6 +5869,7 @@ class Plugin:
                     sources['release_date'] = 'steam_cache'
 
             # Check Metacritic cache FIRST for scores (primary source)
+            # If not in cache, fetch on-demand (this is the new lazy loading pattern)
             metacritic_cache = load_metacritic_metadata_cache()
             metacritic_cache_key = title.lower()
             metacritic_data = metacritic_cache.get(metacritic_cache_key)
@@ -6018,7 +5880,29 @@ class Plugin:
                     sources['metacritic'] = 'metacritic_cache'
                     logger.debug(f"[MetadataDisplay] Metacritic score for '{title}': {metacritic}")
             else:
-                logger.debug(f"[MetadataDisplay] No Metacritic cache for '{title}'")
+                # ON-DEMAND FETCH: Not in cache, so fetch live from Metacritic API
+                logger.debug(f"[MetadataDisplay] No Metacritic cache for '{title}', fetching on-demand...")
+                try:
+                    from backend.metadata.metacritic import fetch_metacritic_metadata
+                    
+                    # Fetch with no delay (user is waiting for panel to open)
+                    metacritic_data = await fetch_metacritic_metadata(title, timeout=10.0, delay=0)
+                    
+                    if metacritic_data:
+                        # Cache the result for future use
+                        metacritic_cache[metacritic_cache_key] = metacritic_data
+                        save_metacritic_metadata_cache(metacritic_cache)
+                        
+                        metacritic = metacritic_data.get('metascore')
+                        if metacritic:
+                            sources['metacritic'] = 'metacritic_live'
+                            logger.info(f"[MetadataDisplay] Fetched Metacritic score for '{title}': {metacritic}")
+                    else:
+                        logger.debug(f"[MetadataDisplay] No Metacritic data found for '{title}'")
+                except ImportError as e:
+                    logger.error(f"[MetadataDisplay] Failed to import Metacritic module: {e}")
+                except Exception as e:
+                    logger.warning(f"[MetadataDisplay] Error fetching Metacritic data for '{title}': {e}")
 
             # Check unifiDB cache for additional metadata
             unifidb_cache = load_unifidb_metadata_cache()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unifideck-decky",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Unified game library for Steam Deck - Epic, GOG, and Steam in one place",
   "type": "module",
   "scripts": {

--- a/src/components/SteamRestartModal.tsx
+++ b/src/components/SteamRestartModal.tsx
@@ -1,0 +1,92 @@
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { ConfirmModal, DialogButton } from "@decky/ui";
+import { FaSyncAlt, FaClock } from "react-icons/fa";
+
+interface SteamRestartModalProps {
+  store?: string;
+  closeModal?: () => void;
+}
+
+export const SteamRestartModal: FC<SteamRestartModalProps> = ({
+  store,
+  closeModal,
+}) => {
+  const { t } = useTranslation();
+
+  const handleRestartNow = () => {
+    // Request Steam restart via backend
+    // This will gracefully close Steam and relaunch it
+    closeModal?.();
+    // TODO: Add backend method to restart Steam
+    console.log("[SteamRestartModal] Restart now requested");
+  };
+
+  const handleLater = () => {
+    closeModal?.();
+  };
+
+  return (
+    <ConfirmModal
+      strTitle={t("confirmModals.steamRestartTitle")}
+      strDescription=""
+      bHideCloseIcon={false}
+      onOK={closeModal}
+      onCancel={closeModal}
+    >
+      <div style={{ padding: "10px 0" }}>
+        {/* Description */}
+        <div
+          style={{
+            marginBottom: "20px",
+            color: "#ccc",
+            fontSize: "14px",
+            lineHeight: "1.5",
+          }}
+        >
+          {store
+            ? t("confirmModals.steamRestartDescriptionStore", { store })
+            : t("confirmModals.steamRestartDescription")}
+        </div>
+
+        {/* Action buttons */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "10px",
+          }}
+        >
+          {/* Restart Now */}
+          <DialogButton
+            onClick={handleRestartNow}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "8px",
+              color: "#1a9fff",
+            }}
+          >
+            <FaSyncAlt /> {t("confirmModals.restartNow")}
+          </DialogButton>
+
+          {/* Later */}
+          <DialogButton
+            onClick={handleLater}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "8px",
+            }}
+          >
+            <FaClock /> {t("confirmModals.later")}
+          </DialogButton>
+        </div>
+      </div>
+    </ConfirmModal>
+  );
+};
+
+export default SteamRestartModal;

--- a/src/components/SteamRestartModal.tsx
+++ b/src/components/SteamRestartModal.tsx
@@ -15,11 +15,20 @@ export const SteamRestartModal: FC<SteamRestartModalProps> = ({
   const { t } = useTranslation();
 
   const handleRestartNow = () => {
-    // Request Steam restart via backend
-    // This will gracefully close Steam and relaunch it
     closeModal?.();
-    // TODO: Add backend method to restart Steam
-    console.log("[SteamRestartModal] Restart now requested");
+
+    // Use StartShutdown instead of StartRestart (safer and works better)
+    // On Steam Deck, gamescope-session will automatically restart Steam
+    // See: https://github.com/SteamDeckHomebrew/decky-loader/blob/main/frontend/src/steamfixes/README.md
+    // StartRestart() breaks CEF debugging, StartShutdown(false) doesn't
+    if (window.SteamClient?.User?.StartShutdown) {
+      console.log("[SteamRestartModal] Restarting Steam via StartShutdown");
+      window.SteamClient.User.StartShutdown(false);
+    } else {
+      console.error(
+        "[SteamRestartModal] SteamClient.User.StartShutdown not available",
+      );
+    }
   };
 
   const handleLater = () => {

--- a/src/components/SteamRestartModal.tsx
+++ b/src/components/SteamRestartModal.tsx
@@ -1,7 +1,6 @@
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
-import { ConfirmModal, DialogButton } from "@decky/ui";
-import { FaSyncAlt, FaClock } from "react-icons/fa";
+import { ConfirmModal } from "@decky/ui";
 
 interface SteamRestartModalProps {
   store?: string;
@@ -38,63 +37,16 @@ export const SteamRestartModal: FC<SteamRestartModalProps> = ({
   return (
     <ConfirmModal
       strTitle={t("confirmModals.steamRestartTitle")}
-      strDescription=""
-      bHideCloseIcon={false}
-      onOK={closeModal}
-      onCancel={closeModal}
-    >
-      <div style={{ padding: "10px 0" }}>
-        {/* Description */}
-        <div
-          style={{
-            marginBottom: "20px",
-            color: "#ccc",
-            fontSize: "14px",
-            lineHeight: "1.5",
-          }}
-        >
-          {store
-            ? t("confirmModals.steamRestartDescriptionStore", { store })
-            : t("confirmModals.steamRestartDescription")}
-        </div>
-
-        {/* Action buttons */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "10px",
-          }}
-        >
-          {/* Restart Now */}
-          <DialogButton
-            onClick={handleRestartNow}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: "8px",
-              color: "#1a9fff",
-            }}
-          >
-            <FaSyncAlt /> {t("confirmModals.restartNow")}
-          </DialogButton>
-
-          {/* Later */}
-          <DialogButton
-            onClick={handleLater}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: "8px",
-            }}
-          >
-            <FaClock /> {t("confirmModals.later")}
-          </DialogButton>
-        </div>
-      </div>
-    </ConfirmModal>
+      strDescription={
+        store
+          ? t("confirmModals.steamRestartDescriptionStore", { store })
+          : t("confirmModals.steamRestartDescription")
+      }
+      strOKButtonText={t("confirmModals.restartNow")}
+      strCancelButtonText={t("confirmModals.later")}
+      onOK={handleRestartNow}
+      onCancel={handleLater}
+    />
   );
 };
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -124,7 +124,7 @@
     "forceSyncDescription": "Would you like to resync all artwork? This will overwrite any manual artwork changes. Select 'Keep Artwork' to only download missing artwork.",
     "resyncArtwork": "Resync Artwork",
     "keepArtwork": "Keep Artwork",
-    "steamRestartTitle": "Synced All Games from Epic!",
+    "steamRestartTitle": "Sync Complete!",
     "steamRestartDescription": "Please Restart Steam to apply your new games and artwork",
     "steamRestartDescriptionStore": "Please Restart Steam to apply your new {{store}} games and artwork",
     "restartNow": "Restart Now",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -124,6 +124,11 @@
     "forceSyncDescription": "Would you like to resync all artwork? This will overwrite any manual artwork changes. Select 'Keep Artwork' to only download missing artwork.",
     "resyncArtwork": "Resync Artwork",
     "keepArtwork": "Keep Artwork",
+    "steamRestartTitle": "Synced All Games from Epic!",
+    "steamRestartDescription": "Please Restart Steam to apply your new games and artwork",
+    "steamRestartDescriptionStore": "Please Restart Steam to apply your new {{store}} games and artwork",
+    "restartNow": "Restart Now",
+    "later": "Later",
     "yes": "Yes",
     "no": "No"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,6 +45,7 @@ import {
 import { DownloadsTab } from "./components/DownloadsTab";
 import { StorageSettings } from "./components/StorageSettings";
 import { UninstallConfirmModal } from "./components/UninstallConfirmModal";
+import { SteamRestartModal } from "./components/SteamRestartModal";
 import { LanguageSelector } from "./components/LanguageSelector";
 import StoreConnections from "./components/settings/StoreConnections";
 import { Store } from "./types/store";
@@ -902,18 +903,13 @@ const Content: FC = () => {
                       console.log(`[Unifideck] ⚠ Sync cancelled by user`);
                     }
 
-                    // Show toast only if changes were made
+                    // Show modal only if changes were made
                     if (result.status === "complete") {
                       const addedCount = result.synced_games || 0;
                       if (addedCount > 0) {
-                        toaster.toast({
-                          title: t("toasts.syncComplete"),
-                          body: t("toasts.syncCompleteMessage", {
-                            count: addedCount,
-                          }),
-                          duration: 15000,
-                          critical: true,
-                        });
+                        showModal(
+                          <SteamRestartModal closeModal={() => {}} />
+                        );
                       }
                     } else if (result.status === "cancelled") {
                       toaster.toast({
@@ -1100,21 +1096,12 @@ const Content: FC = () => {
 
             // Show restart notification when sync completes (only if changes were made)
             if (result.status === "complete") {
-              // Only show toast if there were actual changes (not just a refresh that added 0 games)
+              // Only show modal if there were actual changes (not just a refresh that added 0 games)
               const addedCount = result.synced_games || 0;
               if (addedCount > 0) {
-                toaster.toast({
-                  title: force
-                    ? t("toasts.forceSyncComplete")
-                    : t("toasts.syncComplete"),
-                  body: force
-                    ? t("toasts.forceSyncCompleteMessage", {
-                        count: addedCount,
-                      })
-                    : t("toasts.syncCompleteMessage", { count: addedCount }),
-                  duration: 15000,
-                  critical: true,
-                });
+                showModal(
+                  <SteamRestartModal closeModal={() => {}} />
+                );
               }
             } else if (result.status === "cancelled") {
               toaster.toast({


### PR DESCRIPTION
- Created new SteamRestartModal component using pure Decky UI elements
- Modal prompts user to restart Steam after sync/force sync completes
- On restart button press, it actually shuts down steam, which gamescope-session will then restart itself, effectively restarting steam but preserving a few things like CEF debugging for a clean restore of state
- Moved Metacritic synt out of bulk, into per game page, as it was taking over 12 minutes to sync ~600 entries vs 1.5 min for all previous syncs

<img width="786" height="483" alt="image" src="https://github.com/user-attachments/assets/264bc51c-ccb8-40ef-bd4e-69b450d1d319" />
