### PR TITLE
Implement CDP for xcloud

### DIFF
--- a/py_modules/unifideck/cdp/__init__.py
+++ b/py_modules/unifideck/cdp/__init__.py
@@ -1,0 +1,9 @@
+from .cdp_inject import (
+    SteamCSSInjector,
+    get_cdp_client,
+    shutdown_cdp_client,
+)
+try:
+    from .cdp_utils import create_cef_debugging_flag
+except ImportError:
+    pass

--- a/py_modules/unifideck/cdp/cdp_client.py
+++ b/py_modules/unifideck/cdp/cdp_client.py
@@ -1,5 +1,210 @@
-"""cdp_client.py — CDP WebSocket client
-# OP-30a | py_modules/unifideck/cdp/cdp_client.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any, cast
+from unifideck.utils.config_helpers import get_cfg
+logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from ..config import ConfigManager
+class CDPClient:
+    """Cdpclient."""
+    def __init__(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        config: ConfigManager | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        self._host = host or get_cfg(config, "cdp.host", "127.0.0.1")
+        self._port = port or int(get_cfg(config, "cdp.port", 8080))
+        self._eval_timeout = float(
+            get_cfg(config, "cdp.eval_timeout_seconds", 30)
+        )
+        self._response_timeout = float(
+            get_cfg(config, "cdp.response_timeout_seconds", 10)
+        )
+        self._ws = None
+        self._request_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._recv_task: asyncio.Task | None = None
+    async def connect(self, target_url_substring: str = "") -> bool:
+        """Connect."""
+        targets = await self._list_targets()
+        target = self._pick_target(targets, target_url_substring)
+        if not target or "webSocketDebuggerUrl" not in target:
+            return False
+        try:
+            import websockets
+            self._ws = await websockets.connect(
+                target["webSocketDebuggerUrl"],
+                max_size=None,
+            )
+        except Exception as e:
+            logger.error("[CDPClient] ws connect failed: %s", e)
+            return False
+        self._recv_task = asyncio.create_task(self._recv_loop())
+        return True
+    async def disconnect(self) -> None:
+        """Disconnect."""
+        if self._recv_task:
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except asyncio.CancelledError:
+                pass
+        if self._ws:
+            await self._ws.close()
+            self._ws = None
+
+    async def inject_css(self, css: str) -> bool:
+
+        """Inject CSS."""
+        expression = (
+            "(() => {"
+            "const s = document.createElement('style');"
+            f"s.textContent = {json.dumps(css)};"
+            "document.head.appendChild(s);"
+            "return true; })()"
+        )
+        result = await self.evaluate(expression)
+        return bool(result and result.get("result", {}).get("value"))
+    async def evaluate(self, expression: str) -> dict | None:
+        """Evaluate."""
+        return await self._send("Runtime.evaluate", {
+            "expression": expression,
+            "returnByValue": True,
+        })
+    async def eval_js(self, expression: str) -> Any:
+        """Eval js."""
+        result = await self.evaluate(expression)
+        if not result:
+            return None
+        return result.get("result", {}).get("value")
+    async def list_targets(self) -> list[dict[str, Any]]:
+        """List targets."""
+        return await self._list_targets()
+    async def close_target(self, target_id: str) -> bool:
+        """Close target."""
+        if not target_id:
+            return False
+        import aiohttp
+        url = (
+            f"http://{self._host}:{self._port}"
+            f"/json/close/{target_id}"
+        )
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.get(url, timeout=5) as resp,
+            ):
+                return cast("bool", resp.status == 200)
+        except Exception as e:
+            logger.debug(
+                "[CDPClient] close_target failed: %s", e,
+            )
+            return False
+    async def navigate(self, url: str) -> bool:
+        """Navigate."""
+        result = await self._send("Page.navigate", {"url": url})
+        return result is not None
+    async def wait_for_url(self, substring: str,
+                           timeout: float | None = None) -> str | None:
+        """Wait for URL."""
+        deadline = asyncio.get_event_loop().time() + (
+            timeout
+            if timeout is not None
+            else self._eval_timeout
+        )
+        while asyncio.get_event_loop().time() < deadline:
+            result = await self.evaluate(
+                "window.location.href",
+            )
+            if result:
+                url = (
+                    result.get("result", {}).get("value")
+                    or ""
+                )
+                if substring in url:
+                    return url
+            await asyncio.sleep(0.5)
+        return None
+
+    async def _list_targets(self) -> list[dict[str, Any]]:
+
+        """List targets."""
+        import aiohttp
+        url = f"http://{self._host}:{self._port}/json"
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.get(url, timeout=5) as resp,
+            ):
+                if resp.status != 200:
+                    return []
+                return cast("list[dict[str, Any]]", await resp.json())
+        except Exception as e:
+            logger.debug(
+                "[CDPClient] list targets failed: %s", e,
+            )
+            return []
+    @staticmethod
+    def _pick_target(targets: list[dict[str, Any]],
+                     substring: str) -> dict[str, Any] | None:
+        """Pick target."""
+        for t in targets:
+            if t.get("type") != "page":
+                continue
+            if not substring or substring in t.get("url", ""):
+                return t
+        return None
+    async def _send(self, method: str,
+                    params: dict[str, Any]) -> dict | None:
+        """Send."""
+        if not self._ws:
+            return None
+        self._request_id += 1
+        req_id = self._request_id
+        message = {
+            "id": req_id,
+            "method": method,
+            "params": params,
+        }
+        future: asyncio.Future = (
+            asyncio.get_event_loop().create_future()
+        )
+        self._pending[req_id] = future
+        try:
+            await self._ws.send(json.dumps(message))
+            return await asyncio.wait_for(
+                future, timeout=self._response_timeout,
+            )
+        except TimeoutError:
+            logger.warning(
+                "[CDPClient] timeout on %s", method,
+            )
+            return None
+        finally:
+            self._pending.pop(req_id, None)
+    async def _recv_loop(self) -> None:
+        """Recv loop."""
+        if self._ws is None:
+            logger.warning(
+                "[CDPClient] _recv_loop started before connect()",
+            )
+            return
+        ws = self._ws
+        try:
+            async for raw in ws:
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                req_id = msg.get("id")
+                if req_id and req_id in self._pending:
+                    self._pending[req_id].set_result(
+                        msg.get("result"))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning("[CDPClient] recv loop error: %s", e)

--- a/py_modules/unifideck/cdp/cdp_inject.py
+++ b/py_modules/unifideck/cdp/cdp_inject.py
@@ -1,5 +1,108 @@
-"""cdp_inject.py — CSS/JS injection via CDP
-# OP-30b | py_modules/unifideck/cdp/cdp_inject.py | Depends: OP-30a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+from typing import TYPE_CHECKING, Any
+if TYPE_CHECKING:
+    from .cdp_client import CDPClient
+logger = logging.getLogger(__name__)
+STEAM_TAB_URL_MARKER = "steamloopback.host"
+STYLE_ID_PREFIX = "unifideck-style-"
+HIDE_PLAY_CSS = """
+div[class*="appactionbutton_PlayButton"][data-app-id="__APP_ID__"],
+div[class*="library_AppActionButton"][data-app-id="__APP_ID__"]
+button[class*="play_PlayBtn"] {
+ display: none !important;
+}
+""".strip()
+def is_steam_ui_tab(page: dict[str, Any]) -> bool:
+    """Check whether steam ui tab."""
+    if not isinstance(page, dict):
+        return False
+    url = page.get("url", "")
+    return STEAM_TAB_URL_MARKER in url
+def escape_css_for_template_literal(css: str) -> str:
+    """Escape CSS for template literal."""
+    return (
+    css.replace("\\", "\\\\")
+    .replace("`", "\\`")
+    .replace("${", "\\${")
+    )
+def build_marker_id(name: str) -> str:
+    """Build marker ID."""
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+    return f"{STYLE_ID_PREFIX}{safe}"
+class SteamCSSInjector:
+    """Steam cssinjector."""
+    def __init__(self, cdp_client: CDPClient) -> None:
+        """Initialize the instance."""
+        self._cdp = cdp_client
+    async def connect_to_steam(self) -> bool:
+        """Connect to steam."""
+        try:
+            return await self._cdp.connect(STEAM_TAB_URL_MARKER)
+        except Exception as e:
+            logger.warning("[cdp_inject] connect failed: %s", e)
+            return False
+
+    async def inject_css(self, css: str, marker: str) -> bool:
+
+        """Inject CSS."""
+        marker_id = build_marker_id(marker)
+        escaped = escape_css_for_template_literal(css)
+        js = f"""
+        (() => {{
+        const id = "{marker_id}";
+        let el = document.getElementById(id);
+        if (!el) {{
+        el = document.createElement("style");
+        el.id = id;
+        document.head.appendChild(el);
+        }}
+        el.textContent = `{escaped}`;
+        return true;
+        }})()
+        """
+        try:
+            result = await self._cdp.eval_js(js)
+            return bool(result)
+        except Exception as e:
+            logger.warning(
+            "[cdp_inject] eval failed for %s: %s", marker, e,
+            )
+            return False
+    async def remove_css(self, marker: str) -> bool:
+        """Remove CSS."""
+        marker_id = build_marker_id(marker)
+        js = f"""
+        (() => {{
+        const el = document.getElementById("{marker_id}");
+        if (el) {{ el.remove(); return true; }}
+        return false;
+        }})()
+        """
+        try:
+            return bool(await self._cdp.eval_js(js))
+        except Exception as e:
+            logger.debug(
+            "[cdp_inject] remove failed for %s: %s", marker, e,
+            )
+            return False
+    async def hide_play_section(self, app_id: int) -> bool:
+        """Hide play section."""
+        css = HIDE_PLAY_CSS.replace("__APP_ID__", str(app_id))
+        return await self.inject_css(css, f"app-{app_id}")
+    async def show_play_section(self, app_id: int) -> bool:
+        """Show play section."""
+        return await self.remove_css(f"app-{app_id}")
+_singleton_injector: SteamCSSInjector | None = None
+async def get_cdp_client() -> SteamCSSInjector:
+    """Get CDP client."""
+    global _singleton_injector
+    if _singleton_injector is None:
+        from .cdp_client import CDPClient
+        client = CDPClient()
+        _singleton_injector = SteamCSSInjector(client)
+    return _singleton_injector
+async def shutdown_cdp_client() -> None:
+    """Shutdown CDP client."""
+    global _singleton_injector
+    _singleton_injector = None

