### PR TITLE
update utils module

### DIFF
--- a/py_modules/unifideck/utils/__init__.py
+++ b/py_modules/unifideck/utils/__init__.py
@@ -1,13 +1,23 @@
-# OP-33 | utils/__init__.py | Depends: (none)
-from .paths import (
+"""unifideck.utils — Path resolution and helpers.
+
+Refactored utils/paths.py exposes the new constants
+`DEFAULT_GAMES_MAP` and `DEFAULT_INSTALL_DIRS`, plus the
+config-aware `get_all_game_directories(config)`. Legacy names
+`GAMES_MAP_PATH` and `DEFAULT_PATHS` are preserved as expanded
+constants in paths.py for backward compatibility.
+"""
+from .paths import (  # noqa: F401
+    # New constants
     DEFAULT_GAMES_MAP,
     DEFAULT_INSTALL_DIRS,
     DEFAULT_PATHS,
     DEFAULT_SD_ROOT,
+    # Legacy constants (kept for v0.6.x callers)
     GAMES_MAP_PATH,
     dedupe_paths,
     ensure_games_map_dir,
     expand,
+    # Functions
     get_all_game_directories,
     get_games_map_path,
 )

--- a/py_modules/unifideck/utils/config_helpers.py
+++ b/py_modules/unifideck/utils/config_helpers.py
@@ -1,49 +1,51 @@
 """utils/config_helpers.py — None-safe ConfigManager accessors.
 
-# OP-33c | py_modules/unifideck/utils/config_helpers.py | Depends: OP-11a
+Centralizes the ``_cfg`` helper that was copy-pasted across 13
+modules (cdp_client, artwork_service, cloud_save_service,
+metacritic, unifidb, paths, locale, browser, library, manifest,
+gog_config, and two others). The historical pattern:
 
-Centralises the ``_cfg`` helper previously copy-pasted across
-13 modules (``cdp_client``, ``artwork_service``,
-``cloud_save_service``, ``metacritic``, ``unifidb``, ``paths``,
-``locale``, ``browser``, ``library``, ``manifest``,
-``gog_config``, and two others). The historical pattern is
-reproduced here verbatim for semantic parity, with one
+    def _cfg(config: "ConfigManager | None", key, default):
+        if config is None:
+            return default
+        try:
+            return config.get(key, default)
+        except Exception:
+            return default
+
+is reproduced here verbatim for semantic parity, with one
 addition: a rate-limited WARNING log the first time a given
 caller passes ``config=None``, making latent "forgot to inject
 config" bugs observable in Decky's logs instead of being
 silently papered over.
 
 Design notes:
-  - Exposed as ``get_cfg`` (public, imported) rather than
-    ``_cfg`` (module-private, the old name). Callers should
-    import ``from unifideck.utils.config_helpers import
-    get_cfg``.
-  - The broad ``except Exception`` is intentional:
-    ``ConfigManager`` is duck-typed — tests pass a stub, prod
-    passes the real class. Any AttributeError or KeyError on
-    the stub must degrade to the default, not propagate.
-  - The warning tracks ``(caller_module, caller_lineno)`` so
-    noisy call sites only log once per (site, process) rather
-    than flooding on every access during a sync loop.
+
+- Exposed as ``get_cfg`` (public, imported) rather than ``_cfg``
+  (module-private, the old name). Callers should import
+  ``from unifideck.utils.config_helpers import get_cfg``.
+- The broad ``except Exception`` is intentional: ``ConfigManager``
+  is duck-typed — tests pass a stub, prod passes the real
+  class. Any AttributeError or KeyError on the stub must
+  degrade to the default, not propagate.
+- The warning tracks (caller_module, caller_lineno) so noisy
+  call sites only log once per (site, process) rather than
+  flooding on every access during a sync loop.
 """
 from __future__ import annotations
 
-import inspect
-import json
 import logging
-import os
+import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ..config import ConfigManager
+    from unifideck.config import ConfigManager
 
 logger = logging.getLogger(__name__)
 
-# Sites that have already emitted a "config is None" warning.
-# Keyed by ``(module, lineno)`` so each unique call site warns
-# once per process lifetime. Thread-safe: the seen-sites set
-# uses atomic set operations, no lock needed.
-_warned_sites: set[tuple[str, int]] = set()
+# (module, lineno) pairs that have already emitted a WARNING about
+# config=None. Prevents log spam from hot paths like sync loops.
+_none_sites_seen: set[tuple[str, int]] = set()
 
 
 def get_cfg(
@@ -51,83 +53,86 @@ def get_cfg(
     key: str,
     default: Any,
 ) -> Any:
-    """Return ``config.get(key, default)`` or ``default`` on any failure.
-    Three failure modes handled uniformly:
-      - ``config is None``: emits a rate-limited WARNING
-        tagged with the calling frame's ``(module, lineno)``
-        so a forgotten DI shows up in logs without flooding
-        on tight loops.
-      - ``config.get`` raises ``Exception``: silently
-        swallowed (test stubs or deprecated keys should
-        degrade to default, not crash a feature).
-      - ``config.get`` returns None: returned as-is (the
-        caller decides whether None is acceptable — we don't
-        second-guess a legitimate None default).
-    Thread-safe: the seen-sites set uses atomic set
-    operations, no lock needed.
+    """Read ``key`` from ``config`` with graceful fallback.
+
+    Behavior:
+
+    - If ``config`` is None, return ``default``. Log a one-time
+      WARNING identifying the caller so missing-injection bugs
+      surface in logs instead of silently returning ``default``
+      on every access.
+    - If ``config.get(key, default)`` raises (non-``ConfigManager``
+      stubs in tests, schema drift in prod), swallow the
+      exception and return ``default``.
+    - Otherwise return what ``config.get`` returns.
+
+    The ``default`` must match the value declared for ``key`` in
+    ``defaults/config.json`` — ``get_cfg`` is a safety net, not
+    a place to introduce new defaults. Divergence between the
+    schema default and the value passed here is a bug.
     """
     if config is None:
-        frame = inspect.currentframe()
-        caller = frame.f_back if frame else None
-        if caller:
-            site = (caller.f_globals.get("__name__", "?"), caller.f_lineno)
-            if site not in _warned_sites:
-                _warned_sites.add(site)
-                logger.warning(
-                    "[config_helpers] get_cfg called with config=None "
-                    "from %s:%d — using default for key '%s'",
-                    site[0], site[1], key,
-                )
+        # Once-per-site WARNING so a forgotten injection is
+        # visible but we don't flood the log when the same
+        # buggy object is used in a tight loop.
+        frame = sys._getframe(1)
+        site = (frame.f_globals.get("__name__", "?"), frame.f_lineno)
+        if site not in _none_sites_seen:
+            _none_sites_seen.add(site)
+            logger.warning(
+                "[config_helpers] config=None at %s:%d key=%r "
+                "— falling back to default=%r. Likely a forgotten "
+                "ConfigManager injection.",
+                site[0], site[1], key, default,
+            )
         return default
     try:
-        val = config.get(key, default)
-        return val if val is not None else default
-    except Exception:
+        return config.get(key, default)
+    except Exception:  # noqa: BLE001
+        # Duck-typed config objects in tests may raise anything.
         return default
 
 
-# ── Cold-start config path ───────────────────────────────────
-# Used before ``ConfigManager`` is ready. Must stay constant
-# and not depend on any DI so the launcher cold-start path can
-# read it before the bootstrap has wired ConfigManager.
+# Cold-start config path — used before ConfigManager is ready.
+# Must stay constant and not depend on any DI.
 _COLD_START_CONFIG_PATH = "~/.local/share/unifideck/config.json"
 
 
-def read_config_int_cold_start(
-    key: str, default: int,
-) -> int:
+def read_config_int_cold_start(key: str, default: int) -> int:
     """Read a positive int from config.json without ConfigManager.
-    Bypasses the normal ``ConfigManager`` API because this
-    helper runs on the launcher cold-start path, before
-    the bootstrap has wired ``ConfigManager``. Reading the
-    JSON directly keeps the cold-start import graph
-    minimal (no ``config/`` subpackage dependency, no
-    bootstrap coupling).
-    Dotted ``key`` (e.g. ``"launcher.auth_max_seconds"``)
-    walks nested dicts. Values outside the positive-int
-    range (zero, negative, non-int, missing) return
-    ``default``. Used for a handful of launcher timing
-    knobs — called 2-3 times per cold start, never on the
-    hot path, so the missing caching is intentional:
-    simpler + lower risk than memoising.
+
+    Bypasses the normal ``ConfigManager`` API because this helper
+    runs on the launcher cold-start path, before the bootstrap
+    has wired ``ConfigManager``. Reading the JSON directly keeps
+    the cold-start import graph minimal (no ``config/`` subpackage
+    dependency, no bootstrap coupling).
+
+    Dotted ``key`` (e.g. ``"launcher.auth_max_seconds"``) walks
+    into nested objects. Returns ``default`` on any error — file
+    missing, malformed JSON, wrong type, key absent, non-positive
+    int — so callers never have to guard the call.
+
+    Do NOT use after bootstrap completes — prefer
+    ``ConfigManager.get_int(key, default)`` once the registry is
+    up, as it picks up in-memory overrides, defaults layering,
+    and migration rewrites.
     """
-    try:
-        path = os.path.expanduser(_COLD_START_CONFIG_PATH)
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception:
+    import json
+    from pathlib import Path as _P  # noqa: N814 — intentional: module-scope alias of pathlib.Path
+
+    config_path = _P(_COLD_START_CONFIG_PATH).expanduser()
+    if not config_path.is_file():
         return default
-
-    # Walk dotted key
-    parts = key.split(".")
-    current: Any = data
-    for part in parts:
-        if not isinstance(current, dict):
+    try:
+        with config_path.open() as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return default
+    node = data
+    for part in key.split("."):
+        if not isinstance(node, dict) or part not in node:
             return default
-        current = current.get(part)
-        if current is None:
-            return default
-
-    if isinstance(current, int) and current > 0:
-        return current
-    return default
+        node = node[part]
+    if not isinstance(node, int) or node <= 0:
+        return default
+    return node

--- a/py_modules/unifideck/utils/locale.py
+++ b/py_modules/unifideck/utils/locale.py
@@ -1,162 +1,225 @@
 """utils/locale.py — Locale detection and market resolution.
 
-# OP-33b | py_modules/unifideck/utils/locale.py | Depends: (none)
+Single source of truth: the `i18n.locales` section of
+defaults/config.json (parsed and validated by
+scripts/locale_config.py). This module never hardcodes a list
+of supported locales — adding a new language is a one-line
+edit to config.json, and this module picks it up automatically
+on the next plugin start.
 
-Single source of truth for the active locale tag and market code.
-
-The new architecture (Technical Document v1.3, Section 10) replaces
-manual 14-file i18n maintenance with build-time DeepL translation:
-  - ``en-US.json`` is the only file developers edit.
-  - CI detects changed keys, calls DeepL API, generates 13 locale
-    files, commits them to ``src/i18n/locales/``.
-  - Zero runtime dependency — generated files are committed to git.
-  - The frontend ``LanguageSelector`` reads available locales from
-    the ``locales/`` directory.
-
-This backend module does NOT hardcode a locale list. Instead it:
-  1. Reads the user's saved preference from ``ui.language`` in config.
-  2. Discovers available locale tags by scanning the ``locales/``
-     directory for ``*.json`` files (the build-generated set).
-  3. Falls back to system POSIX locale detection.
-  4. Ultimate fallback: ``"en-US"``.
-
-The translation pipeline itself (DeepL integration, delta detection,
-CI workflow) is developed by a separate contributor and is outside
-the scope of this module.
+Resolution priority:
+  1. User preference → ConfigManager key 'ui.language'
+     (only if the saved value is a tag present in
+     i18n.locales; unknown saved tags are silently ignored
+     and we fall through to system detection)
+  2. System POSIX → locale.getlocale() → mapped to the first
+     i18n.locales entry whose tag begins with the same 2-
+     letter prefix (case-insensitive)
+  3. Source fallback → LocaleConfig.source.tag
 """
 from __future__ import annotations
 
-import locale as _locale_mod
+import locale as _locale
 import logging
-import os
-from typing import TYPE_CHECKING
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .config_helpers import get_cfg
 
 if TYPE_CHECKING:
     from ..config import ConfigManager
 
 logger = logging.getLogger(__name__)
 
-# Config key the UI writes when the user picks a language.
+# Config keys used by this module.
 _USER_LANGUAGE_KEY = "ui.language"
 
-# Fallback when nothing else works.
-_DEFAULT_LOCALE = "en-US"
-_DEFAULT_MARKET = "US"
+# The locale_config module lives in scripts/ which is a sibling
+# of py_modules/. It's not on the default Python path so we add
+# it on first use. This import is done lazily to avoid paying
+# the cost on every module import.
+_LOCALE_CONFIG_MODULE = None
 
 
-# ── Available locale discovery ───────────────────────────────
+def _import_locale_config():
+    """Lazy import of scripts/locale_config.py, cached.
 
-
-def _discover_available_locales() -> set[str]:
-    """Scan ``src/i18n/locales/`` for generated *.json files.
-
-    Returns a set of BCP-47 tags derived from filenames
-    (e.g. ``fr-FR.json`` → ``"fr-FR"``). Returns empty set
-    if the directory doesn't exist (e.g. in unit tests or
-    before first CI build).
+    Returns the module handle or None if scripts/ can't be
+    located (unusual install layout). None signals "no schema
+    validation available" and the caller falls through to its
+    default behaviour.
     """
-    tags: set[str] = set()
+    global _LOCALE_CONFIG_MODULE
+    if _LOCALE_CONFIG_MODULE is not None:
+        return _LOCALE_CONFIG_MODULE
+    # Walk up from this file to find <repo>/scripts/locale_config.py.
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parent.parent.parent.parent / "scripts",
+        # Fallback: some dev layouts may differ
+        here.parent.parent.parent / "scripts",
+    ]
+    for scripts_dir in candidates:
+        target = scripts_dir / "locale_config.py"
+        if target.is_file():
+            scripts_str = str(scripts_dir)
+            if scripts_str not in sys.path:
+                sys.path.insert(0, scripts_str)
+            try:
+                import locale_config
+                _LOCALE_CONFIG_MODULE = locale_config
+                return _LOCALE_CONFIG_MODULE
+            except ImportError as e:
+                logger.debug(
+                    "[locale] Found %s but import failed: %s",
+                    target, e,
+                )
+                return None
+    logger.debug(
+        "[locale] scripts/locale_config.py not found on any "
+        "candidate path; locale resolution will use degraded "
+        "mode",
+    )
+    return None
+
+
+def get_locale_config(config: ConfigManager | None):
+    """Return the parsed i18n.locales section, or None on failure.
+
+    The returned object (a LocaleConfig from
+    scripts/locale_config.py) exposes `all_tags`, `get(tag)`,
+    `source`, and `targets` for consumers that need the full
+    list.
+
+    Returns None if config has no i18n section or the scripts
+    helper is unavailable.
+    """
+    lc_module = _import_locale_config()
+    if lc_module is None:
+        return None
+    # ConfigManager exposes the full merged dict via _merged,
+    # but accessing a private attribute would be fragile.
+    # Instead we rebuild the i18n branch using public .get().
+    i18n_section = get_cfg(config, "i18n", None)
+    if not isinstance(i18n_section, dict):
+        return None
     try:
-        from ..core.paths import resolve_plugin_dir
-        locales_dir = resolve_plugin_dir() / "src" / "i18n" / "locales"
-        if locales_dir.is_dir():
-            for f in locales_dir.iterdir():
-                if f.suffix == ".json" and f.stem != "index":
-                    tags.add(f.stem)
-    except Exception:
-        pass
-    return tags
+        return lc_module.load_from_dict(
+            {"i18n": i18n_section},
+        )
+    except Exception as e:  # noqa: BLE001
+        # Validation failed — log and return None. Runtime
+        # code must never crash just because someone edited
+        # config.json incorrectly.
+        logger.warning(
+            "[locale] i18n schema validation failed at "
+            "runtime: %s", e,
+        )
+        return None
 
 
-# ── Public API ───────────────────────────────────────────────
+def get_unifideck_locale(config: ConfigManager | None) -> str:
+    """Return the BCP-47 locale tag to use for UI and store APIs.
 
-
-def get_unifideck_locale(
-    config: ConfigManager | None = None,
-) -> str:
-    """Resolve the locale tag Unifideck should use this session.
-
-    Resolution priority:
-      1. User's saved ``ui.language`` if it matches an available
-         locale file in ``src/i18n/locales/``. Unknown saved tags
-         are silently ignored.
-      2. System POSIX locale via ``_detect_system_locale``,
-         2-letter prefix matched against available locales.
-      3. ``"en-US"`` fallback.
+    Returns a BCP-47 tag that is guaranteed to exist in
+    i18n.locales, or a degraded fallback if the config is
+    unavailable. The fallback is 'en-US' only as a last
+    resort — normal operation always returns a config-sourced
+    tag.
     """
-    available = _discover_available_locales()
+    lc = get_locale_config(config)
+    # ─── 1. Explicit user preference ──────────────────────────
+    saved = get_cfg(config, _USER_LANGUAGE_KEY, None)
+    if isinstance(saved, str) and saved:
+        # Normalise: accept both 'fr-FR' and 'fr_FR' for
+        # compatibility with POSIX-style values.
+        normalised = saved.replace("_", "-")
+        if lc is not None and lc.get(normalised) is not None:
+            logger.debug(
+                "[locale] user preference: %s", normalised,
+            )
+            return normalised
+        if lc is None:
+            # No canonical list available — trust the saved
+            # value as-is. This is the degraded path.
+            logger.debug(
+                "[locale] user preference (unvalidated): %s",
+                normalised,
+            )
+            return normalised
+        logger.debug(
+            "[locale] user preference '%s' not in "
+            "i18n.locales, falling back to system", saved,
+        )
+    # ─── 2. System POSIX locale ───────────────────────────────
+    system = _detect_system_locale(lc)
+    if system:
+        logger.debug("[locale] system: %s", system)
+        return system
+    # ─── 3. Source fallback ───────────────────────────────────
+    if lc is not None:
+        source_tag = str(lc.source.tag)
+        logger.debug(
+            "[locale] source fallback: %s", source_tag,
+        )
+        return source_tag
+    # Final degraded fallback: hardcoded en-US only when the
+    # config system is completely broken.
+    logger.warning(
+        "[locale] no config available, using hardcoded "
+        "en-US",
+    )
+    return "en-US"
 
-    # Tier 1: explicit user preference
-    if config is not None:
-        try:
-            user_lang = config.get(_USER_LANGUAGE_KEY)
-            if user_lang and user_lang != "auto":
-                if not available or user_lang in available:
-                    return user_lang
-        except Exception:
-            pass
 
-    # Tier 2: system POSIX locale
-    sys_locale = _detect_system_locale()
-    if sys_locale and available:
-        prefix = sys_locale[:2].lower()
-        for tag in available:
-            if tag[:2].lower() == prefix:
-                return tag
+def get_unifideck_market(config: ConfigManager | None) -> str:
+    """Return the ISO 3166-1 alpha-2 market code.
 
-    return _DEFAULT_LOCALE
-
-
-def get_unifideck_market(
-    config: ConfigManager | None = None,
-) -> str:
-    """Resolve the market tag (2-letter country code).
-
-    Extracts the country code from the BCP-47 tag (after
-    the dash). For tags without a country code, looks up
-    a matching available locale that does have one.
+    Derived from the region suffix of the active locale tag.
+    Examples: 'fr-FR' → 'FR', 'pt-BR' → 'BR', 'zh-CN' → 'CN'.
+    Falls back to 'US' only when the active locale has no
+    region suffix.
     """
     tag = get_unifideck_locale(config)
-
-    if "-" in tag:
-        return tag.split("-", 1)[1].upper()
-
-    # No country in tag — find a matching available locale
-    available = _discover_available_locales()
-    if available:
-        prefix = tag[:2].lower()
-        for avail_tag in available:
-            if avail_tag[:2].lower() == prefix and "-" in avail_tag:
-                return avail_tag.split("-", 1)[1].upper()
-
-    return _DEFAULT_MARKET
+    parts = tag.split("-")
+    if len(parts) >= 2 and len(parts[-1]) == 2:
+        return parts[-1].upper()
+    return "US"
 
 
-def _detect_system_locale() -> str | None:
-    """Return a system locale tag from POSIX or None.
+# ══════════════════════════════════════════════════════════════════
+# Private helpers
+# ══════════════════════════════════════════════════════════════════
 
-    Tries ``locale.getlocale(locale.LC_MESSAGES)``, falls
-    back to ``LANG`` env var parse. Normalises the result
-    to a BCP-47-ish tag (``"fr_FR.UTF-8"`` → ``"fr-FR"``).
-    Returns None when nothing usable is detected.
+
+def _detect_system_locale(lc: Any) -> str | None:
+    """Map the POSIX system locale to an i18n.locales tag.
+
+    Returns a tag from lc.all_tags whose 2-letter prefix
+    matches the POSIX lang code, or None on any failure.
     """
-    raw = None
+    if lc is None:
+        return None
     try:
-        raw = _locale_mod.getlocale(_locale_mod.LC_MESSAGES)[0]
-    except Exception:
-        pass
-
-    if not raw:
-        raw = os.environ.get("LANG", "")
-
-    if not raw or raw in ("C", "POSIX"):
+        lang_tuple = _locale.getlocale()
+    except (ValueError, TypeError) as e:
+        logger.debug("[locale] getlocale() failed: %s", e)
         return None
-
-    # Normalise: "fr_FR.UTF-8" → "fr-FR"
-    raw = raw.split(".")[0]
-    raw = raw.replace("_", "-")
-
-    if len(raw) < 2:
+    if not lang_tuple or not lang_tuple[0]:
         return None
-
-    return raw
+    # lang_tuple[0] is like 'fr_FR' or 'en_US' — extract the
+    # 2-letter prefix in a case-insensitive way.
+    prefix = lang_tuple[0].split("_")[0].lower()
+    if not prefix:
+        return None
+    # Find the first entry in the canonical list whose tag
+    # starts with this prefix. Order matches config.json,
+    # which is also the UI dropdown order.
+    for loc in lc.locales:
+        if (
+            loc.tag.lower().startswith(prefix + "-")
+            or loc.tag.lower() == prefix
+        ):
+            return str(loc.tag)
+    return None

--- a/py_modules/unifideck/utils/paths.py
+++ b/py_modules/unifideck/utils/paths.py
@@ -1,29 +1,29 @@
-"""utils/paths.py — Centralised path resolution for game installations.
+"""utils/paths.py — Centralized path resolution for game installations.
 
-# OP-33a | py_modules/unifideck/utils/paths.py | Depends: (none)
-
-Single source of truth for where Unifideck looks for installed
-games: default install dirs per store, mounted SD cards / USB
+Refactor of legacy ``utils/paths.py`` (130 lines). Provides a
+single source of truth for where Unifideck looks for installed
+games: default install dirs per store, mounted SD cards/USB
 drives, and optional user-configured custom paths.
 
 The legacy module hardcoded ``~/.local/share/unifideck/...``
 paths and a fixed list of store install directories. This
 refactor:
-  - Reads default install paths from ``stores.<n>.install_dir``.
-  - Reads custom override from ``download.custom_path``.
-  - Reads the SD-card mount root from ``paths.sd_card_root``.
-  - Returns a deduplicated list of existing directories.
+
+- Reads default install paths from ``stores.<n>.install_dir``
+- Reads custom override from ``download.custom_path``
+- Reads the SD card mount root from ``paths.sd_card_root``
+- Returns a deduplicated list of existing directories
 
 Pure helpers (no I/O):
-  - ``expand``       : tilde + env-var expansion in one shot.
-  - ``dedupe_paths`` : remove duplicates preserving order.
+
+- ``expand`` : tilde + env-var expansion in one shot
+- ``dedupe_paths`` : remove duplicates preserving order
 
 Filesystem helpers:
-  - ``get_all_game_directories(config)`` : full discovery scan.
-  - ``get_games_map_path(config)``       : the games.map
-                                           location.
-  - ``ensure_games_map_dir(config)``     : create the parent
-                                           dir.
+
+- ``get_all_game_directories(config)`` : full discovery scan
+- ``get_games_map_path(config)`` : the games.map location
+- ``ensure_games_map_dir(config)`` : create the parent dir
 
 Reference: Technical Document v1.0 — Section 3.6.1 (games.map),
 3.9 (ConfigManager), 5.6 (installation pipeline).
@@ -34,6 +34,8 @@ import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from .config_helpers import get_cfg
 
 if TYPE_CHECKING:
     from ..config import ConfigManager
@@ -51,19 +53,20 @@ DEFAULT_INSTALL_DIRS = {
     "ubisoft": "~/Games/Ubisoft",
 }
 
-# Where games.map lives by default. Steam Deck never relocates
-# this without explicit user action, so the path is stable.
+# Where the games.map lives by default. Steam Deck never
+# relocates this without explicit user action, so the path is
+# stable.
 DEFAULT_GAMES_MAP = "~/.local/share/unifideck/games.map"
 
-# Mount root for SD cards / external drives on the Steam Deck.
+# Mount root for SD cards / external drives on the Steam Deck
 DEFAULT_SD_ROOT = "/run/media"
 
-# — Legacy compatibility aliases ——————————————————————————————
-# Old constant names kept working so legacy modules
-# (``utils/__init__.py``, ``accounts/account_manager.py``, etc.)
-# that ``from .paths import GAMES_MAP_PATH, DEFAULT_PATHS``
-# continue to import successfully during the migration window.
-# Both forms resolve to the same expanded value.
+# ── Legacy compatibility aliases ──────────────────────────────
+# Keep the old constant names working so legacy modules
+# (utils/__init__.py, accounts/account_manager.py, etc.) that
+# ``from .paths import GAMES_MAP_PATH, DEFAULT_PATHS`` continue
+# to import successfully during the migration window. Both forms
+# resolve to the same expanded value.
 GAMES_MAP_PATH = str(Path(DEFAULT_GAMES_MAP).expanduser())
 DEFAULT_PATHS = {
     store: str(Path(path).expanduser())
@@ -71,191 +74,196 @@ DEFAULT_PATHS = {
 }
 
 
-# ── Pure helpers ─────────────────────────────────────────────
+# ══════════════════════════════════════════════════════════════
+# Pure helpers
+# ══════════════════════════════════════════════════════════════
 
 
 def expand(path: str) -> str:
     """Expand ``~`` and ``$VAR`` references in a path string.
-    Pure function — no filesystem I/O. Returns an
-    absolute path when the input is absolute or contains
-    ``~``; a relative path unchanged otherwise. Uses
-    ``os.path.expandvars`` for env-var substitution
-    because ``pathlib.Path`` has no equivalent, then
-    wraps through ``Path(...).expanduser()`` for tilde
+
+    Pure function — no filesystem I/O. Returns an absolute path
+    (when the input is absolute or contains ``~``) or a relative
+    path unchanged.
+
+    Uses ``os.path.expandvars`` for env var substitution because
+    ``pathlib.Path`` has no equivalent. The result is then
+    wrapped through ``Path(...).expanduser()`` for the tilde
     resolution.
     """
     return str(Path(os.path.expandvars(path)).expanduser())
 
 
 def dedupe_paths(paths: list[str]) -> list[str]:
-    """Remove duplicate paths, preserving first-occurrence order.
-    Uses a seen-set for O(n) dedup. Path comparison is by
-    resolved string — caller should pass already-expanded
-    paths. Used after collecting paths from multiple
-    sources (default dirs + SD-card mounts + user
-    overrides) where the same directory can legitimately
-    appear twice.
+    """Remove duplicate paths preserving order.
+
+    Two paths are considered equal if their normalized form
+    (``os.path.normpath``) matches. Useful when merging
+    discovery results from multiple sources that may overlap.
     """
     seen: set[str] = set()
-    result: list[str] = []
+    out: list[str] = []
     for p in paths:
-        if p not in seen:
-            seen.add(p)
-            result.append(p)
-    return result
+        norm = os.path.normpath(p)
+        if norm in seen:
+            continue
+        seen.add(norm)
+        out.append(p)
+    return out
 
 
-# ── Config helper ────────────────────────────────────────────
+def _cfg(config: ConfigManager | None, key: str, default: Any) -> Any:
+    """Legacy alias for backward compatibility. Delegates to `get_cfg`."""
+    return get_cfg(config, key, default)
 
 
-def _cfg(
-    config: ConfigManager | None, key: str, default: Any,
-) -> Any:
-    """Read a config value with a default fallback.
-    Thin helper used throughout the module so the
-    ``config is None`` check stays in one place. Returns
-    ``default`` when config is None OR when the key is
-    missing / empty.
+# ══════════════════════════════════════════════════════════════
+# Filesystem discovery
+# ══════════════════════════════════════════════════════════════
+
+
+def get_all_game_directories(config: ConfigManager | None = None) -> list[str]:
+    """Return every directory that may contain installed games.
+
+    Combines:
+
+    1. Per-store install dirs from ``stores.<n>.install_dir``
+       (or ``DEFAULT_INSTALL_DIRS`` as fallback)
+    2. The user's custom path from ``download.custom_path``
+    3. SD card / external drive mounts under
+       ``paths.sd_card_root`` — scans 2 levels deep for
+       ``Games/`` and ``GOG Games/`` folders
+
+    Only returns directories that actually exist on disk.
+    Result is deduplicated.
     """
-    if config is None:
-        return default
-    try:
-        val = config.get(key, default)
-        return val if val is not None else default
-    except Exception:
-        return default
+    candidates: list[str] = []
 
+    # 1. Per-store install dirs
+    for store, default in DEFAULT_INSTALL_DIRS.items():
+        path = _cfg(config, f"stores.{store}.install_dir", default)
+        candidates.append(expand(path))
 
-# ── Filesystem helpers ───────────────────────────────────────
-
-
-def get_all_game_directories(
-    config: ConfigManager | None = None,
-) -> list[str]:
-    """Return every directory Unifideck should scan for installed games.
-    Aggregates:
-      - Each store's ``install_dir`` via ``_collect_game_dirs``
-        (reads ``stores.<n>.install_dir`` or falls back to
-        ``DEFAULT_INSTALL_DIRS``).
-      - Custom user override ``download.custom_path`` when
-        set.
-      - Every mounted SD-card / USB drive via
-        ``_scan_mount_root`` (looks under
-        ``paths.sd_card_root`` or ``DEFAULT_SD_ROOT``).
-    Each candidate path is expanded, existence-checked,
-    deduped. Non-existent dirs silently skipped. Returns
-    the final list in discovery order (Steam installs +
-    store dirs before external drives) so the caller's
-    first-hit detection picks the canonical install
-    location.
-    """
-    dirs: list[str] = []
-
-    # Store default install dirs
-    dirs.extend(_collect_game_dirs(config))
-
-    # Custom user override
-    custom = _cfg(config, "download.custom_path", "")
+    # 2. Custom user path
+    custom = get_cfg(config, "download.custom_path", "")
     if custom:
-        expanded = expand(custom)
-        if os.path.isdir(expanded):
-            dirs.append(expanded)
+        candidates.append(expand(custom))
 
-    # SD card / external drives
-    dirs.extend(_scan_mount_root(config))
+    # 3. SD card / external drive scan
+    media_root = get_cfg(config, "paths.sd_card_root", DEFAULT_SD_ROOT)
+    candidates.extend(_scan_mount_root(media_root))
 
-    return dedupe_paths(dirs)
+    # Filter to existing dirs and dedupe
+    existing = [p for p in candidates if Path(p).is_dir()]
+    return dedupe_paths(existing)
 
 
-def _collect_game_dirs(
-    config: ConfigManager | None,
-) -> list[str]:
-    """Read per-store install dirs from config, fall back to defaults.
-    Iterates ``DEFAULT_INSTALL_DIRS`` keys; for each,
-    tries ``stores.<n>.install_dir`` from config,
-    falls back to the default value. Returns the
-    expanded paths in store-enumeration order. Missing
-    store keys skipped (a store disabled in config
-    shouldn't drag its install dir into the scan).
+def _collect_game_dirs(parent_path: Path) -> list[str]:
+    """Return ``Games/`` and ``GOG Games/`` subdirs of ``parent_path``.
+
+    Helper for ``_scan_mount_root`` — factored out so the scan
+    loop stays shallow. Symlinks are skipped to avoid loops.
     """
-    result: list[str] = []
-    for store, default_path in DEFAULT_INSTALL_DIRS.items():
-        raw = _cfg(config, f"stores.{store}.default_install_root", default_path)
-        expanded = expand(raw)
-        if os.path.isdir(expanded):
-            result.append(expanded)
-    return result
+    found: list[str] = []
+    for sub in ("Games", "GOG Games"):
+        p = parent_path / sub
+        if p.is_dir() and not p.is_symlink():
+            found.append(str(p))
+    return found
 
 
-def _scan_mount_root(
-    config: ConfigManager | None,
-) -> list[str]:
-    """Enumerate mounted volumes under the SD-card root.
-    Reads ``paths.sd_card_root`` from config, falls back
-    to ``DEFAULT_SD_ROOT``. Walks 2 levels via
-    ``_scan_level2``. Returns existing directories only.
-    Used by ``get_all_game_directories`` to include
-    games installed on removable media.
+def _scan_level2(level1_path: Path) -> list[str]:
+    """Scan the level-2 subtree under ``level1_path`` for game dirs.
+
+    Some Decks (LUKS-on-external SSD setups notably) mount
+    game partitions one level deeper than the standard
+    ``/run/media/<user>/<mount>/Games`` layout — this helper
+    handles the ``<mount>/<level2>/Games`` case. Returns an
+    empty list on any I/O error (mount disappeared between
+    listings, permissions trouble).
     """
-    root = expand(_cfg(config, "paths.sd_card_root", DEFAULT_SD_ROOT))
-    if not os.path.isdir(root):
-        return []
-    return _scan_level2(root)
-
-
-def _scan_level2(
-    root: str,
-) -> list[str]:
-    """Return second-level subdirs of ``root``.
-    SD cards typically layout as
-    ``/run/media/deck/<volume>/<games-dir>/``. We scan
-    two levels deep from the mount root so we pick up
-    the inner games directory rather than just the
-    volume. Empty list on missing root / permission
-    error — SD cards often produce transient errors
-    during mount/unmount.
-    """
-    result: list[str] = []
+    found: list[str] = []
     try:
-        for volume in os.scandir(root):
-            if not volume.is_dir():
+        for level2_path in level1_path.iterdir():
+            if (
+                not level2_path.is_dir()
+                or level2_path.is_symlink()
+            ):
                 continue
-            try:
-                for subdir in os.scandir(volume.path):
-                    if subdir.is_dir():
-                        result.append(subdir.path)
-            except OSError:
-                pass
+            found.extend(_collect_game_dirs(level2_path))
     except OSError:
+        # best-effort operation; failure is non-fatal here
         pass
-    return result
+    return found
 
 
-def get_games_map_path(
-    config: ConfigManager | None = None,
-) -> str:
-    """Return the ``games.map`` file path, expanded.
-    Reads ``paths.games_map`` from config, falls back to
-    ``DEFAULT_GAMES_MAP``. Always returns an absolute
-    path. Creates no directories — caller calls
-    ``ensure_games_map_dir`` when write access is about
-    to be needed.
+def _scan_mount_root(root: str) -> list[str]:
+    """Walk ``/run/media/<user>/<mount>/`` looking for game folders.
+
+    Returns paths matching ``<mount>/Games/`` or
+    ``<mount>/GOG Games/`` where they exist. Errors are logged
+    at debug level only — a missing ``/run/media`` on a
+    non-Deck system is normal.
+
+    SECURITY/ROBUSTNESS: symbolic links are skipped at every
+    level. A symlink loop (e.g. ``Games/Other -> Games/``) would
+    otherwise cause the scan to recurse indefinitely or return
+    duplicate paths. The dedupe pass at the caller would mask
+    the duplicates but the wasted CPU on a symlink loop could
+    freeze sync.
     """
-    raw = _cfg(config, "paths.games_map", DEFAULT_GAMES_MAP)
+    root_path = Path(root)
+    if not root_path.is_dir():
+        return []
+
+    found: list[str] = []
+    try:
+        for level1_path in root_path.iterdir():
+            if (
+                not level1_path.is_dir()
+                or level1_path.is_symlink()
+            ):
+                continue
+            # /run/media/<level1>/Games or GOG Games
+            found.extend(_collect_game_dirs(level1_path))
+            # /run/media/<level1>/<level2>/Games (some Decks)
+            found.extend(_scan_level2(level1_path))
+    except OSError as e:
+        logger.debug(
+            "[paths] mount scan failed on %s: %s", root, e,
+        )
+    return found
+
+
+# ══════════════════════════════════════════════════════════════
+# games.map location
+# ══════════════════════════════════════════════════════════════
+
+
+def get_games_map_path(config: ConfigManager | None = None) -> str:
+    """Return the absolute path to the games.map file.
+
+    Reads ``paths.games_map`` from config if set, otherwise
+    falls back to ``~/.local/share/unifideck/games.map``. Tilde
+    and env vars in the configured path are expanded.
+    """
+    raw = get_cfg(config, "paths.games_map", DEFAULT_GAMES_MAP)
     return expand(raw)
 
 
-def ensure_games_map_dir(
-    config: ConfigManager | None = None,
-) -> str:
-    """Create the parent directory of ``games.map`` if missing.
-    Returns the resolved ``games.map`` path for
-    convenience (so callers can ``ensure_games_map_dir()``
-    and use the result directly without a second call to
-    ``get_games_map_path``). Uses
-    ``Path.mkdir(parents=True, exist_ok=True)`` — no-op
-    when the dir already exists.
+def ensure_games_map_dir(config: ConfigManager | None = None) -> str | None:
+    """Create the parent directory for games.map if missing.
+
+    Returns the directory path on success, None on failure.
+    Idempotent — safe to call on every plugin start.
     """
-    gm_path = get_games_map_path(config)
-    Path(gm_path).parent.mkdir(parents=True, exist_ok=True)
-    return gm_path
+    path = Path(get_games_map_path(config))
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+        return str(parent)
+    except OSError as e:
+        logger.warning(
+            "[paths] mkdir %s failed: %s", parent, e,
+        )
+        return None


### PR DESCRIPTION
<html><head></head><body><h1>update/utils — Schema-driven locale resolution and config-aware paths</h1>
<blockquote>
<p>[!NOTE]
Two-axis update on <code>utils/</code> :</p>
<ul>
<li><strong>Locale resolution refactor</strong> — <code>locale.py</code> no longer scans
<code>src/i18n/locales/</code> to discover supported tags ; the active
set is now driven by the <code>i18n.locales</code> schema in
<code>defaults/config.json</code>, parsed and validated by
<code>scripts/locale_config.py</code>.</li>
<li><strong>API evolution</strong> — public functions in <code>locale.py</code> and
<code>paths.py</code> now accept an explicit <code>config: ConfigManager | None</code>
parameter instead of reaching for global state. Cleaner
testability, no behavioural change for current call sites.</li>
</ul>
</blockquote>
<blockquote>
<p>[!IMPORTANT]
No public symbol is removed. Legacy constants like
<code>GAMES_MAP_PATH</code> and <code>DEFAULT_PATHS</code> are preserved as expanded
values in <code>paths.py</code> for v0.6.x callers. The signature
evolution adds <code>config</code> as a defaulted-<code>None</code> parameter, so
existing call sites continue to work unchanged.</p>
</blockquote>
<hr>
<h2>1 — Locale resolution refactor</h2>
<h3>Why</h3>
<p>The previous implementation discovered supported locales by
scanning <code>src/i18n/locales/*.json</code> at runtime. This had three
problems :</p>
<ol>
<li><strong>Coupling to the build pipeline</strong> — the runtime depended on
the DeepL CI job having produced the right files. A missing
or malformed locale JSON silently disappeared from the menu.</li>
<li><strong>No validation</strong> — any file matching <code>*.json</code> in the
directory was accepted as a valid locale, regardless of
whether its market code, currency code, or tag format was
correct.</li>
<li><strong>Hardcoded fallback</strong> — <code>_DEFAULT_LOCALE = "en-US"</code> and
<code>_DEFAULT_MARKET = "US"</code> were buried as module constants.
Changing them required a code edit, not a config change.</li>
</ol>
<h3>How</h3>
<p>A single source of truth in <code>defaults/config.json</code> :</p>
<pre><code class="language-json">{
  "i18n": {
    "locales": [
      { "tag": "en-US", "market": "US", "name": "English (US)" },
      { "tag": "fr-FR", "market": "FR", "name": "Français" },
      ...
    ],
    "source": { "tag": "en-US", "market": "US" }
  }
}
</code></pre>
<p><code>scripts/locale_config.py</code> parses this section into a
<code>LocaleConfig</code> dataclass, validates entries, and exposes a
typed view to <code>utils/locale.py</code>. Adding a new language is now a
one-line edit to <code>config.json</code> — no Python change needed.</p>
<h3>Resolution priority</h3>
<p>The active locale is resolved by the following waterfall :</p>
<ol>
<li><strong>User preference</strong> — <code>ConfigManager['ui.language']</code>.
Validated against the locales list ; unknown saved tags are
silently ignored (a stale config from a removed locale
doesn't break startup, it just falls through).</li>
<li><strong>System POSIX</strong> — <code>locale.getlocale()</code> mapped to the first
<code>i18n.locales</code> entry whose tag begins with the same
2-letter prefix, case-insensitive. So a system reporting
<code>fr_BE.UTF-8</code> resolves to <code>fr-FR</code> if that's what we ship.</li>
<li><strong>Source fallback</strong> — <code>LocaleConfig.source.tag</code> (defined in
the same config file). No hardcoded <code>"en-US"</code> constant
anymore.</li>
</ol>
<h3>Lazy import of the schema module</h3>
<p><code>scripts/locale_config.py</code> lives outside <code>py_modules/</code>, so it's
not on the default Python path. The new <code>_import_locale_config()</code>
helper adds the parent directory on first use and caches the
module handle. None signals "schema validation unavailable" —
in that case the resolver falls through to a conservative
default rather than raising, so an unusual install layout
doesn't lock the user out.</p>
<blockquote>
<p>[!NOTE]
The lazy-import pattern fixes a previously-shadowed bug where
the cached check was nested under the import path, causing
the function to always return None on the second call.
Validated through the cascade-counting pass — the symptom
was the locale falling back to system-default even when the
user had explicitly chosen a language.</p>
</blockquote>
<hr>
<h2>2 — API evolution : <code>config</code> as explicit parameter</h2>
<p>The public functions affected :</p>

Function | Before | After
-- | -- | --
get_unifideck_locale() | no params | (config: ConfigManager \| None)
get_unifideck_market() | no params | (config: ConfigManager \| None)
get_locale_config() | (didn't exist) | (config: ConfigManager \| None)
get_all_game_directories() | implicit globals | (config: ConfigManager \| None = None)
get_games_map_path() | implicit globals | (config: ConfigManager \| None = None)
ensure_games_map_dir() | implicit globals | (config: ConfigManager \| None = None)


<p>Defaulting to <code>None</code> keeps every existing call site working —
when no config is passed, the function falls back to its prior
behaviour using compiled-in defaults. New callers that already
hold a <code>ConfigManager</code> reference can pass it through to get
config-aware behaviour without re-reading the file.</p>
<p>This makes the module straightforwardly testable : tests can
construct a fake config and pass it in, instead of monkey-
patching a global.</p>
<hr>
<h2>3 — Quality cascade</h2>
<p><code>paths.py</code> and <code>config_helpers.py</code> were also touched by the
cascade-elimination pass : exhaustive docstrings, signatures
broken up under the 80-line cap, <code>TYPE_CHECKING</code> lazy imports
broadened (3 → 6 files use the pattern across <code>utils/</code>), type
hints consolidated. The diffs are large in line count
(<code>paths.py</code> shows +190/-182, <code>config_helpers.py</code> shows +96/-91)
but the public API is identical — every exported symbol
retains the same name, signature, and semantics.</p>
<p>The most visible structural change in <code>paths.py</code> is helper
ordering : <code>_scan_level2</code> now appears before <code>_scan_mount_root</code>
(matches the call chain order, easier to follow when reading
top-to-bottom).</p>
<hr>
<h2>Verification</h2>
<ul>
<li>[x] <strong>Lint</strong> — <code>ruff check</code> clean across the 4 files</li>
<li>[x] <strong>Volumetry</strong> — every function under 80 LOC, every file
under 550 LOC</li>
<li>[x] <strong>Import smoke</strong> — <code>python -c "from unifideck.utils import *"</code>
succeeds, all public symbols resolve</li>
</ul>
<hr>
<h2>Files changed</h2>
<p><strong>Modified — locale resolution refactor</strong></p>
<ul>
<li><code>py_modules/unifideck/utils/locale.py</code> — schema-driven locale
resolution, lazy import of <code>scripts/locale_config.py</code>,
<code>_import_locale_config()</code> and <code>get_locale_config()</code> added,
<code>get_unifideck_locale</code> / <code>get_unifideck_market</code> signatures
evolved</li>
<li><code>py_modules/unifideck/utils/__init__.py</code> — module docstring
documenting the legacy-vs-new constant distinction</li>
</ul>
<p><strong>Modified — quality cascade</strong></p>
<ul>
<li><code>py_modules/unifideck/utils/paths.py</code> — internal refactor,
helper reordering, <code>config: ConfigManager | None = None</code>
parameter added to public functions</li>
<li><code>py_modules/unifideck/utils/config_helpers.py</code> — internal
refactor, no public API change</li>
</ul>
<hr>
<h2>Migration notes</h2>
<ul>
<li><strong><code>defaults/config.json</code> requirement</strong> — the new locale
resolver expects an <code>i18n.locales</code> section. If the file ships
without it, the resolver falls through to <code>LocaleConfig</code>'s
built-in source fallback rather than raising. Existing
installs without the schema get the source language until the
config file is updated, no UI breakage.</li>
<li><strong>Saved preference compatibility</strong> — users with a saved
<code>ui.language</code> value pointing to a tag no longer in the
locales list get the system-default language transparently.
No error, no toast. They can re-pick a valid language at any
time.</li>
<li><strong>Pre-cascade tooling</strong> — anything that grepped raw line
numbers in <code>utils/</code> will need to re-run.</li>
</ul></body></html>