### PR TITLE
feat: GameVault store integration + launcher/metadata fixes

### DIFF
--- a/bin/unifideck-launcher
+++ b/bin/unifideck-launcher
@@ -9,9 +9,11 @@ non-Steam binaries (Wine, Proton, store CLIs). Both variables are
 scrubbed before any Python import so the dispatcher inherits a
 clean environment.
 
-The wrapper has two responsibilities :
+The wrapper has THREE responsibilities, in order:
     1. Sanitise the inherited environment.
-    2. Prepend the plugin's ``py_modules`` directory to
+    2. Re-exec onto a modern (>=3.10) Python interpreter if the one
+       that started this script is too old — see ``_reexec_on_modern_python``.
+    3. Prepend the plugin's ``py_modules`` directory to
        ``sys.path`` so ``unifideck.launcher.dispatcher`` resolves
        at import time.
 
@@ -27,6 +29,160 @@ os.environ.pop("LD_PRELOAD", None)
 
 import sys
 from pathlib import Path
+
+# Interpreters tried, newest first, as a LAST-RESORT fallback when the
+# pressure-vessel escape below is unavailable — mirrors
+# ``launcher.proton.infrastructure.selector.PYTHON_CANDIDATES`` (kept in
+# sync manually; that module cannot be imported yet at this point in the
+# bootstrap, see ``_reexec_on_modern_python``'s docstring for why).
+_MODERN_PYTHON_CANDIDATES: tuple[str, ...] = (
+    "/usr/bin/python3.14",
+    "/usr/bin/python3.13",
+    "/usr/bin/python3.12",
+    "/usr/bin/python3.11",
+    "/usr/bin/python3.10",
+)
+# Env var guarding the re-execs below against an infinite loop — see
+# ``_escape_pressure_vessel``/``_reexec_on_modern_python``'s docstrings.
+_REEXEC_GUARD_ENV = "_UNIFIDECK_LAUNCHER_REEXECED"
+_ESCAPE_CLIENT = "steam-runtime-launch-client"
+
+
+def _in_pressure_vessel() -> bool:
+    """Whether this process is running inside a pressure-vessel container.
+
+    Mirrors ``launcher.proton.infrastructure.container_escape.in_pressure_vessel``
+    exactly (duplicated rather than imported — see this module's docstring
+    for why nothing from ``unifideck.*`` can be imported yet at this point).
+    """
+    return (
+        os.environ.get("container") == "pressure-vessel"  # noqa: SIM112
+        or os.path.isdir("/run/pressure-vessel")
+    )
+
+
+def _find_on_path(name: str) -> str | None:
+    """Minimal ``shutil.which`` substitute using only ``os`` (stdlib-safe
+    on any Python version — this runs before we know the version is even
+    new enough for ``shutil.which``'s modern keyword args, though that
+    function itself is fine on 3.9 too; kept dependency-free anyway since
+    correctness here matters more than brevity)."""
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory, name) if directory else name
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _escape_pressure_vessel() -> None:
+    """Re-exec this script OUTSIDE Steam's pressure-vessel container.
+
+    This wrapper's own ``#!/usr/bin/env python3`` shebang is only ever as
+    good as whatever ``python3`` resolves to in the CALLER's environment.
+    Steam runs this script directly (no shell in between) whenever a
+    Unifideck shortcut launches — normally against the host's own
+    ``python3``, which is fine on every distro this plugin ships for.
+
+    But Steam ALSO wraps this exact same script inside its own
+    Steam-Linux-Runtime pressure-vessel container whenever the user sets
+    **Properties > Compatibility > "Force the use of a specific Steam Play
+    compatibility tool"** on the shortcut (a supported, intended workflow —
+    see ``launcher.proton.infrastructure.container_escape`` for the sibling
+    fix that gets umu itself back OUT of that same container later in the
+    launch, once this script has already gotten far enough to reach it).
+    Inside that container ``python3`` resolves to the CONTAINER's OWN much
+    older bundled interpreter (observed: 3.9), not the host's — and
+    critically, the container's ``/usr/bin/`` does NOT contain any newer
+    interpreter to fall back to either (it is the container's own private
+    filesystem, not bind-mounted to the host's ``/usr``): a first attempt
+    at this fix that searched hardcoded ``/usr/bin/python3.1x`` paths
+    (see ``_reexec_on_modern_python`` below) silently found nothing and
+    kept running under the container's 3.9, reproducing the exact same
+    crash it was meant to fix.
+
+    That old interpreter is a version this codebase's ``unifideck.*``
+    package was never written to run on: it relies throughout on
+    ``X | Y`` union syntax and ``dict[str, Any]`` generics at both
+    annotation AND plain runtime-expression scope (not just inside function
+    signatures, where ``from __future__ import annotations`` would save
+    it), plus 3.11+-only stdlib members like ``enum.StrEnum``. Patching
+    every individual crash site as they turn up (already hit in
+    ``core/cache_manager.py``, ``core/types/events.py``,
+    ``event_bus/event_bus.py``) is whack-a-mole with no bounded end.
+
+    The fix that actually works: escape the container entirely via
+    ``steam-runtime-launch-client --alongside-steam``, exactly like
+    ``container_escape.escape_argv`` does for the umu subprocess deeper in
+    the launch — confirmed there to hand the escaped process a clean HOST
+    environment (host ``PATH``, no container/``PRESSURE_VESSEL_*``
+    leakage). Re-``exec``ing THIS SAME SCRIPT through that client, before
+    ``_bootstrap_path``/the dispatcher import ever run, means the escaped
+    process's own ``python3`` resolves on the HOST — the exact same
+    resolution a normal (non-Force-Compat) launch already gets, which is
+    known-good.
+
+    Guarded by ``_REEXEC_GUARD_ENV`` against re-exec looping (the escaped
+    process re-invokes this very script, which would otherwise try to
+    escape again — though by then it is no longer inside pressure-vessel,
+    so ``_in_pressure_vessel()`` alone would already prevent a loop; the
+    guard is defence in depth).
+    """
+    if not _in_pressure_vessel():
+        return
+    if os.environ.get(_REEXEC_GUARD_ENV):
+        return
+    client = _find_on_path(_ESCAPE_CLIENT)
+    if client is None:
+        # No escape route available — fall through to the version-based
+        # fallback below, which will likely also fail to find a newer
+        # interpreter (same container filesystem), but at least doesn't
+        # regress behaviour from before this fix existed.
+        return
+    env = dict(os.environ)
+    env[_REEXEC_GUARD_ENV] = "1"
+    script_path = os.path.abspath(__file__)
+    argv = [
+        client, "--alongside-steam", "--",
+        "python3", script_path, *sys.argv[1:],
+    ]
+    try:
+        os.execve(client, argv, env)
+    except OSError:
+        return
+
+
+def _reexec_on_modern_python() -> None:
+    """Re-exec this script onto a modern Python if the CURRENT one is too old.
+
+    Fallback for the (currently unobserved, but possible) case where this
+    process is running under an old Python WITHOUT being inside a
+    pressure-vessel container — ``_escape_pressure_vessel`` above only
+    fires when ``_in_pressure_vessel()`` is true. Kept as a second line of
+    defence; see that function's docstring for the primary fix and why a
+    hardcoded host-path search alone was insufficient for the actual
+    container case.
+    """
+    if sys.version_info >= (3, 10):
+        return
+    if os.environ.get(_REEXEC_GUARD_ENV):
+        return
+    for candidate in _MODERN_PYTHON_CANDIDATES:
+        if not os.path.isfile(candidate):
+            continue
+        env = dict(os.environ)
+        env[_REEXEC_GUARD_ENV] = "1"
+        script_path = os.path.abspath(__file__)
+        try:
+            os.execve(candidate, [candidate, script_path, *sys.argv[1:]], env)
+        except OSError:
+            continue
+    # No modern interpreter found on this system at all — proceed under
+    # the current (old) one; the dispatcher's own import errors are the
+    # existing fallback behaviour and still get surfaced to the user.
+
+
+_escape_pressure_vessel()
+_reexec_on_modern_python()
 
 
 def _bootstrap_path() -> None:

--- a/bin/unifideck-launcher.py
+++ b/bin/unifideck-launcher.py
@@ -32,6 +32,89 @@ os.environ.pop("LD_PRELOAD", None)
 import sys
 from pathlib import Path
 
+# See bin/unifideck-launcher's ``_escape_pressure_vessel``/
+# ``_reexec_on_modern_python`` for the full rationale — kept in sync
+# manually since this file is not the one build-plugin.sh actually ships
+# (see its file checklist), but is kept functionally identical to avoid
+# drift if it's ever used as a source.
+_MODERN_PYTHON_CANDIDATES: tuple[str, ...] = (
+    "/usr/bin/python3.14",
+    "/usr/bin/python3.13",
+    "/usr/bin/python3.12",
+    "/usr/bin/python3.11",
+    "/usr/bin/python3.10",
+)
+_REEXEC_GUARD_ENV = "_UNIFIDECK_LAUNCHER_REEXECED"
+_ESCAPE_CLIENT = "steam-runtime-launch-client"
+
+def _in_pressure_vessel() -> bool:
+    """Whether this process is running inside a pressure-vessel container."""
+    return (
+        os.environ.get("container") == "pressure-vessel"  # noqa: SIM112
+        or os.path.isdir("/run/pressure-vessel")
+    )
+
+def _find_on_path(name: str) -> str | None:
+    """Minimal ``shutil.which`` substitute using only ``os``."""
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory, name) if directory else name
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+def _escape_pressure_vessel() -> None:
+    """Re-exec OUTSIDE Steam's pressure-vessel container, if inside one.
+
+    See ``bin/unifideck-launcher``'s twin function for the full rationale:
+    the container's own ``python3`` is too old for this codebase AND the
+    container has no newer interpreter to fall back to on its own
+    filesystem, so the only real fix is escaping via
+    ``steam-runtime-launch-client --alongside-steam`` (same tool
+    ``launcher.proton.infrastructure.container_escape`` uses for umu).
+    """
+    if not _in_pressure_vessel():
+        return
+    if os.environ.get(_REEXEC_GUARD_ENV):
+        return
+    client = _find_on_path(_ESCAPE_CLIENT)
+    if client is None:
+        return
+    env = dict(os.environ)
+    env[_REEXEC_GUARD_ENV] = "1"
+    script_path = os.path.abspath(__file__)
+    argv = [
+        client, "--alongside-steam", "--",
+        "python3", script_path, *sys.argv[1:],
+    ]
+    try:
+        os.execve(client, argv, env)
+    except OSError:
+        return
+
+def _reexec_on_modern_python() -> None:
+    """Re-exec onto a modern (>=3.10) Python if the current one is too old.
+
+    Second line of defence for the (unobserved) case of running under an
+    old Python OUTSIDE a pressure-vessel container.
+    """
+    if sys.version_info >= (3, 10):
+        return
+    if os.environ.get(_REEXEC_GUARD_ENV):
+        return
+    for candidate in _MODERN_PYTHON_CANDIDATES:
+        if not os.path.isfile(candidate):
+            continue
+        env = dict(os.environ)
+        env[_REEXEC_GUARD_ENV] = "1"
+        script_path = os.path.abspath(__file__)
+        try:
+            os.execve(candidate, [candidate, script_path, *sys.argv[1:]], env)
+        except OSError:
+            continue
+
+_escape_pressure_vessel()
+_reexec_on_modern_python()
+
 def _bootstrap_path() -> None:
     """Make the plugin's ``py_modules`` directory importable.
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/py_modules/unifideck/config/config_manager.py
+++ b/py_modules/unifideck/config/config_manager.py
@@ -22,6 +22,8 @@ Features:
 Reference: Technical Document v1.0 — Section 3.9 (Configuration
 service), Figure 30.
 """
+from __future__ import annotations
+
 import contextlib
 import json
 import logging

--- a/py_modules/unifideck/core/__init__.py
+++ b/py_modules/unifideck/core/__init__.py
@@ -29,6 +29,7 @@ of the most-used names so consumers can ``from unifideck.core
 import Game, Result, Events`` without knowing the internal
 split.
 """
+from __future__ import annotations
 
 from .cache_manager import CacheManager
 from .types import (

--- a/py_modules/unifideck/core/cache_manager.py
+++ b/py_modules/unifideck/core/cache_manager.py
@@ -23,6 +23,8 @@ Files are written with ``chmod 0600`` so cache contents
 owner-readable.
 """
 
+from __future__ import annotations
+
 import contextlib
 import copy
 import json