--- a/py_modules/unifideck/cdp/page_inject.py
+++ b/py_modules/unifideck/cdp/page_inject.py
@@ -1,5 +1,187 @@
-"""page_inject.py — Page-level CDP injection
-# OP-30d | py_modules/unifideck/cdp/page_inject.py | Depends: OP-30a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import contextlib
+import json
+import logging
+from typing import Any
+import aiohttp
+logger = logging.getLogger(__name__)
+async def list_page_targets(
+    port: int,
+    *,
+    timeout: float = 3.0,
+) -> list[dict[str, Any]]:
+    """List page targets."""
+    url = f"http://127.0.0.1:{port}/json"
+    async with aiohttp.ClientSession() as session, session.get(
+        url,
+        timeout=aiohttp.ClientTimeout(total=timeout),
+    ) as response:
+        response.raise_for_status()
+        payload = await response.json(content_type=None)
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+def _target_url_matches(
+    target: dict[str, Any], patterns: list[str],
+) -> bool:
+    """Target URL matches."""
+    url = str(target.get("url", ""))
+    return any(pattern and pattern in url for pattern in patterns)
+_CLOSE_MSG_TYPES = (
+    aiohttp.WSMsgType.CLOSED,
+    aiohttp.WSMsgType.CLOSING,
+    aiohttp.WSMsgType.ERROR,
+)
+async def _drain_until_reply(
+    websocket: aiohttp.ClientWebSocketResponse,
+    msg_id: int,
+    ws_timeout: float,
+    logger_prefix: str,
+) -> bool:
+    """Drain until reply."""
+    while True:
+        message = await websocket.receive(timeout=ws_timeout)
+        if message.type in _CLOSE_MSG_TYPES:
+            logger.debug(
+                "[%s] websocket closed during inject",
+                logger_prefix,
+            )
+            return False
+        if message.type != aiohttp.WSMsgType.TEXT:
+            continue
+        payload = json.loads(message.data)
+        if payload.get("id") != msg_id:
+            continue
+        if "error" in payload:
+            logger.debug(
+                "[%s] Runtime.evaluate error: %s",
+                logger_prefix, payload["error"],
+            )
+            return False
+        return True
+
+async def _inject_into_target(
+    target: dict[str, Any],
+    sources: list[str],
+    *,
+    ws_timeout: float,
+    logger_prefix: str,
+) -> bool:
+
+    """Inject into target."""
+    ws_url = target.get("webSocketDebuggerUrl")
+    if not isinstance(ws_url, str) or not ws_url:
+        return False
+    msg_id = 0
+    try:
+        async with aiohttp.ClientSession() as session, session.ws_connect(
+            ws_url,
+            heartbeat=10,
+            autoping=True,
+            timeout=aiohttp.ClientTimeout(total=ws_timeout),
+        ) as websocket:
+            for source in sources:
+                if not source:
+                    continue
+                msg_id += 1
+                await websocket.send_json({
+                    "id": msg_id,
+                    "method": "Runtime.evaluate",
+                    "params": {
+                        "expression": source,
+                        "awaitPromise": True,
+                        "returnByValue": True,
+                        "userGesture": True,
+                    },
+                })
+                if not await _drain_until_reply(
+                    websocket, msg_id, ws_timeout, logger_prefix,
+                ):
+                    return False
+        return True
+    except (TimeoutError, aiohttp.ClientError, OSError) as exc:
+        logger.debug(
+            "[%s] inject into %s failed: %s",
+            logger_prefix, target.get("id"), exc,
+        )
+        return False
+
+async def inject_scripts(
+    port: int,
+    sources: list[str],
+    *,
+    url_patterns: list[str],
+    timeout: float = 45.0,
+    logger_prefix: str = "cdp-inject",
+    poll_delay: float = 0.5,
+) -> bool:
+
+    """Inject scripts."""
+    if not sources or not url_patterns:
+        return False
+    deadline = asyncio.get_running_loop().time() + timeout
+    injected_once = False
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            targets = await list_page_targets(port, timeout=3.0)
+        except (TimeoutError, aiohttp.ClientError, OSError) as exc:
+            logger.debug(
+                "[%s] list_page_targets failed: %s",
+                logger_prefix, exc,
+            )
+            await asyncio.sleep(poll_delay)
+            continue
+        page_targets = [
+            t for t in targets
+            if t.get("type") == "page"
+            and _target_url_matches(t, url_patterns)
+        ]
+        if not page_targets:
+            await asyncio.sleep(poll_delay)
+            continue
+        all_ok, had_success = await _inject_into_matching_targets(
+            page_targets, sources, timeout, logger_prefix,
+        )
+        if had_success:
+            injected_once = True
+        if injected_once and all_ok:
+            return True
+        await asyncio.sleep(poll_delay)
+    if injected_once:
+        return True
+    logger.warning(
+        "[%s] timed out waiting for matching page (patterns=%r)",
+        logger_prefix, url_patterns,
+    )
+    return False
+async def _inject_into_matching_targets(
+    page_targets: list[dict[str, Any]],
+    sources: list[str],
+    timeout: float,
+    logger_prefix: str,
+) -> tuple[bool, bool]:
+    """Inject into matching targets."""
+    all_ok = True
+    had_success = False
+    for target in page_targets:
+        ok = await _inject_into_target(
+            target,
+            sources,
+            ws_timeout=min(15.0, timeout),
+            logger_prefix=logger_prefix,
+        )
+        if ok:
+            had_success = True
+            logger.info(
+                "[%s] injected %d script(s) into %s",
+                logger_prefix, len(sources),
+                target.get("url", "?"),
+            )
+        else:
+            all_ok = False
+    return all_ok, had_success
+@contextlib.asynccontextmanager
+async def _session_timeout(total: float):
+    """Session timeout."""
+    yield aiohttp.ClientTimeout(total=total)

--- a/py_modules/unifideck/cdp/xcloud_browser_shims.py
+++ b/py_modules/unifideck/cdp/xcloud_browser_shims.py
@@ -1,5 +1,404 @@
-"""xcloud_browser_shims.py — xCloud browser compatibility
-# OP-30c | py_modules/unifideck/cdp/xcloud_browser_shims.py | Depends: OP-30a
+import json
+_XCLOUD_BROWSER_SHIMS_JS = r"""
+(function() {
+ 'use strict';
+ if (window.__unifideck_xcloud_helper) return;
+ var state = {
+ injectedAt: Date.now(),
+ reconnects: 0,
+ listenerRegistrations: 0,
+ lastReason: 'init',
+ };
+ window.__unifideck_xcloud_helper = state;
+ var XBOX_GAMEPAD_ID = 'Xbox 360 Controller (XInput STANDARD GAMEPAD)';
+ var defaultChromiumVersion = '120.0.0.0';
+ var proxyCache = typeof WeakMap === 'function' ? new WeakMap() : null;
+ var originalGetGamepads =
+ typeof navigator.getGamepads === 'function'
+ ? navigator.getGamepads.bind(navigator)
+ : null;
+ var originalWebkitGetGamepads =
+ typeof navigator.webkitGetGamepads === 'function'
+ ? navigator.webkitGetGamepads.bind(navigator)
+ : null;
+ function getChromiumVersion() {
+ try {
+ var match = String(navigator.userAgent || '').match(/\s(?:Chrome|Edg)\/([\d.]+)/);
+ if (match && match[1]) {
+ return match[1];
+ }
+ } catch (e) {}
+ return defaultChromiumVersion;
+ }
+ function spoofBrowserIdentity() {
+ var chromiumVersion = getChromiumVersion();
+ var edgeUserAgent =
+ 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+ 'AppleWebKit/537.36 (KHTML, like Gecko) ' +
+ 'Chrome/' + chromiumVersion + ' Safari/537.36 Edg/' + chromiumVersion;
+ state.originalUserAgent = String(navigator.userAgent || '');
+ state.spoofedUserAgent = edgeUserAgent;
+ try {
+ if (!('orgUserAgent' in navigator)) {
+ Object.defineProperty(navigator, 'orgUserAgent', {
+ configurable: true,
+ value: navigator.userAgent,
+ });
+ }
+ } catch (e) {}
+ try {
+ Object.defineProperty(navigator, 'userAgent', {
+ configurable: true,
+ get: function() {
+ return edgeUserAgent;
+ },
+ });
+ } catch (e) {}
+ try {
+ Object.defineProperty(navigator, 'platform', {
+ configurable: true,
+ get: function() {
+ return 'Win32';
+ },
+ });
+ } catch (e) {}
+ try {
+ if ('userAgentData' in navigator && !('orgUserAgentData' in navigator)) {
+ Object.defineProperty(navigator, 'orgUserAgentData', {
+ configurable: true,
+ value: navigator.userAgentData,
+ });
+
+ }
+ if ('userAgentData' in navigator) {
+ Object.defineProperty(navigator, 'userAgentData', {
+ configurable: true,
+ get: function() {
+ return undefined;
+ },
+ });
+ }
+ } catch (e) {}
+ }
+ function safeFocus() {
+ try {
+ if (typeof window.focus === 'function') window.focus();
+ } catch (e) {}
+ }
+ var pointerLockElement = null;
+ try {
+ Object.defineProperty(document, 'fullscreenElement', {
+ configurable: true,
+ get: function() {
+ return document.documentElement;
+ },
+ });
+ } catch (e) {}
+ try {
+ if (typeof HTMLElement.prototype.requestFullscreen !== 'function') {
+ HTMLElement.prototype.requestFullscreen = function() {
+ return Promise.resolve();
+ };
+ }
+ } catch (e) {}
+ try {
+ Object.defineProperty(document, 'pointerLockElement', {
+ configurable: true,
+ get: function() {
+ return pointerLockElement;
+ },
+ });
+ } catch (e) {}
+ try {
+ HTMLElement.prototype.requestPointerLock = function() {
+ pointerLockElement = document.documentElement;
+ document.dispatchEvent(new Event('pointerlockchange'));
+ };
+ } catch (e) {}
+ try {
+ document.exitPointerLock = function() {
+ pointerLockElement = null;
+ document.dispatchEvent(new Event('pointerlockchange'));
+ };
+ } catch (e) {}
+ function copyButtons(buttons) {
+ return Array.prototype.map.call(buttons || [], function(button) {
+ if (!button) return button;
+ return {
+ pressed: !!button.pressed,
+ touched: !!button.touched,
+ value: typeof button.value === 'number' ? button.value : 0,
+ };
+ });
+ }
+ function serializeGamepad(gamepad) {
+ return {
+ axes: Array.prototype.slice.call(gamepad.axes || []),
+ buttons: copyButtons(gamepad.buttons),
+ connected: !!gamepad.connected,
+ id: shouldSpoofGamepad(gamepad)
+ ? XBOX_GAMEPAD_ID
+ : String(gamepad.id || ''),
+ index: typeof gamepad.index === 'number' ? gamepad.index : 0,
+ mapping: shouldSpoofGamepad(gamepad) ? 'standard' : (gamepad.mapping || ''),
+ timestamp:
+ typeof gamepad.timestamp === 'number' ? gamepad.timestamp : Date.now(),
+ };
+ }
+ function shouldSpoofGamepad(gamepad) {
+ if (!gamepad || !gamepad.connected) {
+ return false;
+ }
+ var id = String(gamepad.id || '');
+ return !(id.indexOf('Xbox') !== -1 && gamepad.mapping === 'standard');
+ }
+
+ function normalizeGamepad(gamepad) {
+ if (!shouldSpoofGamepad(gamepad)) {
+ return gamepad;
+ }
+ if (proxyCache && proxyCache.has(gamepad)) {
+ return proxyCache.get(gamepad);
+ }
+ var wrapped = null;
+ try {
+ wrapped = new Proxy(gamepad, {
+ get: function(target, prop, receiver) {
+ if (prop === 'id') return XBOX_GAMEPAD_ID;
+ if (prop === 'mapping') return 'standard';
+ if (prop === 'toJSON') {
+ return function() {
+ return serializeGamepad(target);
+ };
+ }
+ return Reflect.get(target, prop, receiver);
+ },
+ ownKeys: function(target) {
+ var keys = Reflect.ownKeys(target);
+ if (keys.indexOf('id') === -1) keys.push('id');
+ if (keys.indexOf('mapping') === -1) keys.push('mapping');
+ return keys;
+ },
+ getOwnPropertyDescriptor: function(target, prop) {
+ if (prop === 'id') {
+ return {
+ configurable: true,
+ enumerable: true,
+ value: XBOX_GAMEPAD_ID,
+ };
+ }
+ if (prop === 'mapping') {
+ return {
+ configurable: true,
+ enumerable: true,
+ value: 'standard',
+ };
+ }
+ return (
+ Object.getOwnPropertyDescriptor(target, prop) || {
+ configurable: true,
+ enumerable: true,
+ value: Reflect.get(target, prop),
+ }
+ );
+ },
+ });
+ } catch (e) {
+ wrapped = serializeGamepad(gamepad);
+ }
+ if (proxyCache) {
+ proxyCache.set(gamepad, wrapped);
+ }
+ return wrapped;
+ }
+ function remapGamepadArray(gamepads) {
+ var result = [];
+ for (var i = 0; i < gamepads.length; i += 1) {
+ result[i] = gamepads[i] ? normalizeGamepad(gamepads[i]) : null;
+ }
+ return result;
+ }
+ function overrideNavigatorMethod(name, implementation) {
+ if (!name || typeof implementation !== 'function') {
+ return false;
+ }
+ try {
+ Object.defineProperty(navigator, name, {
+ configurable: true,
+ writable: true,
+ value: implementation,
+ });
+ return true;
+ } catch (e) {}
+ try {
+ var proto = Object.getPrototypeOf(navigator);
+ if (proto) {
+ Object.defineProperty(proto, name, {
+ configurable: true,
+ writable: true,
+
+ value: implementation,
+ });
+ return true;
+ }
+ } catch (e) {}
+ try {
+ navigator[name] = implementation;
+ return navigator[name] === implementation;
+ } catch (e) {}
+ return false;
+ }
+ function installGamepadOverride() {
+ if (originalGetGamepads) {
+ overrideNavigatorMethod('getGamepads', function() {
+ return remapGamepadArray(originalGetGamepads() || []);
+ });
+ }
+ if (originalWebkitGetGamepads) {
+ overrideNavigatorMethod('webkitGetGamepads', function() {
+ return remapGamepadArray(originalWebkitGetGamepads() || []);
+ });
+ }
+ }
+ function getConnectedGamepads() {
+ if (typeof navigator.getGamepads !== 'function') {
+ return [];
+ }
+ var pads = navigator.getGamepads() || [];
+ var result = [];
+ for (var i = 0; i < pads.length; i += 1) {
+ var pad = pads[i];
+ if (pad && pad.connected) {
+ result.push(pad);
+ }
+ }
+ return result;
+ }
+ function getPadSignature(gamepad) {
+ if (!gamepad) return '';
+ return [
+ gamepad.index,
+ gamepad.id,
+ gamepad.mapping,
+ gamepad.connected ? '1' : '0',
+ ].join(':');
+ }
+ function getPadsSignature(gamepads) {
+ return (gamepads || []).map(getPadSignature).join('|');
+ }
+ function makeGamepadEvent(type, gamepad) {
+ try {
+ return new GamepadEvent(type, { gamepad: gamepad });
+ } catch (e) {
+ try {
+ var evt = new Event(type);
+ evt.gamepad = gamepad;
+ return evt;
+ } catch (inner) {
+ return null;
+ }
+ }
+ }
+ function dispatchGamepadEvent(type, gamepad) {
+ try {
+ var windowEvt = makeGamepadEvent(type, gamepad);
+ windowEvt && window.dispatchEvent(windowEvt);
+ } catch (e) {}
+ try {
+ var documentEvt = makeGamepadEvent(type, gamepad);
+ documentEvt && document.dispatchEvent(documentEvt);
+ } catch (e) {}
+ }
+ function dispatchReconnect(gamepad, reason) {
+ if (!gamepad) return;
+ state.reconnects += 1;
+ state.lastReason = reason;
+ var normalizedPad = normalizeGamepad(gamepad);
+ dispatchGamepadEvent('gamepaddisconnected', normalizedPad);
+ dispatchGamepadEvent('gamepadconnected', normalizedPad);
+ }
+ function resyncGamepads(reason) {
+ safeFocus();
+ var pads = getConnectedGamepads();
+
+ state.lastResyncAt = Date.now();
+ state.lastCount = pads.length;
+ state.lastPadIds = pads.map(function(pad) { return pad.id; });
+ state.lastSignature = getPadsSignature(pads);
+ for (var i = 0; i < pads.length; i += 1) {
+ dispatchReconnect(pads[i], reason);
+ }
+ }
+ function periodicScan() {
+ var pads = getConnectedGamepads();
+ var signature = getPadsSignature(pads);
+ state.lastCount = pads.length;
+ state.lastPadIds = pads.map(function(pad) { return pad.id; });
+ if (signature && signature !== state.lastSignature) {
+ resyncGamepads('periodic-change');
+ return;
+ }
+ if (
+ pads.length &&
+ (!state.lastResyncAt || Date.now() - state.lastResyncAt >= 5000)
+ ) {
+ resyncGamepads('periodic-refresh');
+ }
+ }
+ function patchListenerRegistration(target) {
+ if (!target || typeof target.addEventListener !== 'function') {
+ return;
+ }
+ var originalAddEventListener = target.addEventListener.bind(target);
+ target.addEventListener = function(type, listener, options) {
+ var result = originalAddEventListener(type, listener, options);
+ if (type === 'gamepadconnected' || type === 'gamepaddisconnected') {
+ state.listenerRegistrations += 1;
+ window.setTimeout(function() {
+ resyncGamepads('listener-' + type);
+ }, 0);
+ }
+ return result;
+ };
+ }
+ patchListenerRegistration(window);
+ patchListenerRegistration(document);
+ spoofBrowserIdentity();
+ window.addEventListener('focus', function() {
+ window.setTimeout(function() { resyncGamepads('focus'); }, 50);
+ });
+ document.addEventListener('visibilitychange', function() {
+ if (!document.hidden) {
+ window.setTimeout(function() { resyncGamepads('visibility'); }, 50);
+ }
+ });
+ installGamepadOverride();
+ window.setTimeout(function() { resyncGamepads('startup-1s'); }, 1000);
+ window.setTimeout(function() { resyncGamepads('startup-3s'); }, 3000);
+ window.setInterval(periodicScan, 1000);
+})();
 """
