### PR TITLE
minor update: add docstrings

### DIFF
--- a/py_modules/unifideck/__init__.py
+++ b/py_modules/unifideck/__init__.py
@@ -1,3 +1,20 @@
+"""Unifideck — unified game library for Steam Deck.
+
+Top-level package. Defines the public API of the plugin's backend,
+accessible from any Decky-loaded code via simple
+`from unifideck.X import Y` imports.
+
+The new architecture is organized in 5 layers:
+    Layer 1 — core/types (Game, Result, Events, ...)
+    Layer 2 — core/services (EventBus, CacheManager, StoreRegistry,
+              SyncService, BinaryResolver, ExeFinder)
+    Layer 3 — stores/store_base (StoreBase ABC + 5 abstract methods)
+    Layer 4 — stores/ (5 store plugins, one per backend)
+    Layer 5 — services/ (infrastructure services subscribing to EventBus)
+
+Adjacent packages (`auth/`, `cdp/`, `compatibility/`, `metadata/`,
+`steam/`, `utils/`) provide support modules.
+"""
 from __future__ import annotations
 
 __version__ = "0.7.0"


### PR DESCRIPTION
# docs/unifideck-init — Top-level package docstring

> [!NOTE]
> Adds an architecture-level docstring to `py_modules/unifideck/__init__.py`.
> The file previously contained only `__version__`. This PR documents
> the 5-layer architecture and the role of adjacent packages, so any
> developer running `help(unifideck)` or opening the file gets a map
> of the codebase before diving in.

> [!IMPORTANT]
> Documentation-only change. Zero behavioural impact, zero runtime
> cost, no public API change. `__version__ = "0.7.0"` is preserved
> as-is.

---

## What

A 17-line module docstring is prepended to `unifideck/__init__.py`,
followed by `from __future__ import annotations` for forward-compat
with future annotation features.

The docstring summarises :

- **The 5-layer architecture** — `core/types` → `core/services` →
  `stores/store_base` → `stores/` → `services/`. Mirrors the
  ordering documented in the technical design doc, so developers
  see the same vocabulary in code and in design artifacts.
- **The role of adjacent packages** — `auth/`, `cdp/`,
  `compatibility/`, `metadata/`, `steam/`, `utils/` are flagged as
  support modules, distinguishing them from the layered backbone.
- **The import contract** — any Decky-loaded code can use simple
  `from unifideck.X import Y` imports (no special bootstrap needed).

---

## Why

The previous file had no introduction. New contributors landing on
the package — whether through `pydoc`, an IDE's "go to definition",
or a code search — got `__version__` and nothing else. The
architecture diagram lived only in the design PDF, which is fine for
formal review but invisible at the code surface.

A docstring at the package root puts the architectural summary one
keystroke away from any developer working in the codebase, without
requiring them to know the design document exists.

---

## Verification

- [x] **Lint** — `ruff check` clean
- [x] **Import smoke** — `python -c "import unifideck; print(unifideck.__version__)"`
  still resolves to `0.7.0`
- [x] **Docstring access** — `python -c "import unifideck; print(unifideck.__doc__)"`
  surfaces the new architecture summary

---

## Files changed

- `py_modules/unifideck/__init__.py` — +17 lines of module docstring,
  no other change