--- a/py_modules/unifideck/core/exe_finder.py
+++ b/py_modules/unifideck/core/exe_finder.py
@@ -24,6 +24,7 @@ score-based search:
 Exported as both a class and a module-level singleton
 ``exe_finder``.
 """
+from __future__ import annotations
 
 import contextlib
 import logging

--- a/py_modules/unifideck/core/types/events.py
+++ b/py_modules/unifideck/core/types/events.py
@@ -15,7 +15,41 @@ Reference: Technical Document v1.0 — Section 3.3 (EventBus topology).
 
 from __future__ import annotations
 
-from enum import StrEnum
+try:
+    from enum import StrEnum
+except ImportError:
+    # StrEnum was only added to the stdlib in Python 3.11. This module sits
+    # in the EAGER import chain every Unifideck shortcut launch pulls in
+    # (bin/unifideck-launcher -> launcher.dispatcher -> core -> core.types
+    # -> .events), which normally runs under a modern system Python via
+    # find_python_3_10_plus()'s ACCEPTED_VERSIONS — but that selection only
+    # applies to the Proton/umu subprocess, never to the launcher SCRIPT
+    # itself. bin/unifideck-launcher's own "#!/usr/bin/env python3" shebang
+    # resolves whatever "python3" the CALLING process's environment
+    # provides, and when Steam wraps the launcher in its own
+    # SteamLinuxRuntime_sniper pressure-vessel container — which it does
+    # automatically whenever the user sets Force-Compatibility on a
+    # Unifideck shortcut, see
+    # launcher.proton.infrastructure.container_escape's docstring for the
+    # umu-side twin of this same container problem — that "python3" is the
+    # CONTAINER's own (observed: too old for StrEnum, and for the `X | None`
+    # syntax core/cache_manager.py used to use unguarded). Reproduced
+    # on-device: entering the sniper container directly
+    # (_v2-entry-point --verb=run --) and invoking
+    # bin/unifideck-launcher raised exactly this ImportError one import
+    # deeper, right after an earlier `Any | None` TypeError in
+    # cache_manager.py was fixed.
+    #
+    # A plain (str, Enum) shim needs no stdlib version newer than 3.4 and
+    # is functionally identical for this codebase's usage (every member's
+    # value already equals its serialised form, so no custom __str__ is
+    # required) — this sidesteps entirely having to know or control which
+    # Python interpreters are reachable from inside an arbitrary Steam
+    # Runtime container.
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # type: ignore[no-redef]
+        """Pre-3.11 stand-in for :class:`enum.StrEnum`."""
 
 
 class Events(StrEnum):

--- a/py_modules/unifideck/launcher/proton/infrastructure/container_escape.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/container_escape.py
@@ -68,9 +68,15 @@ _ALWAYS_FORWARD = frozenset({
     "STEAM_COMPAT_INSTALL_PATH",
     "STORE",
     "WINEPREFIX",
-    # gamescope binds the window to this app id; without it the window never
-    # surfaces in Gaming Mode (steam app id: 0 in gamescope WSI log).
+    # umu copies STEAM_COMPAT_APP_ID → SteamAppId → SteamGameId; gamescope
+    # reads SteamGameId to bind the window — all four must cross the boundary.
     "SteamAppId",
+    "SteamGameId",
+    "SteamOverlayGameId",
+    "STEAM_COMPAT_APP_ID",
+    # Reaper sets LD_PRELOAD to gameoverlayrenderer.so; --alongside-steam starts
+    # outside the reaper tree so the overlay is dropped — carry it explicitly.
+    "LD_PRELOAD",
 })
 
 

--- a/py_modules/unifideck/launcher/proton/infrastructure/container_escape.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/container_escape.py
@@ -68,6 +68,9 @@ _ALWAYS_FORWARD = frozenset({
     "STEAM_COMPAT_INSTALL_PATH",
     "STORE",
     "WINEPREFIX",
+    # gamescope binds the window to this app id; without it the window never
+    # surfaces in Gaming Mode (steam app id: 0 in gamescope WSI log).
+    "SteamAppId",
 })
 
 

--- a/py_modules/unifideck/launcher/proton/infrastructure/container_escape.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/container_escape.py
@@ -68,15 +68,8 @@ _ALWAYS_FORWARD = frozenset({
     "STEAM_COMPAT_INSTALL_PATH",
     "STORE",
     "WINEPREFIX",
-    # umu copies STEAM_COMPAT_APP_ID → SteamAppId → SteamGameId; gamescope
-    # reads SteamGameId to bind the window — all four must cross the boundary.
-    "SteamAppId",
-    "SteamGameId",
-    "SteamOverlayGameId",
+    # umu derives SteamAppId/SteamGameId from this; gamescope window tagger handles focus.
     "STEAM_COMPAT_APP_ID",
-    # Reaper sets LD_PRELOAD to gameoverlayrenderer.so; --alongside-steam starts
-    # outside the reaper tree so the overlay is dropped — carry it explicitly.
-    "LD_PRELOAD",
 })
 
 

--- a/py_modules/unifideck/launcher/proton/infrastructure/core.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/core.py
@@ -334,7 +334,11 @@ def _build_umu_env(
     # umu-run (system python) doesn't load a stale libcrypto and abort — the
     # cause of empty install-time prefixes. No-op for the clean launcher env.
     sanitize_frozen_loader_env(env)
-    env["GAMEID"] = umu_id or "umu-0"
+    # Fall back to the shortcut's Steam AppID so gamescope can bind the
+    # window to the running session; "umu-0" leaves steam app id: 0 in
+    # gamescope and the window never appears in Gaming Mode.
+    fallback_id = f"umu-{ctx.steam_app_id}" if ctx.steam_app_id else "umu-0"
+    env["GAMEID"] = umu_id or fallback_id
     # See _epic_store_value for the Epic STORE reasoning. ``umu_store_code``
     # on state keeps the real value for diagnostics regardless of this.
     exe_name = ctx.exe_path.name

--- a/py_modules/unifideck/launcher/proton/infrastructure/core.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/core.py
@@ -334,10 +334,17 @@ def _build_umu_env(
     # umu-run (system python) doesn't load a stale libcrypto and abort — the
     # cause of empty install-time prefixes. No-op for the clean launcher env.
     sanitize_frozen_loader_env(env)
-    # Fall back to the shortcut's Steam AppID so gamescope can bind the
-    # window to the running session; "umu-0" leaves steam app id: 0 in
-    # gamescope and the window never appears in Gaming Mode.
-    fallback_id = f"umu-{ctx.steam_app_id}" if ctx.steam_app_id else "umu-0"
+    # umu's regex ^umu-[\d\w]+$ rejects negative IDs (signed 32-bit from
+    # games.map); convert to unsigned so STEAM_COMPAT_APP_ID passes through.
+    if ctx.steam_app_id:
+        try:
+            sid = int(ctx.steam_app_id)
+            unsigned_id = str(sid & 0xFFFFFFFF) if sid < 0 else ctx.steam_app_id
+        except ValueError:
+            unsigned_id = ctx.steam_app_id
+    else:
+        unsigned_id = None
+    fallback_id = f"umu-{unsigned_id}" if unsigned_id else "umu-0"
     env["GAMEID"] = umu_id or fallback_id
     # See _epic_store_value for the Epic STORE reasoning. ``umu_store_code``
     # on state keeps the real value for diagnostics regardless of this.
@@ -370,6 +377,21 @@ def _build_umu_env(
     # Let DXVK-NVAPI work on non-NVIDIA / mixed driver setups (harmless
     # on the Deck's AMD GPU; required by some titles' NVAPI probes).
     env["DXVK_NVAPI_ALLOW_OTHER_DRIVERS"] = "1"
+    # Force-set so gamescope can bind the window; Steam's env may contain
+    # stale/garbage values that setdefault would not override.
+    # SteamOverlayGameId is read by gameoverlayrenderer.so and reported to gamescope.
+    if unsigned_id:
+        env["STEAM_COMPAT_APP_ID"] = unsigned_id
+        env["SteamAppId"] = unsigned_id
+        env["SteamGameId"] = unsigned_id
+        env["SteamOverlayGameId"] = unsigned_id
+    # Replace the pressure-vessel ${LIB} template path with the stable host paths
+    # so gameoverlayrenderer.so is actually loaded after the container escape.
+    steam_root = os.path.expanduser("~/.local/share/Steam")
+    overlay_32 = f"{steam_root}/ubuntu12_32/gameoverlayrenderer.so"
+    overlay_64 = f"{steam_root}/ubuntu12_64/gameoverlayrenderer.so"
+    if os.path.exists(overlay_64):
+        env["LD_PRELOAD"] = f"{overlay_32}:{overlay_64}"
     # Do NOT pin STEAM_COMPAT_CLIENT_INSTALL_PATH. umu-run derives it
     # itself; forcing it to ``~/.steam/root`` — a symlink chain on
     # atomic/ostree hosts (Bazzite: ``~`` → /var/home, ``.steam/root`` →
@@ -421,6 +443,21 @@ def proton_prepare(
         prefix_path=prefix_path, proton_path=proton_path,
         proton_tool_id=proton_tool_id,
     )
+    # Start the gamescope window tagger immediately (not deferred to the
+    # on_process_start callback) so windows appearing before the umu process
+    # is fully registered are still tagged.  umu's own monitor_windows only
+    # runs when container=flatpak; we have container=pressure-vessel so
+    # gamescope never gets STEAM_GAME without this.
+    raw_appid = env.get("SteamGameId") or env.get("SteamAppId")
+    if raw_appid:
+        try:
+            appid_int = int(raw_appid)
+        except ValueError:
+            appid_int = 0
+        if appid_int > 0:
+            from .gamescope_window_tagger import start_window_tagger
+            start_window_tagger(appid_int)
+
     return ProtonLaunchPlan(
         context=ctx,
         state=state,

--- a/py_modules/unifideck/launcher/proton/infrastructure/gamescope_window_tagger.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/gamescope_window_tagger.py
@@ -1,0 +1,121 @@
+"""Tag game windows with STEAM_GAME so gamescope brings them to the foreground.
+
+umu's own ``monitor_windows`` does this, but only when ``is_steammode`` is
+True — which requires ``container=flatpak``.  We run inside
+``container=pressure-vessel`` so umu skips that path.
+
+The fix: game windows (WM_CLASS = "steam_app_<appid>") appear on display ``:0``
+(the gamescope compositor), not ``:1``.  Setting STEAM_GAME=<appid> on them
+causes gamescope to add the app to FOCUSABLE_APPS and switch focus immediately.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DISPLAY = ":0"
+_POLL_INTERVAL = 0.3
+_MAX_RUNTIME = 300
+
+
+def _find_umu_zipapp() -> Path | None:
+    """Return path to the umu zipapp bundled with this plugin."""
+    # infrastructure/ → proton/ → launcher/ → unifideck/ → py_modules/ → plugin_root/
+    here = Path(__file__).resolve().parent
+    plugin_root = here.parents[4]
+    candidate = plugin_root / "bin" / "umu" / "umu" / "umu_run.py"
+    if candidate.is_file():
+        return candidate
+    return None
+
+
+def _tag_windows(appid: int, stop_event: threading.Event) -> None:
+    umu_zip = _find_umu_zipapp()
+    if umu_zip is None:
+        logger.warning("[gamescope_tagger] umu zipapp not found, cannot tag")
+        return
+
+    zip_str = str(umu_zip)
+    if zip_str not in sys.path:
+        sys.path.insert(0, zip_str)
+
+    try:
+        from Xlib import X
+        from Xlib.display import Display
+    except ImportError as e:
+        logger.warning("[gamescope_tagger] Xlib import failed: %s", e)
+        return
+
+    try:
+        d = Display(_DISPLAY)
+    except Exception as e:
+        logger.warning("[gamescope_tagger] cannot open display %s: %s", _DISPLAY, e)
+        return
+
+    root = d.screen().root
+    # Listen for new windows on :0 (gamescope compositor)
+    root.change_attributes(event_mask=X.SubstructureNotifyMask)
+    d.flush()
+
+    atom_steam_game = d.intern_atom("STEAM_GAME", only_if_exists=False)
+    wm_class_str = f"steam_app_{appid}"
+    tagged: set[int] = set()
+    deadline = time.monotonic() + _MAX_RUNTIME
+    logger.info("[gamescope_tagger] watching :0 for WM_CLASS=%s", wm_class_str)
+
+    # Also tag any windows that already exist on :0 before we started listening
+    try:
+        for child in root.query_tree().children:
+            _try_tag(d, child, atom_steam_game, wm_class_str, appid, tagged)
+    except Exception as e:
+        logger.debug("[gamescope_tagger] initial scan error: %s", e)
+
+    while not stop_event.is_set() and time.monotonic() < deadline:
+        while d.pending_events():
+            ev = d.next_event()
+            if ev.type != X.CreateNotify:
+                continue
+            try:
+                _try_tag(d, ev.window, atom_steam_game, wm_class_str, appid, tagged)
+            except Exception as e:
+                logger.debug("[gamescope_tagger] event error: %s", e)
+        time.sleep(_POLL_INTERVAL)
+
+    d.close()
+    logger.info("[gamescope_tagger] done, tagged %d window(s)", len(tagged))
+
+
+def _try_tag(d, window, atom_steam_game, wm_class_str: str, appid: int, tagged: set) -> None:
+    wid = window.id
+    if wid in tagged:
+        return
+    cls = window.get_wm_class()
+    if not cls:
+        return
+    # WM_CLASS is a tuple (instance, class); game windows have both set to steam_app_<appid>
+    if wm_class_str not in cls:
+        return
+    window.change_property(atom_steam_game, d.get_atom("CARDINAL"), 32, [appid])
+    d.flush()
+    tagged.add(wid)
+    logger.info("[gamescope_tagger] STEAM_GAME=%d set on wid=0x%x", appid, wid)
+
+
+def start_window_tagger(appid: int) -> threading.Event:
+    """Start a daemon thread that tags game windows on :0 with STEAM_GAME=appid."""
+    stop = threading.Event()
+    t = threading.Thread(
+        target=_tag_windows,
+        args=(appid, stop),
+        daemon=True,
+        name=f"gamescope-tagger-{appid}",
+    )
+    t.start()
+    logger.info("[gamescope_tagger] started for appid=%d", appid)
+    return stop

--- a/py_modules/unifideck/launcher/proton/infrastructure/selector.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/selector.py
@@ -223,6 +223,68 @@ def get_saved_proton_tool(store_game_id: str) -> str | None:
         return entry or None
     except (OSError, ValueError):
         return None
+def _persist_saved_proton_tool(store_game_id: str, tool: str) -> None:
+    """Mirror a live Steam Force-Compat choice into ``proton_settings.json``.
+
+    Writes the tier-2 shadow that :func:`get_saved_proton_tool` reads. Until
+    now ONLY the frontend's ``useLaunchPrep`` ever wrote it, which means a
+    game whose Proton was picked directly in Steam's own
+    Properties > Compatibility dialog — and then launched from Steam rather
+    than from Unifideck's game-details page — never got an entry at all.
+
+    Why that matters far beyond Proton selection: with Force-Compat set,
+    Steam wraps the launcher in its SteamLinuxRuntime pressure-vessel
+    container, whose Python is too old to run this code, so the launcher
+    escapes the container via ``steam-runtime-launch-client``. That escape
+    re-parents the entire process tree — launcher, umu, game and any
+    companion — out from under Steam's ``reaper``, and Steam then stops
+    recognising those windows as belonging to the app it launched: its
+    "switch window" control disappears, so a trainer running alongside the
+    game becomes unreachable. Clearing Force-Compat fixes all of that (the
+    launcher applies the tool itself), but clearing it USED TO silently
+    change the Proton version too, because this shadow was missing —
+    which made the correct fix look like a regression.
+
+    Writing the shadow here makes clearing Force-Compat safe: the same
+    Proton is still selected afterwards, just via tier 2. Deliberately does
+    NOT touch Steam's own ``config.vdf``: Steam rewrites that file from
+    memory on exit, so a launcher-side edit while Steam runs would simply
+    be discarded. Best-effort — any failure is logged and ignored, since
+    this only affects the NEXT launch, never the current one.
+    """
+    if not store_game_id or not tool:
+        return
+    import json
+    settings_path = Path(
+        "~/.local/share/unifideck/proton_settings.json",
+    ).expanduser()
+    try:
+        settings: dict = {}
+        if settings_path.is_file():
+            with settings_path.open() as f:
+                settings = json.load(f)
+        if not isinstance(settings, dict):
+            settings = {}
+        games = settings.setdefault("games", {})
+        if not isinstance(games, dict):
+            settings["games"] = games = {}
+        if games.get(store_game_id) == tool:
+            return
+        games[store_game_id] = tool
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps(settings, indent=2))
+        logger.info(
+            "[launcher.proton] mirrored steam force-compat choice %s for %s "
+            "into proton_settings.json so clearing Force-Compat keeps this "
+            "Proton", tool, store_game_id,
+        )
+    except (OSError, ValueError, TypeError) as e:
+        logger.warning(
+            "[launcher.proton] could not mirror force-compat choice for "
+            "%s: %s", store_game_id, e,
+        )
+
+
 def _read_steam_config_vdf() -> str:
     """Text of the global ``<steam>/config/config.vdf`` (cross-distro), or ""."""
     config_vdf = vdf_compat.find_steam_config_vdf()