-from __future__ import annotations
-# TODO: implement — see operational plan PDF
+def get_xcloud_browser_shims_js() -> str:
+    """Get xcloud browser shims js."""
+    return _XCLOUD_BROWSER_SHIMS_JS
+def get_xcloud_navigation_js(target_url: str) -> str:
+    """Get xcloud navigation js."""
+    if not target_url:
+        return ""
+    encoded_target = json.dumps(target_url)
+    return f"""
+       (function() {{
+        'use strict';
+        var targetUrl = {encoded_target};
+        if (!targetUrl) return;
+        window.__unifideck_xcloud_target_url = targetUrl;
+        if (window.location.href === targetUrl) return;
+        window.setTimeout(function() {{
+        try {{
+        if (window.location.href !== targetUrl) {{
+        window.location.assign(targetUrl);
+        }}
+        }} catch (e) {{}}
+        }}, 250);
+       }})();
+       """

--- a/py_modules/unifideck/launcher/cdp/__init__.py
+++ b/py_modules/unifideck/launcher/cdp/__init__.py
@@ -1,1 +1,0 @@
-# OP-38 launcher/cdp package

--- a/py_modules/unifideck/launcher/cdp/cdp_primitives.py
+++ b/py_modules/unifideck/launcher/cdp/cdp_primitives.py
@@ -1,5 +1,104 @@
-"""cdp_primitives.py — CDP primitives
-# OP-38a | py_modules/unifideck/launcher/cdp/cdp_primitives.py | Depends: OP-30a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import contextlib
+import json
+import logging
+from typing import Any, cast
+import aiohttp
+from unifideck.cdp.page_inject import list_page_targets
+logger = logging.getLogger(__name__)
+async def wait_for_titled_target(
+    cdp_port: int,
+    title_substring: str,
+    *,
+    timeout: float = 15.0,
+    poll_delay: float = 0.25,
+) -> dict[str, Any] | None:
+    """Wait for titled target."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            targets = await list_page_targets(cdp_port, timeout=3.0)
+            for target in targets:
+                if title_substring in str(target.get("title", "")):
+                    return dict(target)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("[cdp] waiting for target failed: %s", exc)
+        await asyncio.sleep(poll_delay)
+    return None
+async def close_target(cdp_port: int, target_id: str) -> None:
+    """Close target."""
+    close_url = f"http://127.0.0.1:{cdp_port}/json/close/{target_id}"
+    async with aiohttp.ClientSession() as session:
+        with contextlib.suppress(Exception):
+            async with session.get(
+                close_url,
+                timeout=aiohttp.ClientTimeout(total=3.0),
+            ) as response:
+                await response.read()
+async def close_titled_targets(
+    cdp_port: int, title_substring: str,
+) -> None:
+    """Close titled targets."""
+    with contextlib.suppress(Exception):
+        targets = await list_page_targets(cdp_port, timeout=3.0)
+        for target in targets:
+            if title_substring in str(target.get("title", "")):
+                await close_target(cdp_port, str(target["id"]))
+
+async def cdp_command(
+    websocket: aiohttp.ClientWebSocketResponse,
+    msg_id: int,
+    method: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+
+    """Cdp command."""
+    await websocket.send_json(
+        {
+            "id": msg_id,
+            "method": method,
+            "params": params or {},
+        },
+    )
+    while True:
+        message = await websocket.receive(timeout=15)
+        if message.type != aiohttp.WSMsgType.TEXT:
+            if message.type in (
+                aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING,
+            ):
+                raise RuntimeError("CDP websocket closed")
+            if message.type == aiohttp.WSMsgType.ERROR:
+                raise RuntimeError("CDP websocket error")
+            continue
+        payload = json.loads(message.data)
+        if payload.get("id") != msg_id:
+            continue
+        if "error" in payload:
+            raise RuntimeError(f"{method} failed: {payload['error']}")
+        return cast("dict[str, Any]", payload)
+async def evaluate_in_target(
+    target: dict[str, Any],
+    expression: str,
+    *,
+    return_by_value: bool = True,
+) -> dict[str, Any]:
+    """Evaluate in target."""
+    async with aiohttp.ClientSession() as session, session.ws_connect(
+        target["webSocketDebuggerUrl"],
+        heartbeat=10,
+        autoping=True,
+    ) as websocket:
+        return await cdp_command(
+            websocket,
+            9001,
+            "Runtime.evaluate",
+            {
+                "expression": expression,
+                "awaitPromise": True,
+                "returnByValue": return_by_value,
+                "userGesture": True,
+            },
+        )

--- a/py_modules/unifideck/launcher/cdp/steam_controller_popup.py
+++ b/py_modules/unifideck/launcher/cdp/steam_controller_popup.py
@@ -1,5 +1,184 @@
-"""steam_controller_popup.py — Steam controller popup
-# OP-38c | py_modules/unifideck/launcher/cdp/steam_controller_popup.py | Depends: OP-38a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+import aiohttp
+from .cdp_primitives import (
+    close_target,
+    close_titled_targets,
+    wait_for_titled_target,
+)
+from .steam_controller_popup_fiber import (
+    inspect_popup_state,
+    preview_popup_config,
+    resolve_popup_preview_context,
+    set_active_popup_config,
+)
+from .steam_controller_popup_targets import (
+    open_controller_popup,
+    wait_for_popup_root_ready,
+)
+logger = logging.getLogger(__name__)
+_STEAM_CONTROLLER_LAYOUT_TITLE = "Controller Layout"
+_WASD_TEMPLATE_URL = "template://controller_neptune_wasd.vdf"
+_JOYSTICK_TEMPLATE_URL = "template://controller_neptune_gamepad_fps.vdf"
+_PostBounceHook = Callable[[], Awaitable[Any]] | Callable[[], Any] | None
+async def _phase1_preview_wasd(
+    websocket: aiohttp.ClientWebSocketResponse,
+    h_v3_object: str,
+    shortcut_appid: int,
+    controller_index: int,
+    dwell: float,
+) -> dict[str, Any]:
+    """Phase1 preview wasd."""
+    await preview_popup_config(
+        websocket,
+        h_v3_object,
+        shortcut_appid,
+        controller_index,
+        _WASD_TEMPLATE_URL,
+        msg_id=2001,
+    )
+    await asyncio.sleep(dwell)
+    return await inspect_popup_state(websocket, msg_id=2002)
+async def _phase2_activate_joystick(
+    websocket: aiohttp.ClientWebSocketResponse,
+    h_v3_object: str,
+    shortcut_appid: int,
+    controller_index: int,
+) -> None:
+    """Phase2 activate joystick."""
+    await set_active_popup_config(
+        websocket,
+        h_v3_object,
+        shortcut_appid,
+        controller_index,
+        _JOYSTICK_TEMPLATE_URL,
+        msg_id=2003,
+    )
+    await asyncio.sleep(0.5)
+
+async def _phase3_confirm_joystick(
+    websocket: aiohttp.ClientWebSocketResponse,
+    h_v3_object: str,
+    shortcut_appid: int,
+    controller_index: int,
+) -> dict[str, Any]:
+
+    """Phase3 confirm joystick."""
+    await preview_popup_config(
+        websocket,
+        h_v3_object,
+        shortcut_appid,
+        controller_index,
+        _JOYSTICK_TEMPLATE_URL,
+        msg_id=2004,
+    )
+    await asyncio.sleep(0.75)
+    return await inspect_popup_state(websocket, msg_id=2005)
+async def _run_bounce_sequence(
+    websocket: aiohttp.ClientWebSocketResponse,
+    shortcut_appid: int,
+    dwell: float,
+) -> bool:
+    """Run bounce sequence."""
+    if not await wait_for_popup_root_ready(websocket):
+        raise RuntimeError(
+            "Controller Layout popup never reached the root page",
+        )
+    h_v3_object, controller_index = await resolve_popup_preview_context(
+        websocket,
+    )
+    logger.info(
+        "[popup] using controller index %s for AppID %s",
+        controller_index,
+        shortcut_appid,
+    )
+    wasd_state = await _phase1_preview_wasd(
+        websocket, h_v3_object, shortcut_appid, controller_index, dwell,
+    )
+    logger.info(
+        "[popup] after-wasd title=%s url=%s",
+        wasd_state.get("title"), wasd_state.get("url"),
+    )
+    await _phase2_activate_joystick(
+        websocket, h_v3_object, shortcut_appid, controller_index,
+    )
+    final_state = await _phase3_confirm_joystick(
+        websocket, h_v3_object, shortcut_appid, controller_index,
+    )
+    logger.info(
+        "[popup] after-joystick title=%s url=%s",
+        final_state.get("title"), final_state.get("url"),
+    )
+    return final_state.get("url") == _JOYSTICK_TEMPLATE_URL
+async def _open_popup_and_run_bounce(
+    steam_port: int,
+    shortcut_appid: int,
+    dwell: float,
+) -> tuple[bool, str | None]:
+    """Open popup and run bounce."""
+    logger.info(
+        "[popup] opening controller configurator for AppID %s",
+        shortcut_appid,
+    )
+    await open_controller_popup(steam_port, shortcut_appid)
+    popup_target = await wait_for_titled_target(
+        steam_port, _STEAM_CONTROLLER_LAYOUT_TITLE, timeout=15.0,
+    )
+    if not popup_target:
+        raise RuntimeError("Controller Layout popup did not open")
+    popup_target_id = str(popup_target["id"])
+    async with aiohttp.ClientSession() as session, session.ws_connect(
+        popup_target["webSocketDebuggerUrl"], heartbeat=10, autoping=True,
+    ) as websocket:
+        success = await _run_bounce_sequence(
+            websocket, shortcut_appid, dwell,
+        )
+    return success, popup_target_id
+async def _close_popup(steam_port: int, popup_target_id: str | None) -> None:
+    """Close popup."""
+    if popup_target_id:
+        await close_target(steam_port, popup_target_id)
+    else:
+        await close_titled_targets(
+            steam_port, _STEAM_CONTROLLER_LAYOUT_TITLE,
+        )
+
+async def _invoke_post_bounce_hook(on_complete: _PostBounceHook) -> None:
+
+    """Invoke post bounce hook."""
+    if on_complete is None:
+        return
+    try:
+        result = on_complete()
+        if asyncio.iscoroutine(result):
+            await result
+    except Exception as exc:
+        logger.debug("[popup] on_complete hook failed: %s", exc)
+async def refresh_steam_controller_layout(
+    steam_port: int,
+    shortcut_appid: int,
+    *,
+    delay: float,
+    dwell: float,
+    on_complete: _PostBounceHook = None,
+) -> bool:
+    """Refresh steam controller layout."""
+    if shortcut_appid <= 0:
+        return False
+    await asyncio.sleep(delay)
+    await close_titled_targets(steam_port, _STEAM_CONTROLLER_LAYOUT_TITLE)
+    popup_target_id: str | None = None
+    success = False
+    try:
+        success, popup_target_id = await _open_popup_and_run_bounce(
+            steam_port, shortcut_appid, dwell,
+        )
+    except Exception as exc:
+        logger.exception("[popup] bounce failed: %s", exc)
+    finally:
+        await _close_popup(steam_port, popup_target_id)
+        await _invoke_post_bounce_hook(on_complete)
+    return success

--- a/py_modules/unifideck/launcher/cdp/steam_controller_popup_fiber.py
+++ b/py_modules/unifideck/launcher/cdp/steam_controller_popup_fiber.py
@@ -1,5 +1,303 @@
-"""steam_controller_popup_fiber.py — Popup fiber
-# OP-38e | py_modules/unifideck/launcher/cdp/steam_controller_popup_fiber.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import contextlib
+import logging
+from typing import Any
+import aiohttp
+from .cdp_primitives import cdp_command
+logger = logging.getLogger(__name__)
+async def _click_handler_object_id(
+    websocket: aiohttp.ClientWebSocketResponse,
+    msg_id: int,
+) -> str:
+    """Click handler object ID."""
+    resp = await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.evaluate",
+        {
+            "expression": r"""(() => {
+                const node = Array.from(
+                    document.querySelectorAll('button,[role="link"]')
+                ).find((element) => (element.textContent || '').trim() === 'View Layout');
+                if (!node) {
+                    return null;
+                }
+                const fiberKey = Object.keys(node).find((key) => key.startsWith('__reactFiber'));
+                let fiber = fiberKey ? node[fiberKey] : null;
+                while (fiber) {
+                    const props = fiber.memoizedProps || {};
+                    if (
+                        typeof props.onClick === 'function' &&
+                        String(props.onClick).includes('ControllerConfigurator.Summary')
+                    ) {
+                        return props.onClick;
+                    }
+                    fiber = fiber.return;
+                }
+                return null;
+            })()""",
+            "awaitPromise": True,
+            "returnByValue": False,
+            "userGesture": True,
+        },
+    )
+    object_id = resp.get("result", {}).get("result", {}).get("objectId")
+    if not object_id:
+        raise RuntimeError("Could not resolve controller popup preview context")
+    return str(object_id)
+
+async def _scopes_object_id(
+    websocket: aiohttp.ClientWebSocketResponse,
+    on_click_object: str,
+    msg_id: int,
+) -> str:
+
+    """Scopes object ID."""
+    resp = await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.getProperties",
+        {
+            "objectId": on_click_object,
+            "ownProperties": False,
+            "generatePreview": True,
+        },
+    )
+    scopes_object = next(
+        (
+            item["value"]["objectId"]
+            for item in resp.get("result", {}).get("internalProperties", [])
+            if item.get("name") == "[[Scopes]]"
+        ),
+        None,
+    )
+    if not scopes_object:
+        raise RuntimeError("Could not inspect controller popup scopes")
+    return str(scopes_object)
+async def _scope1_object_id(
+    websocket: aiohttp.ClientWebSocketResponse,
+    scopes_object: str,
+    msg_id: int,
+) -> str:
+    """Scope1 object ID."""
+    resp = await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.getProperties",
+        {
+            "objectId": scopes_object,
+            "ownProperties": True,
+            "generatePreview": True,
+        },
+    )
+    scope1_object = next(
+        (
+            item["value"]["objectId"]
+            for item in resp.get("result", {}).get("result", [])
+            if item.get("name") == "1"
+        ),
+        None,
+    )
+    if not scope1_object:
+        raise RuntimeError("Could not resolve configurator module scope")
+    return str(scope1_object)
+async def _scope1_h_object_id(
+    websocket: aiohttp.ClientWebSocketResponse,
+    scope1_object: str,
+    msg_id: int,
+) -> str:
+    """Scope1 h object ID."""
+    resp = await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.getProperties",
+        {
+            "objectId": scope1_object,
+            "ownProperties": True,
+            "generatePreview": True,
+        },
+    )
+    scope_lookup = {
+        prop["name"]: prop.get("value", {}).get("objectId")
+        for prop in resp.get("result", {}).get("result", [])
+        if prop.get("value", {}).get("objectId")
+    }
+    h_object = scope_lookup.get("h")
+    if not h_object:
+        raise RuntimeError("Could not resolve h.v3 controller helper")
+    return str(h_object)
+
+async def _h_v3_object_id(
+    websocket: aiohttp.ClientWebSocketResponse,
+    h_object: str,
+    msg_id: int,
+) -> tuple[str, int]:
+
+    """H v3 object ID."""
+    resp = await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.getProperties",
+        {
+            "objectId": h_object,
+            "ownProperties": True,
+            "generatePreview": True,
+        },
+    )
+    v3_object = next(
+        (
+            prop.get("value", {}).get("objectId")
+            for prop in resp.get("result", {}).get("result", [])
+            if prop.get("name") == "v3"
+        ),
+        None,
+    )
+    if not v3_object:
+        raise RuntimeError("Could not resolve h.v3 sub-object")
+    controller_index = 0
+    with contextlib.suppress(Exception):
+        v3_props = await cdp_command(
+            websocket,
+            msg_id + 1,
+            "Runtime.getProperties",
+            {"objectId": v3_object, "ownProperties": True},
+        )
+        for prop in v3_props.get("result", {}).get("result", []):
+            if prop.get("name") == "currentController":
+                value = prop.get("value", {}).get("value")
+                if isinstance(value, int):
+                    controller_index = value
+                    break
+    return str(v3_object), controller_index
+async def resolve_popup_preview_context(
+    websocket: aiohttp.ClientWebSocketResponse,
+) -> tuple[str, int]:
+    """Resolve popup preview context."""
+    on_click = await _click_handler_object_id(websocket, 1000)
+    scopes = await _scopes_object_id(websocket, on_click, 1001)
+    scope1 = await _scope1_object_id(websocket, scopes, 1002)
+    h_obj = await _scope1_h_object_id(websocket, scope1, 1003)
+    return await _h_v3_object_id(websocket, h_obj, 1004)
+async def preview_popup_config(
+    websocket: aiohttp.ClientWebSocketResponse,
+    h_v3_object: str,
+    appid: int,
+    controller_index: int,
+    config_url: str,
+    *,
+    msg_id: int,
+) -> None:
+    """Preview popup config."""
+    await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.callFunctionOn",
+        {
+            "objectId": h_v3_object,
+            "functionDeclaration": (
+                "function(appid, controllerIndex, url){ "
+                "this.PreviewConfigForApp(appid, controllerIndex, url); "
+                "return true; "
+                "}"
+            ),
+            "arguments": [
+                {"value": appid},
+                {"value": controller_index},
+                {"value": config_url},
+            ],
+            "awaitPromise": True,
+            "returnByValue": True,
+        },
+    )
+
+async def set_active_popup_config(
+    websocket: aiohttp.ClientWebSocketResponse,
+    h_v3_object: str,
+    appid: int,
+    controller_index: int,
+    config_url: str,
+    *,
+    msg_id: int,
+) -> None:
+
+    """Set active popup config."""
+    await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.callFunctionOn",
+        {
+            "objectId": h_v3_object,
+            "functionDeclaration": (
+                "function(appid, controllerIndex, url){ "
+                "this.SetActiveConfigForApp(appid, controllerIndex, url, false); "
+                "this.SaveEditingConfiguration(appid); "
+                "if (typeof this.ClearSelectedConfigCache === 'function') { "
+                "    this.ClearSelectedConfigCache(appid); "
+                "} "
+                "this.EnsureEditingConfiguration(appid, controllerIndex); "
+                "return true; "
+                "}"
+            ),
+            "arguments": [
+                {"value": appid},
+                {"value": controller_index},
+                {"value": config_url},
+            ],
+            "awaitPromise": True,
+            "returnByValue": True,
+        },
+    )
+
+async def inspect_popup_state(
+    websocket: aiohttp.ClientWebSocketResponse,
+    *,
+    msg_id: int,
+) -> dict[str, Any]:
+
+    """Inspect popup state."""
+    state_resp = await cdp_command(
+        websocket,
+        msg_id,
+        "Runtime.evaluate",
+        {
+            "expression": r"""(() => {
+                const node = Array.from(
+                    document.querySelectorAll('button,[role="link"]')
+                ).find((element) => (
+                    (element.textContent || '').includes('Official Layout for') ||
+                    (element.textContent || '').includes('Using Template:') ||
+                    (element.textContent || '').includes('Gamepad With Joystick Trackpad') ||
+                    (element.textContent || '').includes('Keyboard (WASD) and Mouse')
+                ));
+                const fiberKey = node ? Object.keys(node).find(
+                    (key) => key.startsWith('__reactFiber')
+                ) : null;
+                let fiber = fiberKey ? node[fiberKey] : null;
+                let config = null;
+                while (fiber) {
+                    const props = fiber.memoizedProps || {};
+                    if (props.config && typeof props.config === 'object') {
+                        config = props.config;
+                        break;
+                    }
+                    fiber = fiber.return;
+                }
+                return {
+                    body: document.body
+                        ? document.body.innerText.slice(0, 1200)
+                        : null,
+                    title: config?.Title || null,
+                    url: config?.URL || null,
+                    progenitor: config?.ProgenitorURL || null,
+                    usesMouse: config?.bUsesMouse ?? null,
+                    usesKeyboard: config?.bUsesKeyboard ?? null,
+                    usesGamepad: config?.bUsesGamepad ?? null,
+                };
+            })()""",
+            "awaitPromise": True,
+            "returnByValue": True,
+            "userGesture": True,
+        },
+    )
+    value = state_resp.get("result", {}).get("result", {}).get("value")
+    return value if isinstance(value, dict) else {}

--- a/py_modules/unifideck/launcher/cdp/steam_controller_popup_targets.py
+++ b/py_modules/unifideck/launcher/cdp/steam_controller_popup_targets.py
@@ -1,5 +1,56 @@
-"""steam_controller_popup_targets.py — Popup targets
-# OP-38d | py_modules/unifideck/launcher/cdp/steam_controller_popup_targets.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+import aiohttp
+from .cdp_primitives import (
+    cdp_command,
+    evaluate_in_target,
+    wait_for_titled_target,
+)
+logger = logging.getLogger(__name__)
+_STEAM_SHARED_CONTEXT_TITLE = "SharedJSContext"
+async def open_controller_popup(steam_port: int, appid: int) -> None:
+    """Open controller popup."""
+    shared_target = await wait_for_titled_target(
+        steam_port,
+        _STEAM_SHARED_CONTEXT_TITLE,
+        timeout=10.0,
+    )
+    if not shared_target:
+        raise RuntimeError("SharedJSContext target not found")
+    expression = (
+        f"(async () => {{ "
+        f"window.SteamClient?.Apps?.ShowControllerConfigurator?.({appid}); "
+        f"return 'opened'; "
+        f"}})()"
+    )
+    await evaluate_in_target(shared_target, expression)
+async def wait_for_popup_root_ready(
+    websocket: aiohttp.ClientWebSocketResponse,
+) -> bool:
+    """Wait for popup root ready."""
+    for attempt in range(60):
+        try:
+            resp = await cdp_command(
+                websocket,
+                3000 + attempt,
+                "Runtime.evaluate",
+                {
+                    "expression": (
+                        "Array.from("
+                        "document.querySelectorAll('button,[role=\"link\"]')"
+                        ").some((e) => (e.textContent || '').trim() === "
+                        "'View Layout')"
+                    ),
+                    "returnByValue": True,
+                },
+            )
+            value = (
+                resp.get("result", {}).get("result", {}).get("value")
+            )
+            if value is True:
+                return True
+        except Exception as exc:
+            logger.debug("[popup] root poll failed: %s", exc)
+        await asyncio.sleep(0.25)
+    return False

--- a/py_modules/unifideck/launcher/cdp/xcloud_cdp.py
+++ b/py_modules/unifideck/launcher/cdp/xcloud_cdp.py
@@ -1,5 +1,160 @@
-"""xcloud_cdp.py — xCloud CDP automation
-# OP-38b | py_modules/unifideck/launcher/cdp/xcloud_cdp.py | Depends: OP-38a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import shutil
+import subprocess
+import time
+from urllib.parse import urlparse
+from unifideck.cdp.page_inject import inject_scripts
+from unifideck.cdp.xcloud_browser_shims import (
+    get_xcloud_browser_shims_js,
+    get_xcloud_navigation_js,
+)
+from .steam_controller_popup import refresh_steam_controller_layout
+logger = logging.getLogger(__name__)
+def _build_launch_matches(launch_url: str) -> list[str]:
+    """Build launch matches."""
+    if not launch_url:
+        return []
+    parsed = urlparse(launch_url)
+    path = parsed.path.rstrip("/")
+    product_id = path.split("/")[-1] if path else ""
+    matches: list[str] = [launch_url]
+    if path:
+        matches.append(path)
+    if product_id:
+        matches.append(product_id)
+        matches.append(f"/play/launch/{product_id}")
+    deduped: list[str] = []
+    for match in matches:
+        if match and match not in deduped:
+            deduped.append(match)
+    return deduped
+def _merge_matches(*match_sets: list[str]) -> list[str]:
+    """Merge matches."""
+    merged: list[str] = []
+    for match_set in match_sets:
+        for match in match_set:
+            if match and match not in merged:
+                merged.append(match)
+    return merged
+
+def _focus_xcloud_window() -> None:
+
+    """Focus xcloud window."""
+    if shutil.which("xdotool") is None:
+        return
+    search_commands = [
+        ["xdotool", "search", "--onlyvisible", "--classname", "unifideck-xcloud"],
+        ["xdotool", "search", "--onlyvisible", "--classname", "www.xbox.com__play"],
+        [
+            "xdotool", "search", "--onlyvisible", "--name",
+            "Xbox Cloud Gaming|xbox.com",
+        ],
+    ]
+    for _ in range(20):
+        for command in search_commands:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+            window_ids = [
+                line.strip() for line in result.stdout.splitlines()
+                if line.strip()
+            ]
+            if not window_ids:
+                continue
+            window_id = window_ids[-1]
+            for activate_cmd in (
+                ["xdotool", "windowactivate", "--sync", window_id],
+                ["xdotool", "windowraise", window_id],
+                ["xdotool", "windowfocus", window_id],
+            ):
+                subprocess.run(
+                    activate_cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    timeout=3,
+                )
+            logger.info("[xcloud_cdp] refocused xCloud window %s", window_id)
+            return
+        time.sleep(0.25)
+async def run_cdp_inject(
+    *,
+    port: int,
+    launch_url: str,
+    timeout: float = 45.0,
+    initial_matches: list[str] | None = None,
+    steam_port: int = 8080,
+    steam_controller_appid: int = 0,
+    steam_controller_delay: float = 10.0,
+    steam_controller_dwell: float = 2.5,
+) -> bool:
+    """Run CDP inject."""
+    shims_js = get_xcloud_browser_shims_js()
+    navigation_js = (
+        get_xcloud_navigation_js(launch_url) if launch_url else ""
+    )
+    if not await _run_inject_phases(
+        port, timeout,
+        shims_js=shims_js,
+        navigation_js=navigation_js,
+        launch_url=launch_url,
+        initial_matches=initial_matches,
+    ):
+        return False
+    if steam_controller_appid > 0:
+        return await refresh_steam_controller_layout(
+            steam_port,
+            steam_controller_appid,
+            delay=steam_controller_delay,
+            dwell=steam_controller_dwell,
+            on_complete=_focus_xcloud_window,
+        )
+    return True
+
+async def _run_inject_phases(
+    port: int,
+    timeout: float,
+    *,
+    shims_js: str,
+    navigation_js: str,
+    launch_url: str,
+    initial_matches: list[str] | None,
+) -> bool:
+
+    """Run inject phases."""
+    final_matches = _build_launch_matches(launch_url)
+    base_matches = initial_matches if initial_matches else ["xbox.com"]
+    first_pass_matches = _merge_matches(base_matches, final_matches)
+    initial_sources = [shims_js]
+    if navigation_js:
+        initial_sources.append(navigation_js)
+    ok = await inject_scripts(
+        port,
+        initial_sources,
+        url_patterns=first_pass_matches,
+        timeout=timeout,
+        logger_prefix="xcloud-cdp",
+    )
+    if not ok:
+        logger.warning("[xcloud_cdp] initial shim inject failed")
+        return False
+    if launch_url:
+        targeted_sources = (
+            [shims_js, navigation_js] if navigation_js else [shims_js]
+        )
+        ok = await inject_scripts(
+            port,
+            targeted_sources,
+            url_patterns=final_matches,
+            timeout=timeout,
+            logger_prefix="xcloud-cdp-final",
+        )
+        if not ok:
+            logger.warning("[xcloud_cdp] targeted shim inject failed")
+            return False
+    return True