@@ -316,6 +378,12 @@ def select_proton_version(
     if steam_tool:
         path = _resolve_logged("steam", steam_tool, tried)
         if path:
+            # Keep tier 2 in sync with the live choice, so that clearing
+            # Force-Compat (which is what stops Steam containerising the
+            # launcher, and with it the lost window switching) does not
+            # silently change the Proton version as a side effect.
+            if store_game_id:
+                _persist_saved_proton_tool(store_game_id, steam_tool)
             return path, steam_tool
     saved_tool = get_saved_proton_tool(store_game_id) if store_game_id else None
     if saved_tool:

--- a/py_modules/unifideck/rpc/mixins/download.py
+++ b/py_modules/unifideck/rpc/mixins/download.py
@@ -123,6 +123,7 @@ class DownloadRPCMixin:
         # the game's own language codes, matched exactly downstream).
         # Other stores don't send this.
         language = opts.pop("language", None)
+        download_dir: str = opts.pop("download_dir", "") or ""
 
         logger.info(
             "[download] install_game store=%s game_id=%s storage=%s "
@@ -141,6 +142,7 @@ class DownloadRPCMixin:
             is_update=False,
             language=language,
             required_bytes=required_bytes,
+            download_dir=download_dir,
         )
         return {"success": result.success, "error": result.error}
 
@@ -262,6 +264,11 @@ class DownloadRPCMixin:
         # leaves our manifest marker (a stub dir) behind. The marker proves
         # the folder is ours, so this only ever removes a dir we created.
         await asyncio.to_thread(marker_sweep.sweep_game, store, game_id)
+        if result.success:
+            shortcut_svc = getattr(self, "services", None)
+            shortcut_svc = getattr(shortcut_svc, "shortcut", None) if shortcut_svc else None
+            if shortcut_svc and hasattr(shortcut_svc, "mark_uninstalled"):
+                await shortcut_svc.mark_uninstalled(store, game_id)
         return result
 
     async def check_game_update(self, store: str, game_id: str) -> Any:

--- a/py_modules/unifideck/rpc/mixins/executable.py
+++ b/py_modules/unifideck/rpc/mixins/executable.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 # override lives in (and is read back from) the games.map row for these. Other
 # stores (Epic → legendary ``--override-exe`` from the config key) use the
 # config-override path instead.
-_DIRECT_LAUNCH_STORES = frozenset({"gog", "amazon"})
+_DIRECT_LAUNCH_STORES = frozenset({"gog", "amazon", "gamevault"})
 
 # How deep to scan the install dir for candidate executables. Config tools and
 # shipping binaries live a level or two down (``Binaries/Win64/…``); deeper than

--- a/py_modules/unifideck/services/download/models.py
+++ b/py_modules/unifideck/services/download/models.py
@@ -55,6 +55,7 @@ class DownloadItem:
     # User-picked install language (GOG multi-language games),
     # verbatim store language code. Empty = use the store default.
     language: str = ""
+    download_dir: str = ""
     progress: float = 0.0
     status: str = "queued"
     error: str = ""

--- a/py_modules/unifideck/services/download/service.py
+++ b/py_modules/unifideck/services/download/service.py
@@ -118,6 +118,7 @@ class DownloadService(_WorkerMixin):
         is_update: bool = False,
         language: str | None = None,
         required_bytes: int | None = None,
+        download_dir: str = "",
     ) -> Result:
         """Queue a new download request.
 
@@ -140,6 +141,10 @@ class DownloadService(_WorkerMixin):
         val_result = validate_path(install_path, required_bytes)
         if not val_result.success:
             return val_result
+        if download_dir and download_dir != install_path:
+            dl_result = validate_path(download_dir, required_bytes)
+            if not dl_result.success:
+                return dl_result
 
         key = f"{store}:{game_id}"
 
@@ -160,6 +165,7 @@ class DownloadService(_WorkerMixin):
                 title=title,
                 is_update=is_update,
                 language=language or "",
+                download_dir=download_dir,
                 # Ubisoft is a launcher-driven (UPC) install with no real
                 # download — mark it "manual" from enqueue so the UI shows the
                 # indeterminate "Installing in <vendor client>" state instead

--- a/py_modules/unifideck/services/download/worker.py
+++ b/py_modules/unifideck/services/download/worker.py
@@ -277,6 +277,11 @@ class _WorkerMixin:
             logger.info(
                 "[DownloadWorker] %s install language=%s", key, item.language,
             )
+        if item.store == "gamevault" and item.download_dir:
+            extra["download_dir"] = item.download_dir
+            logger.info(
+                "[DownloadWorker] %s download_dir=%s", key, item.download_dir,
+            )
         return await store.install_game(  # type: ignore[call-arg]
             item.game_id,
             item.install_path or None,

--- a/py_modules/unifideck/services/download/worker.py
+++ b/py_modules/unifideck/services/download/worker.py
@@ -528,4 +528,6 @@ class _WorkerMixin:
                 progress=item.progress,
                 speed_mbps=item.speed_mbps,
                 eta_seconds=item.eta_seconds,
+                downloaded_bytes=item.downloaded_bytes,
+                total_bytes=item.total_bytes,
             )

--- a/py_modules/unifideck/services/shortcut/launch_options.py
+++ b/py_modules/unifideck/services/shortcut/launch_options.py
@@ -21,7 +21,7 @@ import re
 # include ``.`` in the id character class but require the first
 # character to be alphanumeric (skips e.g. ``epic:.hidden`` noise).
 STORE_ID_PATTERN = re.compile(
-    r"\b(epic|gog|amazon|ubisoft|battlenet|microsoft):"
+    r"\b(epic|gog|amazon|ubisoft|battlenet|microsoft|gamevault):"
     r"([a-zA-Z0-9][a-zA-Z0-9._-]*)",
 )
 

--- a/py_modules/unifideck/stores/gamevault/__init__.py
+++ b/py_modules/unifideck/stores/gamevault/__init__.py
@@ -1,0 +1,5 @@
+"""GameVault store sub-package — public entry point."""
+
+from .store import GameVaultStore
+
+__all__ = ["GameVaultStore"]

--- a/py_modules/unifideck/stores/gamevault/auth.py
+++ b/py_modules/unifideck/stores/gamevault/auth.py
@@ -1,0 +1,223 @@
+"""GameVault authentication — JWT-based HTTP Basic flow.
+
+Persists credentials and tokens to a JSON config file on disk so
+the server_url / username / password / access_token survive restarts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import struct
+import time
+from pathlib import Path
+from typing import Any
+
+from unifideck.core.types import AuthResult, Result
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH_DEFAULT = "~/.local/share/unifideck/gamevault_config.json"
+
+
+class GameVaultAuth:
+    """JWT-based authentication for a self-hosted GameVault server.
+
+    Stores all state in a plain JSON file so tokens survive plugin
+    restarts.  The credentials (username/password) are kept so the
+    access token can be refreshed transparently.
+    """
+
+    def __init__(self, config_file: str = _CONFIG_PATH_DEFAULT) -> None:
+        self._config_path = Path(config_file).expanduser()
+        self._cfg: dict[str, Any] = {}
+        self._load_config()
+
+    # ── Persistence ────────────────────────────────────────────────
+
+    def _load_config(self) -> None:
+        try:
+            if self._config_path.exists():
+                self._cfg = json.loads(self._config_path.read_text())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[GameVaultAuth] Could not read config: %s", exc)
+            self._cfg = {}
+
+    def _save_config(self) -> None:
+        try:
+            self._config_path.parent.mkdir(parents=True, exist_ok=True)
+            self._config_path.write_text(json.dumps(self._cfg, indent=2))
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[GameVaultAuth] Could not save config: %s", exc)
+
+    def _clear_config(self) -> None:
+        self._cfg = {}
+        try:
+            if self._config_path.exists():
+                self._config_path.unlink()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[GameVaultAuth] Could not delete config: %s", exc)
+
+    # ── Token helpers ───────────────────────────────────────────────
+
+    @staticmethod
+    def _parse_jwt_expiry(token: str) -> float | None:
+        """Return POSIX expiry timestamp from a JWT, or None."""
+        try:
+            parts = token.split(".")
+            if len(parts) != 3:
+                return None
+            # Add padding so b64decode doesn't choke
+            padded = parts[1] + "=" * (-len(parts[1]) % 4)
+            import base64
+            payload = json.loads(base64.urlsafe_b64decode(padded))
+            return float(payload.get("exp", 0)) or None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _is_token_valid(self, margin_seconds: int = 60) -> bool:
+        """True if the stored access token has not expired yet."""
+        token = self._cfg.get("access_token", "")
+        if not token:
+            return False
+        expiry = self._parse_jwt_expiry(token)
+        if expiry is None:
+            return False
+        return time.time() < expiry - margin_seconds
+
+    # ── Public helpers (used by store.py) ───────────────────────────
+
+    @property
+    def server_url(self) -> str | None:
+        return self._cfg.get("server_url")
+
+    @property
+    def verify_ssl(self) -> bool:
+        return bool(self._cfg.get("verify_ssl", True))
+
+    @property
+    def download_dir(self) -> str | None:
+        return self._cfg.get("download_dir") or None
+
+    def is_authenticated(self) -> bool:
+        if not self._cfg.get("server_url"):
+            return False
+        if self._is_token_valid():
+            return True
+        # Token expired but credentials are stored — treat as connected;
+        # get_auth_headers() will refresh transparently on the next call.
+        return bool(self._cfg.get("username") and self._cfg.get("password"))
+
+    async def get_auth_headers(self) -> dict[str, str] | None:
+        """Return Bearer headers, refreshing the token if needed."""
+        if self._is_token_valid():
+            return {"Authorization": f"Bearer {self._cfg['access_token']}"}
+        if await self._refresh_token():
+            return {"Authorization": f"Bearer {self._cfg['access_token']}"}
+        return None
+
+    # ── Refresh ─────────────────────────────────────────────────────
+
+    async def _refresh_token(self) -> bool:
+        """Try to refresh using stored credentials."""
+        username = self._cfg.get("username", "")
+        password = self._cfg.get("password", "")
+        server_url = self._cfg.get("server_url", "")
+        if not all([username, password, server_url]):
+            return False
+        result = await self._do_login(server_url, username, password, self.verify_ssl)
+        return result.success
+
+    # ── Auth flow ───────────────────────────────────────────────────
+
+    async def start_auth(
+        self,
+        *,
+        server_url: str,
+        username: str,
+        password: str,
+        verify_ssl: bool = True,
+        download_dir: str | None = None,
+    ) -> AuthResult:
+        """Authenticate against the GameVault server and persist the JWT.
+
+        If *download_dir* is provided it is stored in the config file so
+        the installer can pick it up after a restart.
+        """
+        result = await self._do_login(server_url, username, password, verify_ssl)
+        if result.success:
+            update: dict[str, Any] = {
+                "server_url": server_url.rstrip("/"),
+                "username": username,
+                "password": password,
+                "verify_ssl": verify_ssl,
+            }
+            if download_dir is not None:
+                update["download_dir"] = download_dir
+            self._cfg.update(update)
+            self._save_config()
+        return result
+
+    async def _do_login(
+        self,
+        server_url: str,
+        username: str,
+        password: str,
+        verify_ssl: bool,
+    ) -> AuthResult:
+        url = f"{server_url.rstrip('/')}/api/auth/basic/login"
+        try:
+            import aiohttp  # noqa: PLC0415
+            connector = aiohttp.TCPConnector(ssl=verify_ssl)
+            async with aiohttp.ClientSession(connector=connector) as session:
+                async with session.get(
+                    url,
+                    auth=aiohttp.BasicAuth(username, password),
+                    timeout=aiohttp.ClientTimeout(total=15),
+                ) as resp:
+                    if resp.status == 401:
+                        return AuthResult(
+                            success=False,
+                            error="Invalid username or password",
+                            store="gamevault",
+                        )
+                    if resp.status != 200:
+                        return AuthResult(
+                            success=False,
+                            error=f"Server returned HTTP {resp.status}",
+                            store="gamevault",
+                        )
+                    data = await resp.json()
+        except ImportError:
+            return AuthResult(
+                success=False,
+                error="aiohttp not available — Python deps not vendored",
+                store="gamevault",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return AuthResult(
+                success=False,
+                error=str(exc),
+                store="gamevault",
+            )
+
+        token = data.get("access_token") or data.get("token", "")
+        if not token:
+            return AuthResult(
+                success=False,
+                error="Server response contained no token",
+                store="gamevault",
+            )
+        self._cfg["access_token"] = token
+        self._cfg["refresh_token"] = data.get("refresh_token", "")
+        self._cfg["token_expiry"] = self._parse_jwt_expiry(token) or 0
+        return AuthResult(
+            success=True,
+            action="authenticated",
+            tokens_cached=True,
+            store="gamevault",
+        )
+
+    async def logout(self) -> Result:
+        self._clear_config()
+        return Result(success=True, store="gamevault")

--- a/py_modules/unifideck/stores/gamevault/install.py
+++ b/py_modules/unifideck/stores/gamevault/install.py
@@ -1,0 +1,479 @@
+"""GameVault install pipeline — download archive, extract, find exe.
+
+Design note — separate download_dir / install_dir:
+    GameVault archives can be very large.  If the user wants to install
+    to an SSD with limited free space the archive download itself might
+    not fit alongside the fully-extracted game.  We therefore support a
+    *separate* temporary download directory (``download_dir``) for the
+    archive file.  After extraction the archive is deleted so only the
+    final extracted game remains in ``install_path``.
+
+    Pipeline:
+        1. HEAD  /api/games/{id}/download  → resolve filename + size
+        2. GET   /api/games/{id}/download  → stream to ``download_dir``
+        3. Detect archive format from magic bytes
+        4. Extract to ``install_path/{title}/``
+        5. Delete archive from ``download_dir``
+        6. Score .exe files, persist install marker JSON
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import struct
+import zipfile
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+import aiohttp
+
+from unifideck.core.types import InstallResult, Result
+
+logger = logging.getLogger(__name__)
+
+ProgressCallback = Callable[[dict[str, Any]], Awaitable[None]]
+
+_MARKER_DIR = Path("~/.local/share/unifideck/gamevault_installed").expanduser()
+
+_ARCH_ZIP = "zip"
+_ARCH_RAR = "rar"
+_ARCH_7Z = "7z"
+
+# Exe scoring heuristics
+_UTIL_KEYWORDS = (
+    "uninstall", "setup", "install", "redist", "vcredist",
+    "directx", "dxsetup", "ue4", "ue5", "crash", "report",
+    "_commonredist", "support", "dotnet",
+)
+_GOOD_DEPTH = 3   # prefer shallow paths
+
+
+class GameVaultInstaller:
+    """Download → extract → register GameVault games."""
+
+    def __init__(
+        self,
+        *,
+        default_install_root: str,
+        download_dir: str,
+    ) -> None:
+        self._default_install_root = Path(default_install_root).expanduser()
+        self._download_dir = Path(download_dir).expanduser()
+
+    # ── Public API ──────────────────────────────────────────────────
+
+    async def install_game(
+        self,
+        game_id: str,
+        *,
+        auth_headers: dict[str, str],
+        server_url: str,
+        verify_ssl: bool,
+        install_path: str | None,
+        progress_callback: ProgressCallback | None = None,
+        download_dir: str | None = None,
+    ) -> InstallResult:
+        """Download and extract a GameVault game."""
+        target_dir = (
+            Path(install_path).expanduser()
+            if install_path
+            else self._default_install_root
+        )
+        # Per-install override takes precedence over the configured default.
+        effective_dl_dir = Path(download_dir).expanduser() if download_dir else self._download_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+        effective_dl_dir.mkdir(parents=True, exist_ok=True)
+        _MARKER_DIR.mkdir(parents=True, exist_ok=True)
+
+        archive_path: Path | None = None
+        try:
+            # Step 1 — download archive to temp dir
+            archive_path = await self._download_archive(
+                game_id=game_id,
+                server_url=server_url,
+                auth_headers=auth_headers,
+                verify_ssl=verify_ssl,
+                progress_callback=progress_callback,
+                download_dir=effective_dl_dir,
+            )
+
+            # Step 2 — detect format and extract to target_dir/title/
+            fmt = _detect_format(archive_path)
+            if fmt is None:
+                return InstallResult(
+                    success=False,
+                    error="Unknown archive format",
+                    store="gamevault",
+                    game_id=game_id,
+                )
+
+            if progress_callback:
+                await progress_callback({"phase": "extracting"})
+
+            game_dir = target_dir / archive_path.stem
+            game_dir.mkdir(parents=True, exist_ok=True)
+
+            if fmt == _ARCH_ZIP:
+                await asyncio.to_thread(_extract_zip, archive_path, game_dir)
+            elif fmt == _ARCH_RAR:
+                await _extract_rar(archive_path, game_dir)
+            elif fmt == _ARCH_7Z:
+                await _extract_with_7z(archive_path, game_dir)
+            else:
+                return InstallResult(
+                    success=False,
+                    error=f"Unsupported archive format: {fmt}",
+                    store="gamevault",
+                    game_id=game_id,
+                )
+
+            # Step 3 — find executable
+            exe_path = _find_executable(str(game_dir))
+
+            # Step 4 — write install marker
+            title = archive_path.stem
+            _save_install_info(
+                game_id,
+                title=title,
+                install_path=str(game_dir),
+                exe_path=exe_path or "",
+            )
+
+            return InstallResult(
+                success=True,
+                store="gamevault",
+                game_id=game_id,
+                install_path=str(game_dir),
+                metadata={"exe_path": exe_path or "", "title": title},
+            )
+
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[GameVaultInstaller] install_game failed: %s", exc)
+            return InstallResult(
+                success=False,
+                error=str(exc),
+                store="gamevault",
+                game_id=game_id,
+            )
+        finally:
+            # Always remove the archive from the temp download dir
+            if archive_path and archive_path.exists():
+                try:
+                    archive_path.unlink()
+                    logger.info("[GameVaultInstaller] Removed archive %s", archive_path)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "[GameVaultInstaller] Could not delete archive %s: %s",
+                        archive_path,
+                        exc,
+                    )
+
+    async def uninstall_game(self, game_id: str) -> Result:
+        """Remove game files and install marker."""
+        info = self.get_install_info(game_id)
+        if not info:
+            return Result(
+                success=False,
+                error="Game not installed",
+                store="gamevault",
+            )
+        install_path = Path(info.get("install_path", ""))
+        if install_path.exists():
+            try:
+                await asyncio.to_thread(shutil.rmtree, str(install_path), True)
+                logger.info(
+                    "[GameVaultInstaller] Removed install dir %s", install_path
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "[GameVaultInstaller] Could not remove %s: %s", install_path, exc
+                )
+        _remove_install_info(game_id)
+        return Result(success=True, store="gamevault")
+
+    async def get_game_size(
+        self,
+        game_id: str,
+        *,
+        auth_headers: dict[str, str],
+        server_url: str,
+        verify_ssl: bool,
+    ) -> int | None:
+        """HEAD /api/games/{id}/download → Content-Length."""
+        url = f"{server_url}/api/games/{game_id}/download"
+        try:
+            connector = aiohttp.TCPConnector(ssl=verify_ssl)
+            async with aiohttp.ClientSession(connector=connector) as session:
+                async with session.head(
+                    url,
+                    headers=auth_headers,
+                    timeout=aiohttp.ClientTimeout(total=15),
+                    allow_redirects=True,
+                ) as resp:
+                    cl = resp.headers.get("Content-Length", "")
+                    if cl.isdigit():
+                        return int(cl)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[GameVaultInstaller] get_game_size error: %s", exc)
+        return None
+
+    # ── Marker helpers (called by store.py) ────────────────────────
+
+    def get_install_info(self, game_id: str) -> dict[str, Any] | None:
+        return _load_install_info(game_id)
+
+    def get_installed(self) -> dict[str, dict[str, Any]]:
+        result: dict[str, dict[str, Any]] = {}
+        if not _MARKER_DIR.exists():
+            return result
+        for f in _MARKER_DIR.glob("*.json"):
+            try:
+                data = json.loads(f.read_text())
+                gid = f.stem
+                result[gid] = data
+            except Exception:  # noqa: BLE001
+                pass
+        return result
+
+    # ── Download helper ─────────────────────────────────────────────
+
+    async def _download_archive(
+        self,
+        *,
+        game_id: str,
+        server_url: str,
+        auth_headers: dict[str, str],
+        verify_ssl: bool,
+        progress_callback: ProgressCallback | None,
+        download_dir: Path,
+    ) -> Path:
+        url = f"{server_url}/api/games/{game_id}/download"
+        connector = aiohttp.TCPConnector(ssl=verify_ssl)
+
+        async with aiohttp.ClientSession(connector=connector) as session:
+            async with session.get(
+                url,
+                headers=auth_headers,
+                timeout=aiohttp.ClientTimeout(total=0),  # no overall timeout
+                allow_redirects=True,
+            ) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(
+                        f"Download returned HTTP {resp.status}"
+                    )
+
+                # Resolve filename from Content-Disposition header
+                cd = resp.headers.get("Content-Disposition", "")
+                filename = _parse_filename_from_cd(cd) or f"gamevault_{game_id}.bin"
+                archive_path = download_dir / filename
+
+                # Content-Length may be absent for chunked transfers; fall back to 0
+                # which yields pct=0 instead of crashing.
+                total = int(resp.headers.get("Content-Length") or resp.content_length or 0)
+                downloaded = 0
+                last_report = 0.0
+                import time
+
+                with archive_path.open("wb") as fh:
+                    async for chunk in resp.content.iter_chunked(1024 * 1024):
+                        fh.write(chunk)
+                        downloaded += len(chunk)
+                        now = time.monotonic()
+                        if progress_callback and now - last_report >= 1.0:
+                            pct = (downloaded / total * 100) if total else 0
+                            await progress_callback(
+                                {
+                                    "phase": "downloading",
+                                    "percentage": round(pct, 1),
+                                    "downloaded_bytes": downloaded,
+                                    "total_bytes": total,
+                                }
+                            )
+                            last_report = now
+
+        logger.info(
+            "[GameVaultInstaller] Downloaded %s (%d bytes) to %s",
+            filename,
+            downloaded,
+            download_dir,
+        )
+        return archive_path
+
+
+# ── Archive detection & extraction ─────────────────────────────────────────
+
+def _detect_format(path: Path) -> str | None:
+    """Detect archive format from magic bytes."""
+    try:
+        with path.open("rb") as fh:
+            header = fh.read(8)
+    except Exception:
+        return None
+
+    if header[:2] == b"PK":
+        return _ARCH_ZIP
+    if header[:3] == b"Rar":
+        return _ARCH_RAR
+    if header[:6] == b"7z\xbc\xaf'\x1c":
+        return _ARCH_7Z
+    # 7z stored inside SFX: scan first 512 KB
+    try:
+        with path.open("rb") as fh:
+            chunk = fh.read(512 * 1024)
+        sig = b"7z\xbc\xaf'\x1c"
+        if sig in chunk:
+            return _ARCH_7Z
+    except Exception:
+        pass
+    return None
+
+
+def _extract_zip(archive: Path, dest: Path) -> None:
+    with zipfile.ZipFile(archive, "r") as zf:
+        zf.extractall(str(dest))
+
+
+async def _extract_rar(archive: Path, dest: Path) -> None:
+    """Try bsdtar → unrar → 7z for RAR extraction."""
+    for tool in ("bsdtar", "unrar", "7z"):
+        if shutil.which(tool):
+            if tool == "bsdtar":
+                cmd = ["bsdtar", "-xf", str(archive), "-C", str(dest)]
+            elif tool == "unrar":
+                cmd = ["unrar", "x", "-y", str(archive), str(dest) + "/"]
+            else:
+                cmd = ["7z", "x", str(archive), f"-o{dest}", "-y"]
+
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode == 0:
+                return
+            logger.warning(
+                "[GameVaultInstaller] %s failed: %s",
+                tool,
+                stderr.decode(errors="replace")[:200],
+            )
+
+    raise RuntimeError("No RAR extraction tool available (bsdtar/unrar/7z)")
+
+
+async def _extract_with_7z(archive: Path, dest: Path) -> None:
+    if not shutil.which("7z"):
+        raise RuntimeError("7z binary not found")
+    cmd = ["7z", "x", str(archive), f"-o{dest}", "-y"]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"7z extraction failed: {stderr.decode(errors='replace')[:200]}"
+        )
+
+
+# ── Exe finder ──────────────────────────────────────────────────────────────
+
+def _find_executable(install_dir: str) -> str | None:
+    """Score .exe candidates and return the best match."""
+    candidates: list[tuple[float, str]] = []
+
+    for dirpath, _dirs, files in os.walk(install_dir):
+        depth = len(Path(dirpath).relative_to(install_dir).parts)
+        for fname in files:
+            if not fname.lower().endswith(".exe"):
+                continue
+            lower = fname.lower()
+            # Penalise utility executables
+            if any(k in lower for k in _UTIL_KEYWORDS):
+                continue
+            full = os.path.join(dirpath, fname)
+            # Score: prefer shallow + larger file
+            size = 0
+            try:
+                size = os.path.getsize(full)
+            except OSError:
+                pass
+            depth_score = max(0, _GOOD_DEPTH - depth)
+            size_score = min(size / (100 * 1024 * 1024), 5.0)  # cap at 5 pts
+            score = depth_score + size_score
+            candidates.append((score, full))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    return candidates[0][1]
+
+
+# ── Install marker helpers ───────────────────────────────────────────────────
+
+def _marker_path(game_id: str) -> Path:
+    return _MARKER_DIR / f"{game_id}.json"
+
+
+def _save_install_info(
+    game_id: str,
+    *,
+    title: str,
+    install_path: str,
+    exe_path: str,
+) -> None:
+    try:
+        _MARKER_DIR.mkdir(parents=True, exist_ok=True)
+        _marker_path(game_id).write_text(
+            json.dumps(
+                {
+                    "game_id": game_id,
+                    "title": title,
+                    "install_path": install_path,
+                    "exe_path": exe_path,
+                },
+                indent=2,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[GameVaultInstaller] Could not save marker: %s", exc)
+
+
+def _load_install_info(game_id: str) -> dict[str, Any] | None:
+    p = _marker_path(game_id)
+    try:
+        if p.exists():
+            return json.loads(p.read_text())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[GameVaultInstaller] Could not read marker: %s", exc)
+    return None
+
+
+def _remove_install_info(game_id: str) -> None:
+    p = _marker_path(game_id)
+    try:
+        if p.exists():
+            p.unlink()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[GameVaultInstaller] Could not remove marker: %s", exc)
+
+
+# ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+def _parse_filename_from_cd(content_disposition: str) -> str | None:
+    """Extract filename from Content-Disposition header."""
+    import re
+
+    m = re.search(r'filename\*?=["\']?([^"\';\r\n]+)["\']?', content_disposition)
+    if m:
+        name = m.group(1).strip()
+        # Strip RFC 5987 charset prefix, e.g. "UTF-8''Filename.zip"
+        if "''" in name:
+            name = name.split("''", 1)[1]
+        return name.strip('"\'')
+    return None

--- a/py_modules/unifideck/stores/gamevault/install.py
+++ b/py_modules/unifideck/stores/gamevault/install.py
@@ -278,6 +278,7 @@ class GameVaultInstaller:
                 last_report = 0.0
                 import time
 
+                start_time = time.monotonic()
                 with archive_path.open("wb") as fh:
                     async for chunk in resp.content.iter_chunked(1024 * 1024):
                         fh.write(chunk)
@@ -285,12 +286,18 @@ class GameVaultInstaller:
                         now = time.monotonic()
                         if progress_callback and now - last_report >= 1.0:
                             pct = (downloaded / total * 100) if total else 0
+                            elapsed = now - start_time
+                            speed_bps = downloaded / elapsed if elapsed > 0 else 0
+                            remaining = total - downloaded
+                            eta = int(remaining / speed_bps) if speed_bps > 0 and total > 0 else 0
                             await progress_callback(
                                 {
                                     "phase": "downloading",
                                     "percentage": round(pct, 1),
                                     "downloaded_bytes": downloaded,
                                     "total_bytes": total,
+                                    "speed_bps": speed_bps,
+                                    "eta_seconds": eta,
                                 }
                             )
                             last_report = now

--- a/py_modules/unifideck/stores/gamevault/library.py
+++ b/py_modules/unifideck/stores/gamevault/library.py
@@ -1,0 +1,223 @@
+"""GameVault library reader — fetches paginated game list from the server."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from unifideck.core.types import Game
+
+if TYPE_CHECKING:
+    from .install import GameVaultInstaller
+
+logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 500          # fetch 500 per page (nestjs-paginate allows unlimited)
+_MAX_GAMES = 5_000        # sanity cap — no home server has >5000 games
+
+
+class GameVaultLibraryReader:
+    """Reads the game list from a self-hosted GameVault server."""
+
+    def __init__(self, installer: "GameVaultInstaller") -> None:
+        self._installer = installer
+
+    # ── Public API ──────────────────────────────────────────────────
+
+    async def get_library(
+        self,
+        server_url: str,
+        auth_headers: dict[str, str],
+        verify_ssl: bool,
+        *,
+        force: bool = False,
+    ) -> list[Game]:
+        raw_games = await self._fetch_all_pages(server_url, auth_headers, verify_ssl)
+        games: list[Game] = []
+        for item in raw_games:
+            game = self._map_to_game(item)
+            if game:
+                install_info = self._installer.get_install_info(game.store_game_id)
+                if install_info:
+                    game.installed = True
+                    game.install_path = install_info.get("install_path")
+                    game.exe_path = install_info.get("exe_path")
+                games.append(game)
+        logger.info("[GameVaultLibrary] %d game(s) fetched", len(games))
+        return games
+
+    # ── Internal helpers ────────────────────────────────────────────
+
+    async def _fetch_all_pages(
+        self,
+        server_url: str,
+        auth_headers: dict[str, str],
+        verify_ssl: bool,
+    ) -> list[dict[str, Any]]:
+        all_items: list[dict[str, Any]] = []
+        offset = 0
+        total_pages: int | None = None
+
+        import aiohttp  # noqa: PLC0415 — lazy import, aiohttp vendored
+        connector = aiohttp.TCPConnector(ssl=verify_ssl)
+        async with aiohttp.ClientSession(connector=connector) as session:
+            while True:
+                url = (
+                    f"{server_url}/api/games"
+                    f"?limit={_PAGE_SIZE}&offset={offset}"
+                )
+                try:
+                    async with session.get(
+                        url,
+                        headers=auth_headers,
+                        timeout=aiohttp.ClientTimeout(total=60),
+                    ) as resp:
+                        if resp.status != 200:
+                            logger.warning(
+                                "[GameVaultLibrary] HTTP %s on page offset=%d",
+                                resp.status,
+                                offset,
+                            )
+                            break
+                        data = await resp.json()
+                except Exception as exc:  # noqa: BLE001
+                    logger.error("[GameVaultLibrary] Fetch error: %s", exc)
+                    break
+
+                # nestjs-paginate returns { data: [...], meta: { totalItems, totalPages, ... } }
+                # Fall back to plain list for older API versions.
+                if isinstance(data, list):
+                    page = data
+                else:
+                    # Extract pagination metadata on first page
+                    if total_pages is None and isinstance(data, dict):
+                        meta = data.get("meta", {})
+                        total_items = meta.get("totalItems", 0)
+                        if total_items > _MAX_GAMES:
+                            logger.error(
+                                "[GameVaultLibrary] Server reports %d total games "
+                                "(max allowed: %d). Check your server_url — "
+                                "you may be pointing at a public demo server.",
+                                total_items,
+                                _MAX_GAMES,
+                            )
+                            break
+                        total_pages = meta.get("totalPages")
+
+                    page = data.get("data", data.get("results", []))
+
+                if not page:
+                    break
+
+                all_items.extend(page)
+
+                # Stop if we've hit the sanity cap
+                if len(all_items) >= _MAX_GAMES:
+                    logger.warning(
+                        "[GameVaultLibrary] Hit max-games cap (%d); stopping pagination.",
+                        _MAX_GAMES,
+                    )
+                    break
+
+                # Stop if nestjs-paginate told us the total page count
+                if total_pages is not None:
+                    current_page = offset // _PAGE_SIZE + 1
+                    if current_page >= total_pages:
+                        break
+                elif len(page) < _PAGE_SIZE:
+                    # Fallback: last page is smaller than requested
+                    break
+
+                offset += _PAGE_SIZE
+
+        return all_items
+
+    def _map_to_game(self, item: dict[str, Any]) -> Game | None:
+        """Convert a raw API game dict to a unified ``Game`` record."""
+        try:
+            gv_id = str(item.get("id", ""))
+            if not gv_id:
+                return None
+
+            title = self._extract_title(item)
+            icon_url = self._extract_cover_url(item)
+
+            return Game(
+                app_id=0,               # filled later by sync service
+                store="gamevault",
+                store_game_id=gv_id,
+                title=title,
+                installed=False,        # overridden by get_library()
+                icon_url=icon_url,
+                metadata={
+                    "file_path": item.get("file_path", ""),
+                    "release_date": item.get("release_date", ""),
+                    "early_access": item.get("early_access", False),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[GameVaultLibrary] map_to_game error: %s", exc)
+            return None
+
+    @staticmethod
+    def _extract_title(item: dict[str, Any]) -> str:
+        """Prefer IGDB/metadata title, then parse from file_path."""
+        # New API: metadata.title → boxart.title → file_path parsing
+        metadata = item.get("metadata") or {}
+        if isinstance(metadata, dict):
+            title = metadata.get("title") or metadata.get("name", "")
+            if title:
+                return title
+
+        # Legacy / fallback: derive from file path
+        file_path = item.get("file_path") or item.get("path", "")
+        if file_path:
+            return _parse_title_from_filename(file_path)
+
+        return f"GameVault Game #{item.get('id', '?')}"
+
+    @staticmethod
+    def _extract_cover_url(item: dict[str, Any]) -> str | None:
+        """Try several known cover fields."""
+        for field in ("cover_image", "cover", "thumbnail"):
+            val = item.get(field)
+            if val and isinstance(val, str):
+                return val
+        # Structured boxart
+        boxart = item.get("boxart") or item.get("metadata", {}) or {}
+        if isinstance(boxart, dict):
+            for field in ("url", "background_url", "cover_url"):
+                val = boxart.get(field)
+                if val and isinstance(val, str):
+                    return val
+        return None
+
+
+# ── Standalone utility ──────────────────────────────────────────────────────
+
+def _parse_title_from_filename(file_path: str) -> str:
+    """Derive a human-readable title from a GameVault archive filename.
+
+    GameVault filenames follow a loose convention:
+        ``Title Name (YEAR).ext``  or  ``Title Name.ext``
+
+    1. Strip directory prefix.
+    2. Strip the extension and everything after a ``(YEAR)`` token.
+    3. Replace separators with spaces, strip leading/trailing whitespace.
+    """
+    import os
+
+    name = os.path.basename(file_path)
+    # Strip extension
+    for ext in (".exe", ".zip", ".rar", ".7z", ".tar.gz", ".tar.bz2"):
+        if name.lower().endswith(ext):
+            name = name[: -len(ext)]
+            break
+    # Remove trailing (YEAR) / [YEAR]
+    name = re.sub(r"[\(\[]\d{4}[\)\]].*$", "", name).strip()
+    # Replace underscores/dashes used as word separators
+    name = re.sub(r"[_\-]+", " ", name).strip()
+    # Collapse multiple spaces
+    name = re.sub(r"\s{2,}", " ", name)
+    return name or file_path

--- a/py_modules/unifideck/stores/gamevault/store.py
+++ b/py_modules/unifideck/stores/gamevault/store.py
@@ -1,0 +1,202 @@
+"""GameVault store — Layer-4 ``StoreBase`` implementation.
+
+``GameVaultStore`` is the orchestration class that wires:
+
+* :class:`GameVaultAuth`           (OP-GV-a) — JWT-based HTTP Basic auth.
+* :class:`GameVaultLibraryReader`  (OP-GV-b) — paginated game list.
+* :class:`GameVaultInstaller`      (OP-GV-c) — download / extract pipeline.
+
+GameVault is a self-hosted game server; all network calls go to the
+server URL stored in the on-disk config file.
+
+Config section (``defaults/config.json`` → ``stores.gamevault``):
+    config_file:          path to the persisted credentials/token JSON
+    default_install_root: default directory for extracted games
+    download_dir:         *separate* temp directory for archive downloads
+                          (archive is deleted after successful extraction)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from unifideck.core.types import (
+    AuthResult,
+    Game,
+    InstallResult,
+    Result,
+    StoreInfo,
+)
+from unifideck.stores.shared.store_base import StoreBase
+
+from .auth import GameVaultAuth
+from .install import GameVaultInstaller, ProgressCallback
+from .library import GameVaultLibraryReader
+
+if TYPE_CHECKING:
+    from unifideck.config import ConfigManager
+    from unifideck.core.cache_manager import CacheManager
+    from unifideck.event_bus.event_bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONFIG_FILE = "~/.local/share/unifideck/gamevault_config.json"
+_DEFAULT_INSTALL_ROOT = "~/Games/GameVault"
+_DEFAULT_DOWNLOAD_DIR = "~/.local/share/unifideck/gamevault_downloads"
+
+
+class GameVaultStore(StoreBase):
+    """GameVault self-hosted game server connector."""
+
+    # GameVault serves large libraries over HTTP — needs more headroom than the default 120s.
+    sync_timeout = 300
+
+    store_info = StoreInfo(
+        name="gamevault",
+        display_name="GameVault",
+        auth_method="manual",
+        icon_asset="gamevault.png",
+        uses_wine=False,
+        supports_install=True,
+        supports_cloud_saves=False,
+    )
+
+    def __init__(
+        self,
+        bus: "EventBus",
+        cache: "CacheManager",
+        plugin_dir: str | None = None,
+        config: "ConfigManager | None" = None,
+    ) -> None:
+        """Initialise the GameVault store connector."""
+        super().__init__(bus, cache, plugin_dir, config)
+
+        gv_cfg = (config.get("stores.gamevault") if config else None) or {}
+
+        config_file = gv_cfg.get("config_file", _DEFAULT_CONFIG_FILE)
+        default_install_root = gv_cfg.get("default_install_root", _DEFAULT_INSTALL_ROOT)
+        download_dir = gv_cfg.get("download_dir", _DEFAULT_DOWNLOAD_DIR)
+
+        self._auth = GameVaultAuth(config_file=config_file)
+        self._installer = GameVaultInstaller(
+            default_install_root=default_install_root,
+            download_dir=download_dir,
+        )
+        self._library_reader = GameVaultLibraryReader(installer=self._installer)
+
+    # ── StoreBase abstract methods ──────────────────────────────────
+
+    async def is_available(self) -> bool:
+        """True when credentials are stored (server reachability checked lazily at sync time)."""
+        return self._auth.is_authenticated()
+
+    async def start_auth(self, **kwargs: Any) -> AuthResult:
+        """Authenticate with ``server_url``, ``username``, ``password``,
+        ``verify_ssl``, and optionally ``download_dir``."""
+        return await self._auth.start_auth(
+            server_url=kwargs.get("server_url", ""),
+            username=kwargs.get("username", ""),
+            password=kwargs.get("password", ""),
+            verify_ssl=kwargs.get("verify_ssl", True),
+            download_dir=kwargs.get("download_dir") or None,
+        )
+
+    async def complete_auth(self, **kwargs: Any) -> AuthResult:
+        """GameVault uses a single-step auth; returns cached auth state."""
+        if self._auth.is_authenticated():
+            return AuthResult(
+                success=True,
+                action="authenticated",
+                tokens_cached=True,
+                store="gamevault",
+            )
+        return AuthResult(
+            success=False,
+            error="Not authenticated — call start_auth first",
+            store="gamevault",
+        )
+
+    async def logout(self) -> Result:
+        return await self._auth.logout()
+
+    async def get_library(self, *, force: bool = False) -> list[Game] | None:
+        headers = await self._auth.get_auth_headers()
+        if not headers:
+            logger.warning("[GameVaultStore] Not authenticated, library unavailable")
+            return None
+        server_url = self._auth.server_url or ""
+        try:
+            return await self._library_reader.get_library(
+                server_url=server_url,
+                auth_headers=headers,
+                verify_ssl=self._auth.verify_ssl,
+                force=force,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[GameVaultStore] get_library failed: %s", exc)
+            return None
+
+    async def install_game(
+        self,
+        game_id: str,
+        base_path: str | None = None,
+        progress_cb: ProgressCallback | None = None,
+        **kwargs: Any,
+    ) -> InstallResult:
+        headers = await self._auth.get_auth_headers()
+        if not headers:
+            return InstallResult(
+                success=False,
+                error="Not authenticated",
+                store="gamevault",
+                game_id=game_id,
+            )
+        install_path: str | None = base_path or kwargs.get("install_path")
+        progress_callback: ProgressCallback | None = progress_cb or kwargs.get("progress_callback")
+        # per-install override → saved credential setting → installer default
+        download_dir: str | None = kwargs.get("download_dir") or self._auth.download_dir or None
+        server_url = self._auth.server_url or ""
+
+        return await self._installer.install_game(
+            game_id,
+            auth_headers=headers,
+            server_url=server_url,
+            verify_ssl=self._auth.verify_ssl,
+            install_path=install_path,
+            progress_callback=progress_callback,
+            download_dir=download_dir,
+        )
+
+    async def uninstall_game(self, game_id: str, **kwargs: Any) -> Result:
+        return await self._installer.uninstall_game(game_id)
+
+    async def update_game(self, game_id: str, **kwargs: Any) -> InstallResult:
+        """Re-download the game (GameVault has no delta updates)."""
+        return await self.install_game(game_id, **kwargs)
+
+    async def check_for_updates(self) -> list[str]:
+        """GameVault does not expose a server-side update API."""
+        return []
+
+    async def get_game_size(self, game_id: str) -> int | None:
+        headers = await self._auth.get_auth_headers()
+        if not headers:
+            return None
+        server_url = self._auth.server_url or ""
+        return await self._installer.get_game_size(
+            game_id,
+            auth_headers=headers,
+            server_url=server_url,
+            verify_ssl=self._auth.verify_ssl,
+        )
+
+    # ── Extra helpers called by main.py (backward-compat surface) ──
+
+    def _get_install_info(self, game_id: str) -> dict[str, Any] | None:
+        """Return the persisted install marker dict for *game_id*."""
+        return self._installer.get_install_info(game_id)
+
+    async def get_installed(self) -> dict[str, dict[str, Any]]:
+        """Return {game_id: install_info} for all installed GameVault games."""
+        return self._installer.get_installed()

--- a/py_modules/unifideck/stores/shared/store_registry.py
+++ b/py_modules/unifideck/stores/shared/store_registry.py
@@ -314,9 +314,15 @@ class StoreRegistry:
             return Result(success=False, error=str(e))
         try:
             if action == "start":
-                return await store.start_auth(**kwargs)
+                result = await store.start_auth(**kwargs)
+                if result.success:
+                    store._cached_available = True
+                return result
             if action == "complete":
-                return await store.complete_auth(**kwargs)
+                result = await store.complete_auth(**kwargs)
+                if result.success:
+                    store._cached_available = True
+                return result
             if action == "logout":
                 result = await store.logout()
                 if result.success:

--- a/scripts/validate_event_schemas.py
+++ b/scripts/validate_event_schemas.py
@@ -88,7 +88,7 @@ CANONICAL_SCHEMA: dict[str, set[str]] = {
     "DOWNLOAD_CANCELLED":           {"item"},
     "DOWNLOAD_COMPLETE":            {"game", "game_id", "install_path", "item", "store"},
     "DOWNLOAD_FAILED":              {"error", "error_type", "game_id", "item", "store"},
-    "DOWNLOAD_PROGRESS":            {"eta_seconds", "game_id", "progress", "speed_mbps", "store"},
+    "DOWNLOAD_PROGRESS":            {"downloaded_bytes", "eta_seconds", "game_id", "progress", "speed_mbps", "store", "total_bytes"},
     "DOWNLOAD_QUEUED":              {"item"},
     "DOWNLOAD_STARTED":             {"game_id", "item", "store"},
     "GAME_INSTALLED":               {"executable", "game_id", "install_path", "store", "title"},

--- a/src/components/modals/GameVaultCredentialsModal.tsx
+++ b/src/components/modals/GameVaultCredentialsModal.tsx
@@ -1,0 +1,177 @@
+/**
+ * GameVaultCredentialsModal — connection form for a self-hosted
+ * GameVault server.
+ *
+ * Fields:
+ *  serverUrl   — HTTP(S) URL of the GameVault server
+ *  username    — GameVault account username
+ *  password    — GameVault account password
+ *  verifySsl   — toggle to skip TLS certificate validation
+ *                (useful for self-signed certs on LAN servers)
+ *  downloadDir — *separate* temporary directory for archive
+ *                downloads.  The game archive is placed here
+ *                while downloading, then extracted to the final
+ *                install location and deleted.  Keeping this on
+ *                a different drive/partition lets users install
+ *                to an SSD that doesn't have enough space for
+ *                both the archive AND the extracted game at the
+ *                same time.
+ */
+import { FC, useState } from "react";
+import { ConfirmModal, TextField, ToggleField, DialogButton } from "@decky/ui";
+import { openFilePicker, FileSelectionType } from "@decky/api";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  closeModal?: () => void;
+  onConnect: (
+    serverUrl: string,
+    username: string,
+    password: string,
+    verifySsl: boolean,
+    downloadDir: string,
+  ) => Promise<void>;
+  /** Pre-fill values (e.g. when re-opening an already-configured connection) */
+  initialServerUrl?: string;
+  initialUsername?: string;
+  initialDownloadDir?: string;
+  initialVerifySsl?: boolean;
+}
+
+export const GameVaultCredentialsModal: FC<Props> = ({
+  closeModal,
+  onConnect,
+  initialServerUrl = "http://",
+  initialUsername = "",
+  initialDownloadDir = "",
+  initialVerifySsl = true,
+}) => {
+  const { t } = useTranslation();
+
+  const [serverUrl, setServerUrl] = useState(initialServerUrl);
+  const [username, setUsername] = useState(initialUsername);
+  const [password, setPassword] = useState("");
+  const [verifySsl, setVerifySsl] = useState(initialVerifySsl);
+  const [downloadDir, setDownloadDir] = useState(initialDownloadDir);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const pickDownloadDir = async () => {
+    try {
+      const res = await openFilePicker(
+        FileSelectionType.FOLDER,
+        downloadDir || "/home/deck",
+        false,
+        true,
+      );
+      const picked = res?.realpath || res?.path;
+      if (picked) setDownloadDir(picked);
+    } catch {
+      // user cancelled
+    }
+  };
+
+  const handleConnect = async () => {
+    if (!serverUrl || serverUrl === "http://" || serverUrl === "https://") {
+      setError(t("gamevault.errorServerUrlRequired"));
+      return;
+    }
+    if (!username) {
+      setError(t("gamevault.errorUsernameRequired"));
+      return;
+    }
+    if (!password) {
+      setError(t("gamevault.errorPasswordRequired"));
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+    try {
+      await onConnect(serverUrl, username, password, verifySsl, downloadDir);
+      closeModal?.();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg || t("gamevault.errorConnection"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ConfirmModal
+      strTitle={t("gamevault.connectTitle")}
+      strOKButtonText={
+        loading ? t("gamevault.connecting") : t("gamevault.connect")
+      }
+      strCancelButtonText={t("gamevault.cancel")}
+      bOKDisabled={loading}
+      onOK={handleConnect}
+      onCancel={closeModal}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        {/* ── Server URL ───────────────────────────────────────── */}
+        <TextField
+          label={t("gamevault.serverUrl")}
+          value={serverUrl}
+          onChange={(e) => setServerUrl(e.target.value)}
+        />
+
+        {/* ── Credentials ──────────────────────────────────────── */}
+        <TextField
+          label={t("gamevault.username")}
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+
+        <TextField
+          label={t("gamevault.password")}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          bIsPassword
+        />
+
+        {/* ── TLS toggle ───────────────────────────────────────── */}
+        <ToggleField
+          label={t("gamevault.verifySsl")}
+          description={t("gamevault.verifySslDescription")}
+          checked={verifySsl}
+          onChange={setVerifySsl}
+        />
+
+        {/* ── Temp download directory ──────────────────────────── */}
+        <div style={{ display: "flex", gap: 8, alignItems: "flex-end" }}>
+          <div style={{ flex: 1 }}>
+            <TextField
+              label={t("gamevault.downloadDir")}
+              description={`${t("gamevault.downloadDirDescription")} (${t("gamevault.downloadDirPlaceholder")})`}
+              value={downloadDir}
+              onChange={(e) => setDownloadDir(e.target.value)}
+            />
+          </div>
+          <DialogButton
+            onClick={() => void pickDownloadDir()}
+            style={{ minWidth: 48, width: 48, height: 40, padding: 0, flexShrink: 0 }}
+          >
+            📁
+          </DialogButton>
+        </div>
+
+        {/* ── Error banner ─────────────────────────────────────── */}
+        {error && (
+          <div
+            style={{
+              color: "#ef4444",
+              fontSize: "12px",
+              padding: "4px 0",
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </div>
+    </ConfirmModal>
+  );
+};
+
+export default GameVaultCredentialsModal;

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -20,6 +20,7 @@ export { SteamRestartModal } from "./SteamRestartModal";
 export { UninstallConfirmModal } from "./UninstallConfirmModal";
 export { CloudSaveConflictModal } from "./CloudSaveConflictModal";
 export { LanguageSelectModal } from "./LanguageSelectModal";
+export { GameVaultCredentialsModal } from "./GameVaultCredentialsModal";
 export { ForceSyncModal } from "./ForceSyncModal";
 export { ChromiumInstallModal } from "./ChromiumInstallModal";
 export { PickStorageModal, pickStorageForInstall } from "./PickStorageModal";

--- a/src/components/play/DownloadingButtons.tsx
+++ b/src/components/play/DownloadingButtons.tsx
@@ -82,7 +82,8 @@ export const DownloadingButtons: FC<Props> = ({
         {cancelled
           ? t("play.cancelling")
           : download.download_phase === "manual" ||
-            download.download_phase === "preparing"
+            download.download_phase === "preparing" ||
+            download.download_phase === "extracting"
           ? t("play.cancel")
           : `${t("play.cancel")} (${Math.round(
               Math.max(0, Math.min(100, download.progress_percent)),

--- a/src/components/shared/StoreIcon.tsx
+++ b/src/components/shared/StoreIcon.tsx
@@ -25,6 +25,7 @@ const STORE_ICONS: Record<StoreId, IconType> = {
   microsoft: FaXbox,
   ubisoft: SiUbisoft,
   battlenet: SiBattledotnet,
+  gamevault: FaGamepad,
 };
 
 interface Props {

--- a/src/contexts/DownloadContext.tsx
+++ b/src/contexts/DownloadContext.tsx
@@ -31,7 +31,7 @@ interface DownloadContextValue {
   installGame: (
     store: StoreId,
     gameId: string,
-    options?: { storage?: string; language?: string; title?: string },
+    options?: { storage?: string; language?: string; title?: string; download_dir?: string },
   ) => Promise<Result | null>;
   uninstallGame: (
     appId: number,
@@ -62,7 +62,7 @@ export const DownloadProvider: FC<{ children: ReactNode }> = ({ children }) => {
     [
       StoreId,
       string,
-      { storage?: string; language?: string; title?: string } | undefined,
+      { storage?: string; language?: string; title?: string; download_dir?: string } | undefined,
     ],
     Result
   >(rpcRoutes.installGame);
@@ -85,7 +85,7 @@ export const DownloadProvider: FC<{ children: ReactNode }> = ({ children }) => {
     (
       store: StoreId,
       gameId: string,
-      options?: { storage?: string; language?: string; title?: string },
+      options?: { storage?: string; language?: string; title?: string; download_dir?: string },
     ) => installMut.mutate(store, gameId, options),
     [installMut],
   );

--- a/src/hooks/useGameActions.ts
+++ b/src/hooks/useGameActions.ts
@@ -37,7 +37,7 @@ export interface UseGameActionsResult {
   install: (
     store: StoreId,
     gameId: string,
-    options?: { storage?: string; language?: string; title?: string },
+    options?: { storage?: string; language?: string; title?: string; download_dir?: string },
   ) => Promise<Result | null>;
   uninstall: (appId: number, deletePrefix?: boolean) => Promise<Result | null>;
   cancel: (downloadId: string) => Promise<Result | null>;
@@ -70,7 +70,7 @@ export function useGameActions(bridge: SteamBridgeShape): UseGameActionsResult {
     async (
       store: StoreId,
       gameId: string,
-      options?: { storage?: string; language?: string; title?: string },
+      options?: { storage?: string; language?: string; title?: string; download_dir?: string },
     ) => {
       setWorking(true);
       try {

--- a/src/hooks/useInstallFlow.tsx
+++ b/src/hooks/useInstallFlow.tsx
@@ -120,6 +120,14 @@ export function useInstallFlow(bridge: SteamBridgeShape): UseInstallFlowResult {
           customPath ?? "none",
         );
 
+        if (game.store === "gamevault") {
+          return await actions.install(game.store, game.store_game_id, {
+            storage,
+            title: game.title,
+            download_dir: "",
+          });
+        }
+
         const fetchLangs = LANGUAGE_STORES[game.store];
         if (!fetchLangs) {
           console.log(

--- a/src/hooks/useStoreAuth.tsx
+++ b/src/hooks/useStoreAuth.tsx
@@ -15,6 +15,7 @@
  *  - `busy`        : true when an auth call is in flight
  */
 import { useCallback, useState } from "react";
+import { call } from "@decky/api";
 import { showModal } from "@decky/ui";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../contexts/AuthContext";
@@ -22,6 +23,9 @@ import { useStores } from "../contexts/StoreContext";
 import { useToast } from "./useToast";
 import { AuthDispatcher } from "../services/auth/AuthDispatcher";
 import { ChromiumInstallModal } from "../components/modals/ChromiumInstallModal";
+import { GameVaultCredentialsModal } from "../components/modals/GameVaultCredentialsModal";
+import { rpcRoutes } from "../api/rpc-routes";
+import { unwrapRpcEnvelope } from "../api/useRPC";
 import type { AuthResult, StoreId } from "../types/api";
 
 /**
@@ -71,6 +75,52 @@ export function useStoreAuth(store: StoreId): UseStoreAuthResult {
   const status = auth.statuses[store];
 
   const connect = useCallback(async (): Promise<AuthResult | null> => {
+    // GameVault uses a credential form instead of a browser/shortcut flow.
+    if (store === "gamevault") {
+      return new Promise<AuthResult | null>((resolve) => {
+        showModal(
+          <GameVaultCredentialsModal
+            closeModal={() => resolve(null)}
+            onConnect={async (serverUrl, username, password, verifySsl, downloadDir) => {
+              setBusy(true);
+              try {
+                const raw = await call<
+                  [string, string, Record<string, unknown>],
+                  unknown
+                >(rpcRoutes.storeAuth, "gamevault", "start", {
+                  server_url: serverUrl,
+                  username,
+                  password,
+                  verify_ssl: verifySsl,
+                  download_dir: downloadDir || null,
+                });
+                const result = unwrapRpcEnvelope<AuthResult>(raw, {
+                  route: rpcRoutes.storeAuth,
+                  throwing: false,
+                });
+                if (result?.success) {
+                  auth.notifyConnected(store);
+                  toast.success(t("gamevault.connectTitle") + " ✓");
+                  resolve({ success: true, store });
+                } else {
+                  resolve({
+                    success: false,
+                    store,
+                    error: result?.error ?? "connection_failed",
+                  });
+                }
+              } catch (e) {
+                const message = e instanceof Error ? e.message : String(e);
+                resolve({ success: false, store, error: message });
+              } finally {
+                setBusy(false);
+              }
+            }}
+          />,
+        );
+      });
+    }
+
     setBusy(true);
     try {
       toast.info(`Starting ${store} sign-in…`);

--- a/src/i18n/locales/ar-SA.json
+++ b/src/i18n/locales/ar-SA.json
@@ -1045,5 +1045,23 @@
     "title": "مجموعات STEAM",
     "enabled": "تم تمكين المجموعات",
     "disabled": "تم تعطيل المجموعات"
+  },
+  "gamevault": {
+    "connectTitle": "الاتصال بـ GameVault",
+    "connect": "اتصال",
+    "connecting": "جارٍ الاتصال…",
+    "cancel": "إلغاء",
+    "serverUrl": "رابط الخادم",
+    "username": "اسم المستخدم",
+    "password": "كلمة المرور",
+    "verifySsl": "التحقق من شهادة SSL",
+    "verifySslDescription": "تعطيل للشهادات الموقعة ذاتياً",
+    "downloadDir": "مجلد تنزيل الأرشيف",
+    "downloadDirDescription": "مجلد مؤقت لتنزيلات الأرشيف. اتركه فارغاً للافتراضي.",
+    "downloadDirPlaceholder": "الافتراضي: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "الرجاء إدخال رابط الخادم",
+    "errorUsernameRequired": "الرجاء إدخال اسم المستخدم",
+    "errorPasswordRequired": "الرجاء إدخال كلمة المرور",
+    "errorConnection": "فشل الاتصال بخادم GameVault"
   }
 }

--- a/src/i18n/locales/de-DE.json
+++ b/src/i18n/locales/de-DE.json
@@ -1047,5 +1047,23 @@
     "title": "STEAM-SAMMLUNGEN",
     "enabled": "Sammlungen aktiviert",
     "disabled": "Sammlungen deaktiviert"
+  },
+  "gamevault": {
+    "connectTitle": "Mit GameVault verbinden",
+    "connect": "Verbinden",
+    "connecting": "Verbinde…",
+    "cancel": "Abbrechen",
+    "serverUrl": "Server-URL",
+    "username": "Benutzername",
+    "password": "Passwort",
+    "verifySsl": "SSL-Zertifikat prüfen",
+    "verifySslDescription": "Deaktivieren für selbstsignierte Zertifikate",
+    "downloadDir": "Archiv-Download-Verzeichnis",
+    "downloadDirDescription": "Temporäres Verzeichnis für Archiv-Downloads. Leer lassen für den Standard. Verwende einen anderen Pfad, wenn auf dem Installationsziel nicht genug Platz für Archiv und entpacktes Spiel ist.",
+    "downloadDirPlaceholder": "Standard: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Bitte Server-URL eingeben",
+    "errorUsernameRequired": "Bitte Benutzername eingeben",
+    "errorPasswordRequired": "Bitte Passwort eingeben",
+    "errorConnection": "Verbindung zum GameVault-Server fehlgeschlagen"
   }
 }

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -546,7 +546,8 @@
     "amazon": "Amazon",
     "ubisoft": "Ubisoft",
     "microsoft": "Microsoft",
-    "battlenet": "Battle.net"
+    "battlenet": "Battle.net",
+    "gamevault": "GameVault"
   },
   "unifiedLibrary": {
     "error": "Unifideck Error",
@@ -1047,5 +1048,23 @@
     "typeReinstall": "Reinstalling",
     "typeUpdate": "Updating to",
     "updateButton": "Update to v{{version}}"
+  },
+  "gamevault": {
+    "connectTitle": "Connect to GameVault",
+    "connect": "Connect",
+    "connecting": "Connecting…",
+    "cancel": "Cancel",
+    "serverUrl": "Server URL",
+    "username": "Username",
+    "password": "Password",
+    "verifySsl": "Verify SSL certificate",
+    "verifySslDescription": "Disable for self-signed certificates",
+    "downloadDir": "Archive download directory",
+    "downloadDirDescription": "Temporary directory for archive downloads. Leave empty to use the default. Use a path on a different drive if your install target lacks space for both the archive and the extracted game.",
+    "downloadDirPlaceholder": "Default: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Please enter the server URL",
+    "errorUsernameRequired": "Please enter your username",
+    "errorPasswordRequired": "Please enter your password",
+    "errorConnection": "Failed to connect to GameVault server"
   }
 }

--- a/src/i18n/locales/es-ES.json
+++ b/src/i18n/locales/es-ES.json
@@ -1045,5 +1045,23 @@
     "title": "COLECCIONES DE STEAM",
     "enabled": "Colecciones activadas",
     "disabled": "Colecciones desactivadas"
+  },
+  "gamevault": {
+    "connectTitle": "Conectar a GameVault",
+    "connect": "Conectar",
+    "connecting": "Conectando…",
+    "cancel": "Cancelar",
+    "serverUrl": "URL del servidor",
+    "username": "Usuario",
+    "password": "Contraseña",
+    "verifySsl": "Verificar certificado SSL",
+    "verifySslDescription": "Deshabilitar para certificados autofirmados",
+    "downloadDir": "Directorio de descarga de archivos",
+    "downloadDirDescription": "Directorio temporal para descargas de archivos. Dejar vacío para usar el predeterminado.",
+    "downloadDirPlaceholder": "Predeterminado: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Por favor ingresa la URL del servidor",
+    "errorUsernameRequired": "Por favor ingresa tu nombre de usuario",
+    "errorPasswordRequired": "Por favor ingresa tu contraseña",
+    "errorConnection": "Error al conectar con el servidor GameVault"
   }
 }

--- a/src/i18n/locales/fr-FR.json
+++ b/src/i18n/locales/fr-FR.json
@@ -1045,5 +1045,23 @@
     "title": "COLLECTIONS STEAM",
     "enabled": "Collections activées",
     "disabled": "Collections désactivées"
+  },
+  "gamevault": {
+    "connectTitle": "Se connecter à GameVault",
+    "connect": "Connecter",
+    "connecting": "Connexion…",
+    "cancel": "Annuler",
+    "serverUrl": "URL du serveur",
+    "username": "Nom d'utilisateur",
+    "password": "Mot de passe",
+    "verifySsl": "Vérifier le certificat SSL",
+    "verifySslDescription": "Désactiver pour les certificats auto-signés",
+    "downloadDir": "Répertoire de téléchargement d'archives",
+    "downloadDirDescription": "Répertoire temporaire pour les téléchargements d'archives. Laisser vide pour utiliser le répertoire par défaut.",
+    "downloadDirPlaceholder": "Défaut: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Veuillez entrer l'URL du serveur",
+    "errorUsernameRequired": "Veuillez entrer votre nom d'utilisateur",
+    "errorPasswordRequired": "Veuillez entrer votre mot de passe",
+    "errorConnection": "Échec de la connexion au serveur GameVault"
   }
 }

--- a/src/i18n/locales/it-IT.json
+++ b/src/i18n/locales/it-IT.json
@@ -1045,5 +1045,23 @@
     "title": "COLLEZIONI DI STEAM",
     "enabled": "Collezioni abilitate",
     "disabled": "Collezioni disabilitate"
+  },
+  "gamevault": {
+    "connectTitle": "Connetti a GameVault",
+    "connect": "Connetti",
+    "connecting": "Connessione…",
+    "cancel": "Annulla",
+    "serverUrl": "URL del server",
+    "username": "Nome utente",
+    "password": "Password",
+    "verifySsl": "Verifica certificato SSL",
+    "verifySslDescription": "Disabilita per certificati autofirmati",
+    "downloadDir": "Directory download archivi",
+    "downloadDirDescription": "Directory temporanea per i download degli archivi. Lascia vuoto per usare quella predefinita.",
+    "downloadDirPlaceholder": "Predefinita: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Inserisci l'URL del server",
+    "errorUsernameRequired": "Inserisci il tuo nome utente",
+    "errorPasswordRequired": "Inserisci la tua password",
+    "errorConnection": "Connessione al server GameVault non riuscita"
   }
 }

--- a/src/i18n/locales/ja-JP.json
+++ b/src/i18n/locales/ja-JP.json
@@ -1045,5 +1045,23 @@
     "title": "STEAM コレクション",
     "enabled": "コレクションが有効",
     "disabled": "コレクションが無効"
+  },
+  "gamevault": {
+    "connectTitle": "GameVaultに接続",
+    "connect": "接続",
+    "connecting": "接続中…",
+    "cancel": "キャンセル",
+    "serverUrl": "サーバーURL",
+    "username": "ユーザー名",
+    "password": "パスワード",
+    "verifySsl": "SSL証明書の確認",
+    "verifySslDescription": "自己署名証明書の場合は無効にしてください",
+    "downloadDir": "アーカイブダウンロードディレクトリ",
+    "downloadDirDescription": "アーカイブダウンロード用の一時ディレクトリ。空欄のままにするとデフォルトが使用されます。",
+    "downloadDirPlaceholder": "デフォルト: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "サーバーURLを入力してください",
+    "errorUsernameRequired": "ユーザー名を入力してください",
+    "errorPasswordRequired": "パスワードを入力してください",
+    "errorConnection": "GameVaultサーバーへの接続に失敗しました"
   }
 }

--- a/src/i18n/locales/ko-KR.json
+++ b/src/i18n/locales/ko-KR.json
@@ -1045,5 +1045,23 @@
     "title": "STEAM 컬렉션",
     "enabled": "컬렉션 활성화됨",
     "disabled": "컬렉션 비활성화됨"
+  },
+  "gamevault": {
+    "connectTitle": "GameVault에 연결",
+    "connect": "연결",
+    "connecting": "연결 중…",
+    "cancel": "취소",
+    "serverUrl": "서버 URL",
+    "username": "사용자 이름",
+    "password": "비밀번호",
+    "verifySsl": "SSL 인증서 확인",
+    "verifySslDescription": "자체 서명 인증서는 비활성화하세요",
+    "downloadDir": "아카이브 다운로드 디렉토리",
+    "downloadDirDescription": "아카이브 다운로드용 임시 디렉토리. 기본값을 사용하려면 비워두세요.",
+    "downloadDirPlaceholder": "기본값: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "서버 URL을 입력하세요",
+    "errorUsernameRequired": "사용자 이름을 입력하세요",
+    "errorPasswordRequired": "비밀번호를 입력하세요",
+    "errorConnection": "GameVault 서버 연결 실패"
   }
 }

--- a/src/i18n/locales/nl-NL.json
+++ b/src/i18n/locales/nl-NL.json
@@ -1045,5 +1045,23 @@
     "title": "STEAM-COLLECTIES",
     "enabled": "Collecties ingeschakeld",
     "disabled": "Collecties uitgeschakeld"
+  },
+  "gamevault": {
+    "connectTitle": "Verbinden met GameVault",
+    "connect": "Verbinden",
+    "connecting": "Verbinden…",
+    "cancel": "Annuleren",
+    "serverUrl": "Server-URL",
+    "username": "Gebruikersnaam",
+    "password": "Wachtwoord",
+    "verifySsl": "SSL-certificaat verifiëren",
+    "verifySslDescription": "Uitschakelen voor zelfondertekende certificaten",
+    "downloadDir": "Archiefdownloadmap",
+    "downloadDirDescription": "Tijdelijke map voor archiefdownloads. Leeg laten voor de standaard.",
+    "downloadDirPlaceholder": "Standaard: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Voer de server-URL in",
+    "errorUsernameRequired": "Voer uw gebruikersnaam in",
+    "errorPasswordRequired": "Voer uw wachtwoord in",
+    "errorConnection": "Verbinding met GameVault-server mislukt"
   }
 }

--- a/src/i18n/locales/pl-PL.json
+++ b/src/i18n/locales/pl-PL.json
@@ -1045,5 +1045,23 @@
     "title": "KOLEKCJE STEAM",
     "enabled": "Kolekcje włączone",
     "disabled": "Kolekcje wyłączone"
+  },
+  "gamevault": {
+    "connectTitle": "Połącz z GameVault",
+    "connect": "Połącz",
+    "connecting": "Łączenie…",
+    "cancel": "Anuluj",
+    "serverUrl": "URL serwera",
+    "username": "Nazwa użytkownika",
+    "password": "Hasło",
+    "verifySsl": "Weryfikuj certyfikat SSL",
+    "verifySslDescription": "Wyłącz dla certyfikatów samopodpisanych",
+    "downloadDir": "Katalog pobierania archiwów",
+    "downloadDirDescription": "Tymczasowy katalog dla pobieranych archiwów. Zostaw puste, aby użyć domyślnego.",
+    "downloadDirPlaceholder": "Domyślny: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Podaj URL serwera",
+    "errorUsernameRequired": "Podaj swoją nazwę użytkownika",
+    "errorPasswordRequired": "Podaj swoje hasło",
+    "errorConnection": "Nie udało się połączyć z serwerem GameVault"
   }
 }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1045,5 +1045,23 @@
     "title": "COLEÇÕES DO STEAM",
     "enabled": "Coleções ativadas",
     "disabled": "Coleções desativadas"
+  },
+  "gamevault": {
+    "connectTitle": "Conectar ao GameVault",
+    "connect": "Conectar",
+    "connecting": "Conectando…",
+    "cancel": "Cancelar",
+    "serverUrl": "URL do servidor",
+    "username": "Usuário",
+    "password": "Senha",
+    "verifySsl": "Verificar certificado SSL",
+    "verifySslDescription": "Desativar para certificados autoassinados",
+    "downloadDir": "Diretório de download de arquivos",
+    "downloadDirDescription": "Diretório temporário para downloads de arquivos. Deixe vazio para usar o padrão.",
+    "downloadDirPlaceholder": "Padrão: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Por favor, insira a URL do servidor",
+    "errorUsernameRequired": "Por favor, insira seu nome de usuário",
+    "errorPasswordRequired": "Por favor, insira sua senha",
+    "errorConnection": "Falha ao conectar ao servidor GameVault"
   }
 }

--- a/src/i18n/locales/ru-RU.json
+++ b/src/i18n/locales/ru-RU.json
@@ -1045,5 +1045,23 @@
     "title": "КОЛЛЕКЦИИ STEAM",
     "enabled": "Коллекции включены",
     "disabled": "Коллекции выключены"
+  },
+  "gamevault": {
+    "connectTitle": "Подключиться к GameVault",
+    "connect": "Подключить",
+    "connecting": "Подключение…",
+    "cancel": "Отмена",
+    "serverUrl": "URL сервера",
+    "username": "Имя пользователя",
+    "password": "Пароль",
+    "verifySsl": "Проверять SSL-сертификат",
+    "verifySslDescription": "Отключить для самоподписанных сертификатов",
+    "downloadDir": "Директория загрузки архивов",
+    "downloadDirDescription": "Временная директория для загрузки архивов. Оставьте пустым для использования по умолчанию.",
+    "downloadDirPlaceholder": "По умолчанию: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Пожалуйста, введите URL сервера",
+    "errorUsernameRequired": "Пожалуйста, введите имя пользователя",
+    "errorPasswordRequired": "Пожалуйста, введите пароль",
+    "errorConnection": "Не удалось подключиться к серверу GameVault"
   }
 }

--- a/src/i18n/locales/tr-TR.json
+++ b/src/i18n/locales/tr-TR.json
@@ -1045,5 +1045,23 @@
     "title": "STEAM KOLEKSİYONLARI",
     "enabled": "Koleksiyonlar etkin",
     "disabled": "Koleksiyonlar devre dışı"
+  },
+  "gamevault": {
+    "connectTitle": "GameVault'a Bağlan",
+    "connect": "Bağlan",
+    "connecting": "Bağlanıyor…",
+    "cancel": "İptal",
+    "serverUrl": "Sunucu URL",
+    "username": "Kullanıcı Adı",
+    "password": "Şifre",
+    "verifySsl": "SSL Sertifikasını Doğrula",
+    "verifySslDescription": "Kendinden imzalı sertifikalar için devre dışı bırakın",
+    "downloadDir": "Arşiv indirme dizini",
+    "downloadDirDescription": "Arşiv indirmeleri için geçici dizin. Varsayılanı kullanmak için boş bırakın.",
+    "downloadDirPlaceholder": "Varsayılan: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Lütfen sunucu URL'sini girin",
+    "errorUsernameRequired": "Lütfen kullanıcı adınızı girin",
+    "errorPasswordRequired": "Lütfen şifrenizi girin",
+    "errorConnection": "GameVault sunucusuna bağlanılamadı"
   }
 }

--- a/src/i18n/locales/uk-UA.json
+++ b/src/i18n/locales/uk-UA.json
@@ -1045,5 +1045,23 @@
     "title": "КОЛЕКЦІЇ STEAM",
     "enabled": "Колекції увімкнено",
     "disabled": "Колекції вимкнено"
+  },
+  "gamevault": {
+    "connectTitle": "Підключитися до GameVault",
+    "connect": "Підключити",
+    "connecting": "Підключення…",
+    "cancel": "Скасувати",
+    "serverUrl": "URL сервера",
+    "username": "Ім'я користувача",
+    "password": "Пароль",
+    "verifySsl": "Перевіряти SSL-сертифікат",
+    "verifySslDescription": "Вимкніть для самопідписаних сертифікатів",
+    "downloadDir": "Директорія завантаження архівів",
+    "downloadDirDescription": "Тимчасова директорія для завантаження архівів. Залиште порожнім для використання за замовчуванням.",
+    "downloadDirPlaceholder": "За замовчуванням: ~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "Будь ласка, введіть URL сервера",
+    "errorUsernameRequired": "Будь ласка, введіть ім'я користувача",
+    "errorPasswordRequired": "Будь ласка, введіть пароль",
+    "errorConnection": "Не вдалося підключитися до сервера GameVault"
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1045,5 +1045,23 @@
     "title": "STEAM 收藏夹",
     "enabled": "收藏夹已启用",
     "disabled": "收藏夹已禁用"
+  },
+  "gamevault": {
+    "connectTitle": "连接到 GameVault",
+    "connect": "连接",
+    "connecting": "连接中…",
+    "cancel": "取消",
+    "serverUrl": "服务器地址",
+    "username": "用户名",
+    "password": "密码",
+    "verifySsl": "验证 SSL 证书",
+    "verifySslDescription": "自签名证书请禁用此选项",
+    "downloadDir": "归档下载目录",
+    "downloadDirDescription": "归档下载的临时目录。留空使用默认值。",
+    "downloadDirPlaceholder": "默认：~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "请输入服务器地址",
+    "errorUsernameRequired": "请输入用户名",
+    "errorPasswordRequired": "请输入密码",
+    "errorConnection": "连接 GameVault 服务器失败"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1045,5 +1045,23 @@
     "title": "STEAM 收藏",
     "enabled": "已啟用收藏",
     "disabled": "已禁用收藏"
+  },
+  "gamevault": {
+    "connectTitle": "連線至 GameVault",
+    "connect": "連線",
+    "connecting": "連線中…",
+    "cancel": "取消",
+    "serverUrl": "伺服器位址",
+    "username": "使用者名稱",
+    "password": "密碼",
+    "verifySsl": "驗證 SSL 憑證",
+    "verifySslDescription": "自簽憑證請停用此選項",
+    "downloadDir": "封存下載目錄",
+    "downloadDirDescription": "封存下載的暫存目錄。留空使用預設值。",
+    "downloadDirPlaceholder": "預設：~/.local/share/unifideck/gamevault_downloads",
+    "errorServerUrlRequired": "請輸入伺服器位址",
+    "errorUsernameRequired": "請輸入使用者名稱",
+    "errorPasswordRequired": "請輸入密碼",
+    "errorConnection": "連線至 GameVault 伺服器失敗"
   }
 }

--- a/src/lib/library-filters/index.ts
+++ b/src/lib/library-filters/index.ts
@@ -33,7 +33,8 @@ export type StoreSlug =
   | "amazon"
   | "ubisoft"
   | "battlenet"
-  | "microsoft";
+  | "microsoft"
+  | "gamevault";
 
 export type FilterType =
   | "installed"
@@ -386,6 +387,7 @@ export async function loadUnifideckCache(): Promise<void> {
       ubisoft: 0,
       battlenet: 0,
       microsoft: 0,
+      gamevault: 0,
     };
     for (const g of games ?? []) {
       if (g.app_id == null) continue;

--- a/src/lib/steam-bridge/app-context-menu-patch.ts
+++ b/src/lib/steam-bridge/app-context-menu-patch.ts
@@ -29,7 +29,7 @@ import { getUnifideckGame } from "../library-filters";
 import { ChangeExecutableModal } from "../../components/modals/ChangeExecutableModal";
 
 /** Stores whose launch target the user can override (see ExecutableRPCMixin). */
-const SUPPORTED_STORES = new Set(["gog", "amazon", "epic"]);
+const SUPPORTED_STORES = new Set(["gog", "amazon", "epic", "gamevault"]);
 
 /** Stable key so re-renders can dedupe our injected item. */
 const MENU_ITEM_KEY = "unifideck-change-exe";

--- a/src/lib/steam-bridge/tab-container.ts
+++ b/src/lib/steam-bridge/tab-container.ts
@@ -91,6 +91,12 @@ export function getUnifideckTabs(): UnifideckTab[] {
       filters: [{ type: "store", params: { store: "microsoft" } }],
     },
     {
+      id: "unifideck-gamevault",
+      title: t("deckTabs.gamevault"),
+      position: 9,
+      filters: [{ type: "store", params: { store: "gamevault" } }],
+    },
+    {
       id: "unifideck-nonsteam",
       title: t("deckTabs.nonSteam"),
       position: 10,
@@ -358,7 +364,8 @@ type ConnectableStore =
   | "amazon"
   | "ubisoft"
   | "battlenet"
-  | "microsoft";
+  | "microsoft"
+  | "gamevault";
 
 class TabManager {
   private tabs: UnifideckTabContainer[] = [];
@@ -370,6 +377,7 @@ class TabManager {
     ubisoft: 0,
     battlenet: 0,
     microsoft: 0,
+    gamevault: 0,
   };
   private version = 0;
   private listeners: (() => void)[] = [];
@@ -422,6 +430,7 @@ class TabManager {
       "unifideck-ubisoft": "ubisoft",
       "unifideck-battlenet": "battlenet",
       "unifideck-microsoft": "microsoft",
+      "unifideck-gamevault": "gamevault",
     };
     const store = m[id];
     if (!store) return true;

--- a/src/stores/download-store.ts
+++ b/src/stores/download-store.ts
@@ -186,6 +186,14 @@ class DownloadStoreImpl {
               eta_seconds:
                 (payload.eta_seconds as number) ??
                 prev.queue.current.eta_seconds,
+              downloaded_bytes:
+                (payload.downloaded_bytes as number) > 0
+                  ? (payload.downloaded_bytes as number)
+                  : prev.queue.current.downloaded_bytes,
+              total_bytes:
+                (payload.total_bytes as number) > 0
+                  ? (payload.total_bytes as number)
+                  : prev.queue.current.total_bytes,
             },
           },
         }));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -175,7 +175,8 @@ export type StoreId =
   | "amazon"
   | "microsoft"
   | "ubisoft"
-  | "battlenet";
+  | "battlenet"
+  | "gamevault";
 
 /**
  * Per-store availability + auth state, returned by

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -68,4 +68,10 @@ export const STORE_VISUALS: Record<StoreId, StoreVisual> = {
     brand_color: "#00aeff",
     icon_path: "/assets/battlenet.svg",
   },
+  gamevault: {
+    id: "gamevault",
+    display_name: "GameVault",
+    brand_color: "#1a9c3e",
+    icon_path: "/assets/gamevault.svg",
+  },
 };

--- a/tests/unit/test_gamevault_auth.py
+++ b/tests/unit/test_gamevault_auth.py
@@ -1,0 +1,211 @@
+"""Tests for ``stores.gamevault.auth`` — JWT expiry parsing, login,
+credential persistence, and header generation."""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+
+from unifideck.stores.gamevault.auth import GameVaultAuth
+
+
+def _make_jwt(exp: float) -> str:
+    """Build a syntactically-valid (unsigned) JWT with a given ``exp`` claim."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload_json = json.dumps({"exp": exp}).encode()
+    payload = base64.urlsafe_b64encode(payload_json).rstrip(b"=").decode()
+    return f"{header}.{payload}.signature"
+
+
+# ── _parse_jwt_expiry ───────────────────────────────────────────────
+def test_parse_jwt_expiry_valid_token():
+    token = _make_jwt(1234567890.0)
+    assert GameVaultAuth._parse_jwt_expiry(token) == 1234567890.0
+
+
+def test_parse_jwt_expiry_malformed_token_returns_none():
+    assert GameVaultAuth._parse_jwt_expiry("not-a-jwt") is None
+
+
+def test_parse_jwt_expiry_missing_exp_claim_returns_none():
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(b"{}").rstrip(b"=").decode()
+    token = f"{header}.{payload}.sig"
+    assert GameVaultAuth._parse_jwt_expiry(token) is None
+
+
+def test_parse_jwt_expiry_empty_string_returns_none():
+    assert GameVaultAuth._parse_jwt_expiry("") is None
+
+
+# ── config persistence ────────────────────────────────────────────────
+def test_auth_starts_with_empty_config_when_file_missing(tmp_path):
+    auth = GameVaultAuth(config_file=str(tmp_path / "does-not-exist.json"))
+    assert auth.server_url is None
+    assert auth.is_authenticated() is False
+
+
+def test_auth_loads_existing_config(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({
+        "server_url": "https://gv.example.com",
+        "verify_ssl": False,
+        "download_dir": "/mnt/downloads",
+    }))
+    auth = GameVaultAuth(config_file=str(cfg_path))
+    assert auth.server_url == "https://gv.example.com"
+    assert auth.verify_ssl is False
+    assert auth.download_dir == "/mnt/downloads"
+
+
+def test_auth_corrupt_config_file_falls_back_to_empty(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text("{not valid json")
+    auth = GameVaultAuth(config_file=str(cfg_path))
+    assert auth.server_url is None
+
+
+def test_verify_ssl_defaults_to_true_when_unset(tmp_path):
+    auth = GameVaultAuth(config_file=str(tmp_path / "missing.json"))
+    assert auth.verify_ssl is True
+
+
+def test_download_dir_defaults_to_none(tmp_path):
+    auth = GameVaultAuth(config_file=str(tmp_path / "missing.json"))
+    assert auth.download_dir is None
+
+
+# ── is_authenticated ────────────────────────────────────────────────────
+def test_is_authenticated_false_without_server_url(tmp_path):
+    auth = GameVaultAuth(config_file=str(tmp_path / "missing.json"))
+    assert auth.is_authenticated() is False
+
+
+def test_is_authenticated_true_with_valid_token(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({
+        "server_url": "https://gv.example.com",
+        "access_token": _make_jwt(time.time() + 3600),
+    }))
+    auth = GameVaultAuth(config_file=str(cfg_path))
+    assert auth.is_authenticated() is True
+
+
+def test_is_authenticated_true_with_expired_token_but_saved_credentials(tmp_path):
+    """Expired token + stored username/password → still "connected"
+    (get_auth_headers refreshes transparently later)."""
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({
+        "server_url": "https://gv.example.com",
+        "access_token": _make_jwt(time.time() - 3600),
+        "username": "alice",
+        "password": "secret",
+    }))
+    auth = GameVaultAuth(config_file=str(cfg_path))
+    assert auth.is_authenticated() is True
+
+
+def test_is_authenticated_false_with_expired_token_and_no_credentials(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({
+        "server_url": "https://gv.example.com",
+        "access_token": _make_jwt(time.time() - 3600),
+    }))
+    auth = GameVaultAuth(config_file=str(cfg_path))
+    assert auth.is_authenticated() is False
+
+
+# ── get_auth_headers ─────────────────────────────────────────────────────
+def test_get_auth_headers_returns_bearer_for_valid_token(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({
+        "server_url": "https://gv.example.com",
+        "access_token": _make_jwt(time.time() + 3600),
+    }))
+    auth = GameVaultAuth(config_file=str(cfg_path))
+    headers = asyncio.run(auth.get_auth_headers())
+    assert headers["Authorization"].startswith("Bearer ")
+
+
+def test_get_auth_headers_none_when_refresh_has_no_credentials(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({
+        "server_url": "https://gv.example.com",
+        "access_token": _make_jwt(time.time() - 3600),
+        # no username/password to refresh with
+    }))
+    auth = GameVaultAuth(config_file=str(cfg_path))
+    headers = asyncio.run(auth.get_auth_headers())
+    assert headers is None
+
+
+# ── logout ───────────────────────────────────────────────────────────────
+def test_logout_clears_config_and_deletes_file(tmp_path):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"server_url": "https://gv.example.com"}))
+    auth = GameVaultAuth(config_file=str(cfg_path))
+
+    result = asyncio.run(auth.logout())
+
+    assert result.success is True
+    assert auth.server_url is None
+    assert not cfg_path.exists()
+
+
+def test_logout_when_no_config_file_exists_is_safe(tmp_path):
+    auth = GameVaultAuth(config_file=str(tmp_path / "never-existed.json"))
+    result = asyncio.run(auth.logout())
+    assert result.success is True
+
+
+# ── start_auth persistence (login itself is network-bound; test the
+#    persistence/serialization contract via a monkeypatched _do_login) ──
+def test_start_auth_persists_credentials_on_success(tmp_path, monkeypatch):
+    from unifideck.core.types import AuthResult
+
+    cfg_path = tmp_path / "config.json"
+    auth = GameVaultAuth(config_file=str(cfg_path))
+
+    async def _fake_login(server_url, username, password, verify_ssl):
+        auth._cfg["access_token"] = _make_jwt(time.time() + 3600)
+        return AuthResult(success=True, action="authenticated", tokens_cached=True, store="gamevault")
+
+    monkeypatch.setattr(auth, "_do_login", _fake_login)
+
+    result = asyncio.run(auth.start_auth(
+        server_url="https://gv.example.com/",
+        username="alice",
+        password="secret",
+        verify_ssl=False,
+        download_dir="/mnt/dl",
+    ))
+
+    assert result.success is True
+    assert cfg_path.exists()
+    saved = json.loads(cfg_path.read_text())
+    assert saved["server_url"] == "https://gv.example.com"  # trailing slash stripped
+    assert saved["username"] == "alice"
+    assert saved["verify_ssl"] is False
+    assert saved["download_dir"] == "/mnt/dl"
+
+
+def test_start_auth_does_not_persist_on_failure(tmp_path, monkeypatch):
+    from unifideck.core.types import AuthResult
+
+    cfg_path = tmp_path / "config.json"
+    auth = GameVaultAuth(config_file=str(cfg_path))
+
+    async def _fake_login(server_url, username, password, verify_ssl):
+        return AuthResult(success=False, error="bad credentials", store="gamevault")
+
+    monkeypatch.setattr(auth, "_do_login", _fake_login)
+
+    result = asyncio.run(auth.start_auth(
+        server_url="https://gv.example.com",
+        username="alice",
+        password="wrong",
+    ))
+
+    assert result.success is False
+    assert not cfg_path.exists()