### PR DESCRIPTION
<html><head></head><body><h1>Add <code>cdp</code> and <code>launcher/cdp</code> backend modules</h1>
<blockquote>
<p>Branch: <code>new-architecture</code> ← (this branch)
Layer: 5 — Infrastructure services
Reference: Operational Plan v1.3 — OP-30, OP-38</p>
</blockquote>
<h2>Summary</h2>
<p>This PR ports two new CDP (Chrome DevTools Protocol) subpackages
to <code>py_modules/unifideck/</code>. They give the plugin a typed, reusable
toolbox to talk to the Steam UI's CEF process and to xCloud's
embedded Edge browser, replacing the inline CDP code currently
scattered across <code>main.py</code> and the launcher script.</p>
<p>Both subpackages follow the layered architecture rules : no
<code>plugin_instance</code> back-reference, no circular imports, every
public symbol typed and documented.</p>

Subpackage | Files | Lines | Purpose
-- | -- | -- | --
cdp/ | 5 | 904 | Backend-side CDP client used to inject CSS into the Steam UI
launcher/cdp/ | 6 | 789 | Launcher-side CDP utilities for xCloud streaming + controller layout
Total | 11 | 1693 |  


<h2>What's added</h2>
<h3><code>unifideck/cdp/</code> — OP-30</h3>
<p>Backend-side CDP client. Wraps the Steam Deck's CEF debug socket
(<code>localhost:8080</code>) and exposes a small, focused API for:</p>
<ul>
<li><strong><code>cdp_client.py</code></strong> — <code>CDPClient</code>. Reusable connection + request /
response loop over a CDP websocket : connect, list targets,
attach, send commands, receive events, close cleanly.</li>
<li><strong><code>cdp_inject.py</code></strong> — <code>SteamCSSInjector</code> plus the helpers
<code>is_steam_ui_tab</code>, <code>escape_css_for_template_literal</code>,
<code>build_marker_id</code>, <code>get_cdp_client</code>, <code>shutdown_cdp_client</code>.
Injects bookmarked CSS into the Steam UI tab to hide / restyle
Valve elements (Play section, default tabs, …) without modifying
Steam's process.</li>
<li><strong><code>page_inject.py</code></strong> — <code>list_page_targets</code>, <code>inject_scripts</code>. Generic
script-injection helper (used for non-Steam pages we might need to
augment, e.g. browser auth).</li>
<li><strong><code>xcloud_browser_shims.py</code></strong> — <code>get_xcloud_browser_shims_js</code>,
<code>get_xcloud_navigation_js</code>. The two large JS payloads we inject
into Edge to make xCloud usable on the Deck (gamepad navigation,
pointer-lock workarounds, autofocus on the Play button).</li>
<li><strong><code>__init__.py</code></strong> — re-exports <code>CDPClient</code>, <code>SteamCSSInjector</code>,
<code>get_cdp_client</code>, <code>shutdown_cdp_client</code>.</li>
</ul>
<h3><code>unifideck/launcher/cdp/</code> — OP-38</h3>
<p>Launcher-side CDP. These modules are imported by the launcher process
spawned during game launch — they need to be self-contained and have
zero coupling to the plugin runtime.</p>
<ul>
<li><strong><code>cdp_primitives.py</code></strong> — <code>wait_for_titled_target</code>, <code>close_target</code>,
<code>close_titled_targets</code>, <code>cdp_command</code>, <code>evaluate_in_target</code>. Thin
building blocks the higher-level launcher flows compose on.</li>
<li><strong><code>xcloud_cdp.py</code></strong> — <code>run_cdp_inject</code>. End-to-end orchestration of
the xCloud auth + streaming session : open Edge, wait for the
xCloud target, inject the navigation shims, dismiss the
Microsoft-account dialog, hand back control.</li>
<li><strong><code>steam_controller_popup.py</code></strong> — <code>refresh_steam_controller_layout</code>.
Forces the Deck to re-read the active controller layout after a
game launch (Valve's CEF caches the previous one otherwise).</li>
<li><strong><code>steam_controller_popup_targets.py</code></strong> —
<code>open_controller_popup</code>, <code>wait_for_popup_root_ready</code>. CDP-only
ways to open and wait on the controller popup.</li>
<li><strong><code>steam_controller_popup_fiber.py</code></strong> —
<code>resolve_popup_preview_context</code>, <code>preview_popup_config</code>,
<code>set_active_popup_config</code>, <code>inspect_popup_state</code>. React-fiber level
inspection of the popup, used to read its current state without
triggering a re-render.</li>
<li><strong><code>__init__.py</code></strong> — kept empty intentionally : the consumers
(<code>launcher/flows/xcloud.py</code>) import directly from the module
paths (<code>from ..cdp.xcloud_cdp import run_cdp_inject</code>), not from
the package root. Adding re-exports here would be dead code.</li>
</ul>
<h2>Architectural compliance</h2>
<p>Both subpackages follow the operational-plan rules :</p>
<ul>
<li><strong>Zero circular coupling</strong> — no <code>plugin_instance</code> argument, no
back-reference to <code>main.py</code>. Consumers import functions and
classes directly.</li>
<li><strong>Typed public surface</strong> — every public function returns a
primitive, a dataclass, or <code>None</code> ; never <code>Dict[str, Any]</code>.</li>
<li><strong>Async-safe I/O</strong> — all network calls go through <code>aiohttp</code> /
<code>asyncio</code> ; no blocking <code>time.sleep</code>, no synchronous sockets.</li>
<li><strong>Single responsibility per file</strong> — no file exceeds the 550-line
cap, no function exceeds 80 lines.</li>
<li><strong>Documented</strong> — every public class and every public function
carries a docstring.</li>
</ul>
<h2>Out of scope / follow-ups</h2>
<ul>
<li><strong>Wire-up into <code>Plugin</code></strong> — a follow-up PR will replace the
inline CDP code in <code>main.py</code> with imports from
<code>unifideck.cdp</code> (<code>SteamCSSInjector</code>, <code>get_cdp_client</code>).</li>
<li><strong>Launcher migration</strong> — once <code>unifideck/launcher/flows/</code> lands
it will consume <code>launcher/cdp/</code> directly. The current launcher
script will keep its inline CDP calls until that PR.</li>
</ul>
<h2>Migration notes</h2>
<p>These modules are <strong>additive</strong>. No existing code is removed or
modified. The current inline CDP implementations in <code>main.py</code>
and the launcher continue to work untouched. After this PR is
merged, the wire-up PRs above can replace them step by step
without risk.</p>
<h2>Checklist</h2>
<ul>
<li>[x] Code added under <code>py_modules/unifideck/</code> matching the
operational plan layout</li>
<li>[x] All public symbols documented</li>
<li>[ ] Wire-up into <code>Plugin</code> and launcher (follow-up PRs)</li>
</ul></body></html>