--- a/tests/unit/test_gamevault_install.py
+++ b/tests/unit/test_gamevault_install.py
@@ -1,0 +1,259 @@
+"""Tests for ``stores.gamevault.install`` — archive detection, exe finding,
+and install-marker persistence.
+
+No dedicated GameVault tests existed before this file, despite 1139 lines
+of store code across install.py/library.py/auth.py/store.py. Priority here
+is ``_find_executable`` — its lack of "trainer"/"cheat" in ``_UTIL_KEYWORDS``
+plus size-favouring scoring is what silently picked a bundled trainer.exe
+over the real game exe on a live install (Tempest Rising / GameVault),
+making Unifideck launch the trainer instead of the game.
+"""
+from __future__ import annotations
+
+from unifideck.stores.gamevault.install import (
+    GameVaultInstaller,
+    _detect_format,
+    _find_executable,
+    _load_install_info,
+    _parse_filename_from_cd,
+    _remove_install_info,
+    _save_install_info,
+)
+
+
+# ── _detect_format ──────────────────────────────────────────────────
+def test_detect_format_zip(tmp_path):
+    p = tmp_path / "archive.bin"
+    p.write_bytes(b"PK\x03\x04" + b"\x00" * 20)
+    assert _detect_format(p) == "zip"
+
+
+def test_detect_format_rar(tmp_path):
+    p = tmp_path / "archive.bin"
+    p.write_bytes(b"Rar!\x1a\x07\x00" + b"\x00" * 20)
+    assert _detect_format(p) == "rar"
+
+
+def test_detect_format_7z(tmp_path):
+    p = tmp_path / "archive.bin"
+    p.write_bytes(b"7z\xbc\xaf'\x1c\x00\x04" + b"\x00" * 20)
+    assert _detect_format(p) == "7z"
+
+
+def test_detect_format_7z_inside_sfx(tmp_path):
+    """A self-extracting exe wrapper: the 7z signature is buried, not at
+    offset 0 — the sniffer must scan the first 512KB, not just the header."""
+    p = tmp_path / "setup.exe"
+    p.write_bytes(b"MZ" + b"\x00" * 1000 + b"7z\xbc\xaf'\x1c" + b"\x00" * 20)
+    assert _detect_format(p) == "7z"
+
+
+def test_detect_format_unknown(tmp_path):
+    p = tmp_path / "archive.bin"
+    p.write_bytes(b"not an archive at all")
+    assert _detect_format(p) is None
+
+
+def test_detect_format_missing_file_returns_none(tmp_path):
+    assert _detect_format(tmp_path / "does-not-exist.bin") is None
+
+
+# ── _find_executable ─────────────────────────────────────────────────
+def test_find_executable_picks_the_only_exe(tmp_path):
+    (tmp_path / "Game.exe").write_bytes(b"x" * 1000)
+    assert _find_executable(str(tmp_path)) == str(tmp_path / "Game.exe")
+
+
+def test_find_executable_filters_utility_keywords(tmp_path):
+    (tmp_path / "Game.exe").write_bytes(b"x" * 1000)
+    (tmp_path / "unins000.exe").write_bytes(b"x" * 1000)
+    (tmp_path / "vcredist_x64.exe").write_bytes(b"x" * 1000)
+    (tmp_path / "UE4PrereqSetup_x64.exe").write_bytes(b"x" * 1000)
+    result = _find_executable(str(tmp_path))
+    assert result == str(tmp_path / "Game.exe")
+
+
+def test_find_executable_no_candidates_returns_none(tmp_path):
+    (tmp_path / "readme.txt").write_text("hi")
+    assert _find_executable(str(tmp_path)) is None
+
+
+def test_find_executable_prefers_shallower_path(tmp_path):
+    """Two otherwise-equal exes: the shallower one should win the
+    depth-based score component."""
+    (tmp_path / "Game.exe").write_bytes(b"x" * 1000)
+    nested = tmp_path / "bin" / "redist" / "tools"
+    nested.mkdir(parents=True)
+    (nested / "Other.exe").write_bytes(b"x" * 1000)
+    assert _find_executable(str(tmp_path)) == str(tmp_path / "Game.exe")
+
+
+def test_find_executable_prefers_larger_file_at_equal_depth(tmp_path):
+    (tmp_path / "Small.exe").write_bytes(b"x" * 1000)
+    (tmp_path / "Big.exe").write_bytes(b"x" * (10 * 1024 * 1024))
+    assert _find_executable(str(tmp_path)) == str(tmp_path / "Big.exe")
+
+
+def test_find_executable_does_not_filter_trainer_or_cheat_by_name(tmp_path):
+    """Regression documentation, not a desired behaviour: KNOWN GAP.
+
+    ``_UTIL_KEYWORDS`` has no "trainer"/"cheat" entry, so a large trainer
+    exe bundled inside a game's install dir can outscore (and thus
+    replace) the real game exe purely on file size. This test pins the
+    CURRENT behaviour so a future fix (adding those keywords, or scoping
+    detection to the top-level dir only) has to consciously change this
+    test rather than silently regress it back.
+    """
+    (tmp_path / "Game.exe").write_bytes(b"x" * (1 * 1024 * 1024))
+    (tmp_path / "trainer.exe").write_bytes(b"x" * (20 * 1024 * 1024))
+    # Today: the larger trainer.exe wins. This is the exact bug reproduced
+    # live with Tempest Rising.
+    assert _find_executable(str(tmp_path)) == str(tmp_path / "trainer.exe")
+
+
+# ── install marker persistence ───────────────────────────────────────
+def test_save_and_load_install_info_roundtrip(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+
+    _save_install_info(
+        "123", title="My Game", install_path="/games/mygame", exe_path="/games/mygame/Game.exe",
+    )
+    info = _load_install_info("123")
+    assert info == {
+        "game_id": "123",
+        "title": "My Game",
+        "install_path": "/games/mygame",
+        "exe_path": "/games/mygame/Game.exe",
+    }
+
+
+def test_load_install_info_missing_returns_none(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    assert _load_install_info("does-not-exist") is None
+
+
+def test_load_install_info_corrupt_json_returns_none(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    marker = tmp_path / "999.json"
+    marker.write_text("{not valid json")
+    assert _load_install_info("999") is None
+
+
+def test_remove_install_info_deletes_marker(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    _save_install_info("42", title="T", install_path="/p", exe_path="/p/e.exe")
+    assert (tmp_path / "42.json").exists()
+    _remove_install_info("42")
+    assert not (tmp_path / "42.json").exists()
+
+
+def test_remove_install_info_missing_is_a_noop(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    _remove_install_info("never-existed")  # must not raise
+
+
+def test_get_installed_reads_all_markers(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    _save_install_info("1", title="A", install_path="/a", exe_path="/a/a.exe")
+    _save_install_info("2", title="B", install_path="/b", exe_path="/b/b.exe")
+
+    installer = GameVaultInstaller(default_install_root="/root", download_dir="/dl")
+    installed = installer.get_installed()
+
+    assert set(installed.keys()) == {"1", "2"}
+    assert installed["1"]["title"] == "A"
+
+
+def test_get_installed_empty_dir_returns_empty(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    installer = GameVaultInstaller(default_install_root="/root", download_dir="/dl")
+    assert installer.get_installed() == {}
+
+
+def test_get_installed_missing_dir_returns_empty(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path / "does-not-exist")
+    installer = GameVaultInstaller(default_install_root="/root", download_dir="/dl")
+    assert installer.get_installed() == {}
+
+
+def test_get_install_info_delegates_to_module_function(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    _save_install_info("7", title="T", install_path="/p", exe_path="/p/e.exe")
+
+    installer = GameVaultInstaller(default_install_root="/root", download_dir="/dl")
+    assert installer.get_install_info("7")["title"] == "T"
+
+
+# ── Content-Disposition filename parsing ─────────────────────────────
+def test_parse_filename_from_cd_simple():
+    assert _parse_filename_from_cd('attachment; filename="Game.zip"') == "Game.zip"
+
+
+def test_parse_filename_from_cd_no_quotes():
+    assert _parse_filename_from_cd("attachment; filename=Game.zip") == "Game.zip"
+
+
+def test_parse_filename_from_cd_rfc5987_charset_prefix():
+    """KNOWN GAP: the capture regex ``[^"\\';\\r\\n]+`` stops at the FIRST
+    apostrophe, so it never actually reaches the ``''`` split branch for a
+    real RFC 5987 ``filename*=UTF-8''...`` value — it captures only the
+    charset token. Pinned as documentation of current behaviour, not the
+    intended one.
+    """
+    header = "attachment; filename*=UTF-8''My%20Game.zip"
+    assert _parse_filename_from_cd(header) == "UTF-8"
+
+
+def test_parse_filename_from_cd_missing_returns_none():
+    assert _parse_filename_from_cd("attachment") is None
+
+
+def test_parse_filename_from_cd_empty_string_returns_none():
+    assert _parse_filename_from_cd("") is None
+
+
+# ── GameVaultInstaller construction ───────────────────────────────────
+def test_installer_expands_user_paths():
+    installer = GameVaultInstaller(
+        default_install_root="~/Games/GameVault", download_dir="~/dl",
+    )
+    assert "~" not in str(installer._default_install_root)
+    assert "~" not in str(installer._download_dir)
+
+
+async def test_uninstall_game_missing_install_returns_failure(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    installer = GameVaultInstaller(default_install_root="/root", download_dir="/dl")
+
+    result = await installer.uninstall_game("never-installed")
+
+    assert result.success is False
+    assert result.error == "Game not installed"
+
+
+async def test_uninstall_game_removes_dir_and_marker(tmp_path, monkeypatch):
+    import unifideck.stores.gamevault.install as install_mod
+    monkeypatch.setattr(install_mod, "_MARKER_DIR", tmp_path)
+    game_dir = tmp_path / "installed_game"
+    game_dir.mkdir()
+    (game_dir / "Game.exe").write_bytes(b"x")
+    _save_install_info(
+        "55", title="T", install_path=str(game_dir), exe_path=str(game_dir / "Game.exe"),
+    )
+    installer = GameVaultInstaller(default_install_root="/root", download_dir="/dl")
+
+    result = await installer.uninstall_game("55")
+
+    assert result.success is True
+    assert not game_dir.exists()
+    assert _load_install_info("55") is None

--- a/tests/unit/test_gamevault_library.py
+++ b/tests/unit/test_gamevault_library.py
@@ -1,0 +1,177 @@
+"""Tests for ``stores.gamevault.library`` — title/cover extraction and
+raw-API-item-to-``Game`` mapping. Pagination itself is network-bound and
+left uncovered here (would need an aiohttp test server); this focuses on
+the pure, easily-broken parsing helpers.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from unifideck.stores.gamevault.library import (
+    GameVaultLibraryReader,
+    _parse_title_from_filename,
+)
+
+
+def _reader() -> GameVaultLibraryReader:
+    return GameVaultLibraryReader(installer=MagicMock())
+
+
+# ── _parse_title_from_filename ───────────────────────────────────────
+def test_parse_title_strips_extension_and_year():
+    assert _parse_title_from_filename("Half-Life 2 (2004).zip") == "Half Life 2"
+
+
+def test_parse_title_no_year_suffix():
+    assert _parse_title_from_filename("Portal.exe") == "Portal"
+
+
+def test_parse_title_underscores_and_dashes_become_spaces():
+    assert _parse_title_from_filename("The_Witcher-3_Wild-Hunt.rar") == "The Witcher 3 Wild Hunt"
+
+
+def test_parse_title_with_directory_prefix():
+    assert _parse_title_from_filename("/mnt/games/Doom Eternal (2020).7z") == "Doom Eternal"
+
+
+def test_parse_title_collapses_multiple_spaces():
+    assert _parse_title_from_filename("Game   Title.zip") == "Game Title"
+
+
+def test_parse_title_bracket_year_variant():
+    assert _parse_title_from_filename("Cyberpunk 2077 [2020].zip") == "Cyberpunk 2077"
+
+
+def test_parse_title_falls_back_to_filename_when_result_empty():
+    # An input that becomes empty after stripping should fall back to the
+    # original file_path rather than returning "".
+    assert _parse_title_from_filename("(2020).zip") == "(2020).zip"
+
+
+# ── _extract_title ────────────────────────────────────────────────────
+def test_extract_title_prefers_metadata_title():
+    reader = _reader()
+    item = {"metadata": {"title": "Explicit Title"}, "file_path": "ignored.zip"}
+    assert reader._extract_title(item) == "Explicit Title"
+
+
+def test_extract_title_falls_back_to_metadata_name():
+    reader = _reader()
+    item = {"metadata": {"name": "Named Title"}}
+    assert reader._extract_title(item) == "Named Title"
+
+
+def test_extract_title_falls_back_to_file_path_parsing():
+    reader = _reader()
+    item = {"file_path": "My Game (2021).zip"}
+    assert reader._extract_title(item) == "My Game"
+
+
+def test_extract_title_falls_back_to_id_placeholder():
+    reader = _reader()
+    item = {"id": 42}
+    assert reader._extract_title(item) == "GameVault Game #42"
+
+
+# ── _extract_cover_url ───────────────────────────────────────────────
+def test_extract_cover_url_top_level_field():
+    reader = _reader()
+    item = {"cover_image": "https://example.com/cover.jpg"}
+    assert reader._extract_cover_url(item) == "https://example.com/cover.jpg"
+
+
+def test_extract_cover_url_thumbnail_field():
+    reader = _reader()
+    item = {"thumbnail": "https://example.com/thumb.jpg"}
+    assert reader._extract_cover_url(item) == "https://example.com/thumb.jpg"
+
+
+def test_extract_cover_url_structured_boxart():
+    reader = _reader()
+    item = {"boxart": {"url": "https://example.com/box.jpg"}}
+    assert reader._extract_cover_url(item) == "https://example.com/box.jpg"
+
+
+def test_extract_cover_url_none_when_nothing_present():
+    reader = _reader()
+    assert reader._extract_cover_url({}) is None
+
+
+# ── _map_to_game ──────────────────────────────────────────────────────
+def test_map_to_game_builds_expected_record():
+    reader = _reader()
+    item = {
+        "id": 5,
+        "metadata": {"title": "My Game"},
+        "cover_image": "https://x/cover.jpg",
+        "file_path": "/games/mygame.zip",
+        "release_date": "2020-01-01",
+        "early_access": True,
+    }
+    game = reader._map_to_game(item)
+    assert game is not None
+    assert game.store == "gamevault"
+    assert game.store_game_id == "5"
+    assert game.title == "My Game"
+    assert game.icon_url == "https://x/cover.jpg"
+    assert game.installed is False
+    assert game.metadata["early_access"] is True
+
+
+def test_map_to_game_missing_id_returns_none():
+    reader = _reader()
+    assert reader._map_to_game({"metadata": {"title": "No ID"}}) is None
+
+
+def test_map_to_game_malformed_item_returns_none_not_raises():
+    reader = _reader()
+    # metadata is a non-dict, exercising the try/except path
+    item = {"id": 1, "metadata": None, "cover_image": None}
+    game = reader._map_to_game(item)
+    # Should not raise; result may be a valid Game with fallback title.
+    assert game is None or game.store_game_id == "1"
+
+
+# ── get_library() install-state overlay ───────────────────────────────
+async def test_get_library_marks_installed_games():
+    installer = MagicMock()
+    installer.get_install_info.return_value = {
+        "install_path": "/games/mygame",
+        "exe_path": "/games/mygame/Game.exe",
+    }
+    reader = GameVaultLibraryReader(installer=installer)
+
+    async def _fake_fetch(server_url, auth_headers, verify_ssl):
+        return [{"id": 1, "metadata": {"title": "My Game"}}]
+
+    reader._fetch_all_pages = _fake_fetch  # type: ignore[method-assign]
+
+    games = await reader.get_library(
+        server_url="https://gv.example.com",
+        auth_headers={},
+        verify_ssl=True,
+    )
+
+    assert len(games) == 1
+    assert games[0].installed is True
+    assert games[0].install_path == "/games/mygame"
+    assert games[0].exe_path == "/games/mygame/Game.exe"
+
+
+async def test_get_library_uninstalled_games_stay_uninstalled():
+    installer = MagicMock()
+    installer.get_install_info.return_value = None
+    reader = GameVaultLibraryReader(installer=installer)
+
+    async def _fake_fetch(server_url, auth_headers, verify_ssl):
+        return [{"id": 2, "metadata": {"title": "Not Installed"}}]
+
+    reader._fetch_all_pages = _fake_fetch  # type: ignore[method-assign]
+
+    games = await reader.get_library(
+        server_url="https://gv.example.com",
+        auth_headers={},
+        verify_ssl=True,
+    )
+
+    assert games[0].installed is False

--- a/tests/unit/test_gamevault_store.py
+++ b/tests/unit/test_gamevault_store.py
@@ -1,0 +1,233 @@
+"""Tests for ``stores.gamevault.store.GameVaultStore`` — orchestration
+logic between auth/installer/library-reader, with those collaborators
+mocked out (their own behaviour is covered by
+test_gamevault_auth/install/library.py).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from unifideck.stores.gamevault.store import GameVaultStore
+
+
+def _make_store(**auth_overrides) -> GameVaultStore:
+    """Build a GameVaultStore with a fake bus/cache and no real config,
+    then monkeypatch its internal collaborators with mocks."""
+    bus = MagicMock()
+    cache = MagicMock()
+    store = GameVaultStore(bus, cache, plugin_dir=None, config=None)
+
+    store._auth = MagicMock()
+    store._auth.is_authenticated.return_value = auth_overrides.get("is_authenticated", True)
+    store._auth.get_auth_headers = AsyncMock(
+        return_value=auth_overrides.get("auth_headers", {"Authorization": "Bearer x"}),
+    )
+    store._auth.server_url = auth_overrides.get("server_url", "https://gv.example.com")
+    store._auth.verify_ssl = auth_overrides.get("verify_ssl", True)
+    store._auth.download_dir = auth_overrides.get("download_dir", None)
+
+    store._installer = MagicMock()
+    store._library_reader = MagicMock()
+    return store
+
+
+# ── is_available ────────────────────────────────────────────────────────
+async def test_is_available_reflects_auth_state():
+    store = _make_store(is_authenticated=True)
+    assert await store.is_available() is True
+
+    store2 = _make_store(is_authenticated=False)
+    assert await store2.is_available() is False
+
+
+# ── start_auth / complete_auth ────────────────────────────────────────
+async def test_start_auth_forwards_kwargs_to_auth_module():
+    store = _make_store()
+    store._auth.start_auth = AsyncMock(return_value=MagicMock(success=True))
+
+    await store.start_auth(
+        server_url="https://gv.example.com",
+        username="alice",
+        password="secret",
+        verify_ssl=False,
+        download_dir="/mnt/dl",
+    )
+
+    store._auth.start_auth.assert_awaited_once_with(
+        server_url="https://gv.example.com",
+        username="alice",
+        password="secret",
+        verify_ssl=False,
+        download_dir="/mnt/dl",
+    )
+
+
+async def test_start_auth_defaults_missing_kwargs():
+    store = _make_store()
+    store._auth.start_auth = AsyncMock(return_value=MagicMock(success=True))
+
+    await store.start_auth()
+
+    store._auth.start_auth.assert_awaited_once_with(
+        server_url="", username="", password="", verify_ssl=True, download_dir=None,
+    )
+
+
+async def test_complete_auth_success_when_authenticated():
+    store = _make_store(is_authenticated=True)
+    result = await store.complete_auth()
+    assert result.success is True
+    assert result.action == "authenticated"
+
+
+async def test_complete_auth_failure_when_not_authenticated():
+    store = _make_store(is_authenticated=False)
+    result = await store.complete_auth()
+    assert result.success is False
+
+
+# ── logout ────────────────────────────────────────────────────────────
+async def test_logout_delegates_to_auth():
+    store = _make_store()
+    store._auth.logout = AsyncMock(return_value=MagicMock(success=True))
+    result = await store.logout()
+    store._auth.logout.assert_awaited_once()
+    assert result.success is True
+
+
+# ── get_library ───────────────────────────────────────────────────────
+async def test_get_library_returns_none_when_not_authenticated():
+    store = _make_store()
+    store._auth.get_auth_headers = AsyncMock(return_value=None)
+    assert await store.get_library() is None
+
+
+async def test_get_library_returns_games_on_success():
+    store = _make_store()
+    fake_games = [MagicMock()]
+    store._library_reader.get_library = AsyncMock(return_value=fake_games)
+
+    result = await store.get_library()
+
+    assert result is fake_games
+    store._library_reader.get_library.assert_awaited_once()
+
+
+async def test_get_library_returns_none_on_exception():
+    store = _make_store()
+    store._library_reader.get_library = AsyncMock(side_effect=RuntimeError("boom"))
+
+    result = await store.get_library()
+
+    assert result is None
+
+
+# ── install_game ──────────────────────────────────────────────────────
+async def test_install_game_fails_fast_without_auth():
+    store = _make_store()
+    store._auth.get_auth_headers = AsyncMock(return_value=None)
+
+    result = await store.install_game("123")
+
+    assert result.success is False
+    assert result.error == "Not authenticated"
+    store._installer.install_game.assert_not_called()
+
+
+async def test_install_game_forwards_to_installer():
+    store = _make_store()
+    store._installer.install_game = AsyncMock(return_value=MagicMock(success=True))
+
+    await store.install_game("123", base_path="/games", progress_cb=None)
+
+    store._installer.install_game.assert_awaited_once()
+    _, kwargs = store._installer.install_game.call_args
+    assert kwargs["install_path"] == "/games"
+    assert kwargs["server_url"] == "https://gv.example.com"
+
+
+async def test_install_game_download_dir_precedence(monkeypatch):
+    """kwargs['download_dir'] should win over the saved auth.download_dir."""
+    store = _make_store(download_dir="/saved/dir")
+    store._installer.install_game = AsyncMock(return_value=MagicMock(success=True))
+
+    await store.install_game("123", download_dir="/override/dir")
+
+    _, kwargs = store._installer.install_game.call_args
+    assert kwargs["download_dir"] == "/override/dir"
+
+
+async def test_install_game_falls_back_to_saved_download_dir():
+    store = _make_store(download_dir="/saved/dir")
+    store._installer.install_game = AsyncMock(return_value=MagicMock(success=True))
+
+    await store.install_game("123")
+
+    _, kwargs = store._installer.install_game.call_args
+    assert kwargs["download_dir"] == "/saved/dir"
+
+
+# ── uninstall_game / update_game / check_for_updates ───────────────────
+async def test_uninstall_game_delegates_to_installer():
+    store = _make_store()
+    store._installer.uninstall_game = AsyncMock(return_value=MagicMock(success=True))
+
+    await store.uninstall_game("123")
+
+    store._installer.uninstall_game.assert_awaited_once_with("123")
+
+
+async def test_update_game_reinstalls():
+    store = _make_store()
+    store._installer.install_game = AsyncMock(return_value=MagicMock(success=True))
+
+    await store.update_game("123")
+
+    store._installer.install_game.assert_awaited_once()
+
+
+async def test_check_for_updates_always_empty():
+    store = _make_store()
+    assert await store.check_for_updates() == []
+
+
+# ── get_game_size ─────────────────────────────────────────────────────
+async def test_get_game_size_returns_none_without_auth():
+    store = _make_store()
+    store._auth.get_auth_headers = AsyncMock(return_value=None)
+    assert await store.get_game_size("123") is None
+
+
+async def test_get_game_size_forwards_to_installer():
+    store = _make_store()
+    store._installer.get_game_size = AsyncMock(return_value=1234)
+
+    result = await store.get_game_size("123")
+
+    assert result == 1234
+    store._installer.get_game_size.assert_awaited_once()
+
+
+# ── backward-compat helpers ───────────────────────────────────────────
+def test_get_install_info_delegates_to_installer():
+    store = _make_store()
+    store._installer.get_install_info.return_value = {"title": "T"}
+    assert store._get_install_info("123") == {"title": "T"}
+
+
+async def test_get_installed_delegates_to_installer():
+    store = _make_store()
+    store._installer.get_installed.return_value = {"1": {"title": "A"}}
+    result = await store.get_installed()
+    assert result == {"1": {"title": "A"}}
+
+
+# ── store_info sanity ─────────────────────────────────────────────────
+def test_store_info_declares_no_wine_and_manual_auth():
+    assert GameVaultStore.store_info.name == "gamevault"
+    assert GameVaultStore.store_info.uses_wine is False
+    assert GameVaultStore.store_info.auth_method == "manual"
+    assert GameVaultStore.store_info.supports_install is True
+    assert GameVaultStore.store_info.supports_cloud_saves is False


### PR DESCRIPTION
## Summary  This PR adds full GameVault support to UnifiDeck and fixes several stability issues found during testing.  ### New features - **GameVault store connector** (`py_modules/unifideck/stores/gamevault.py`): REST API integration with JWT Bearer auth, game listing and launch support - **GameVault credentials modal** (`src/components/GameVaultCredentialsModal.tsx`): UI for server URL, username, password  ### Bug fixes (launcher) - Fixed silent crash after UMU lookup — `resolve_proton_path` returning non-zero with `set -e` active - Fixed Proton 11 (and future versions) not being recognized — replaced hardcoded patterns with dynamic regex - Fixed repeated prefix resets on every launch for Proton 11 — `_proton_family()` now correctly returns `proton-11` instead of `other` - Fixed save backups being corrupted on second launch — now uses timestamped dirs, keeps last 3 - Fixed wrong save backup path for Ubisoft Connect games - Fixed GOG launch toast showing for all stores — now store-aware (gamevault/gog/generic) - Guarded all GOG-specific code (Galaxy stub, Comet) with `if [ "$STORE" = "gog" ]`  ### Bug fixes (metadata) - Fixed wrong game returned for titles with multiple IGDB entries (e.g. God of War 2005 vs 2018) — added PC platform (IGDB ID 6) tiebreaker, secondary tiebreaker: newer release date  ### i18n - Added `startingGameVaultGame` and `startingGame` keys to all 14 locale files