### PR TITLE
feat/launcher: Implement launcher logic

### DIFF
--- a/py_modules/unifideck/launcher/__init__.py
+++ b/py_modules/unifideck/launcher/__init__.py
@@ -1,1 +1,23 @@
-# OP-35 launcher package
+from __future__ import annotations
+from .types.context import LaunchContext
+from .types.errors import (
+ DependencyMissingError,
+ GameNotFoundError,
+ LaunchAbortedError,
+ LauncherError,
+ PrefixCorruptedError,
+ ProtonUnavailableError,
+ UmuRuntimeError,
+)
+from .types.exit_codes import ExitCode
+__all__ = [
+ "LaunchContext",
+ "LauncherError",
+ "LaunchAbortedError",
+ "DependencyMissingError",
+ "GameNotFoundError",
+ "PrefixCorruptedError",
+ "ProtonUnavailableError",
+ "UmuRuntimeError",
+ "ExitCode",
+]

--- a/py_modules/unifideck/launcher/bootstrap.py
+++ b/py_modules/unifideck/launcher/bootstrap.py
@@ -1,5 +1,68 @@
-"""bootstrap.py — Launcher bootstrap
-# OP-35e | py_modules/unifideck/launcher/bootstrap.py | Depends: OP-04f
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import os
+from pathlib import Path
+from typing import Any
+logger = logging.getLogger(__name__)
+def build_launcher_service(config: Any | None = None) -> Any:
+    """Build launcher service."""
+    from ..auth.edge_browser import EdgeBrowser
+    from ..event_bus import EventBus
+    from ..services.bootstrap import (
+        ServicePaths,
+        build_service_subset,
+    )
+    from ..services.launcher import LauncherService
+    if config is None:
+        config = _load_standalone_config()
+        bus = EventBus()
+        paths = ServicePaths.from_config(config)
+        services = build_service_subset(
+            bus, config, paths,
+            attrs={"shortcut", "proton", "cloudsave", "launch_history"},
+        )
+        shortcut_svc = services.get("shortcut")
+        proton_svc = services.get("proton")
+        cloud_svc = services.get("cloudsave")
+        assert shortcut_svc is not None, "bootstrap: shortcut service missing"
+        assert proton_svc is not None, "bootstrap: proton service missing"
+        assert cloud_svc is not None, "bootstrap: cloudsave service missing"
+        edge_browser = EdgeBrowser(
+            cdp_port=config.get_int("edge.cdp_port", 9222),
+            locale_fn=lambda: config.get_str("ui.locale", "en-US"),
+        )
+        return LauncherService(
+            bus=bus,
+            shortcut_svc=shortcut_svc,
+            proton_svc=proton_svc,
+            cloud_svc=cloud_svc,
+            edge_browser=edge_browser,
+            config=config,
+        )
+def _load_standalone_config() -> Any:
+    """Load standalone config."""
+    from ..config.config_manager import ConfigManager
+    plugin_dir = _resolve_plugin_dir()
+    defaults_path = os.path.join(
+        plugin_dir, "defaults", "config.json",
+    )
+    user_path = _user_config_path()
+    return ConfigManager(
+        defaults_path=defaults_path,
+        user_path=user_path,
+    )
+def _resolve_plugin_dir() -> str:
+    """Resolve plugin dir."""
+    from ..core.paths import resolve_plugin_dir
+    return str(resolve_plugin_dir(start=Path(__file__)))
+
+def _user_config_path() -> str | None:
+
+    """User config path."""
+    override = os.environ.get("UNIFIDECK_USER_CONFIG")
+    if override:
+        return override
+    xdg = os.environ.get("XDG_CONFIG_HOME") or str(
+        Path.home() / ".config",
+    )
+    return str(Path(xdg) / "unifideck" / "config.json")

--- a/py_modules/unifideck/launcher/cloud/cloud_failure.py
+++ b/py_modules/unifideck/launcher/cloud/cloud_failure.py
@@ -1,5 +1,182 @@
-"""cloud_failure.py — Cloud failure handling
-# OP-39a | py_modules/unifideck/launcher/cloud/cloud_failure.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+from typing import TYPE_CHECKING, Any
+from ...core.types.events import Events
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+    from ...event_bus.event_bus import EventBus
+logger = logging.getLogger(__name__)
+def classify_cloud_error(err: BaseException) -> str:
+    """Classify cloud error."""
+    try:
+        import aiohttp
+    except ImportError:
+        aiohttp = None
+    if aiohttp is not None:
+        if isinstance(err, aiohttp.ClientConnectionError):
+            return "network_unreachable"
+        if isinstance(err, aiohttp.ClientResponseError):
+            status = getattr(err, "status", 0)
+            if status == 401:
+                return "auth_expired"
+            if status == 403:
+                return "forbidden"
+            if status == 413:
+                return "quota_exceeded"
+            if 500 <= status < 600:
+                return "server_error"
+        if isinstance(err, aiohttp.ClientTimeout):
+            return "timed_out"
+    if isinstance(err, OSError):
+        import errno
+        if err.errno == errno.ENOSPC:
+            return "disk_full"
+        if err.errno in (errno.EACCES, errno.EPERM):
+            return "permission_denied"
+    try:
+        from .disk_space import LowDiskSpaceError
+        if isinstance(err, LowDiskSpaceError):
+            return "disk_space_low"
+    except ImportError:
+        pass
+    try:
+        import asyncio
+        if isinstance(err, asyncio.CancelledError):
+            return "cancelled"
+    except ImportError:
+        pass
+    return "unknown"
+
+_DEFAULT_BEHAVIOR = "toast"
+_VALID_BEHAVIORS = frozenset({"silent", "toast"})
+def get_failure_behavior(config: ConfigManager | None, store: str) -> str:
+    """Get failure behavior."""
+    if config is None or not hasattr(config, "get_str"):
+        return _DEFAULT_BEHAVIOR
+    key = f"cloud.failure_behavior.{store}"
+    raw = config.get_str(key, "")
+    if not raw:
+        raw = config.get_str(
+            "cloud.failure_behavior.default", _DEFAULT_BEHAVIOR,
+        )
+    if raw not in _VALID_BEHAVIORS:
+        logger.warning(
+            "[cloud_failure] invalid behavior %r for store %s, "
+            "falling back to %r", raw, store, _DEFAULT_BEHAVIOR,
+        )
+        return _DEFAULT_BEHAVIOR
+    return raw
+async def handle_cloud_sync_failure(
+    bus: EventBus,
+    config: ConfigManager | None,
+    *,
+    phase: str,
+    store: str,
+    game_id: str,
+    error: BaseException,
+) -> None:
+    """Handle cloud sync failure."""
+    code = classify_cloud_error(error)
+    behavior = get_failure_behavior(config, store)
+    logger.error(
+        "[cloud_failure] phase=%s store=%s game_id=%s "
+        "error_code=%s behavior=%s error=%s",
+        phase, store, game_id, code, behavior, error,
+        exc_info=error,
+    )
+    if behavior == "silent":
+        return
+    await _emit_toast(bus, phase=phase, store=store, game_id=game_id, code=code)
+async def _emit_toast(
+    bus: EventBus, *,
+    phase: str, store: str, game_id: str, code: str,
+) -> None:
+    """Emit toast."""
+    if bus is None:
+        return
+    i18n_key = (
+        "toasts.launcher.cloudSyncDownFailed"
+        if phase == "sync_down"
+        else "toasts.launcher.cloudSyncUpFailed"
+    )
+    payload: dict[str, Any] = {
+        "severity": "warning",
+        "i18n_key": i18n_key,
+        "i18n_params": {
+            "store": store,
+            "error_code": code,
+            "error_i18n_key": f"cloudSync.error.{code}",
+        },
+        "duration_ms": 6000,
+        "game_id": game_id,
+        "store": store,
+        "phase": phase,
+    }
+    resolved_action = _resolve_toast_action(
+        code, store=store, game_id=game_id, phase=phase,
+    )
+    if resolved_action is not None:
+        payload["action"] = resolved_action
+    try:
+        await bus.emit(Events.LAUNCHER_STAGE, **payload)
+    except Exception:
+        logger.exception("[cloud_failure] toast emit failed")
+
+def _resolve_toast_action(
+    code: str, *, store: str, game_id: str, phase: str,
+) -> dict[str, str] | None:
+
+    """Resolve toast action."""
+    action = _TOAST_ACTIONS.get(code)
+    if action is None:
+        return None
+    ctx_vars = {"store": store, "game_id": game_id, "phase": phase}
+    working: dict[str, str] = dict(action)
+    for url_key in ("target_url", "fallback_url"):
+        if url_key not in working:
+            continue
+        try:
+            working[url_key] = working[url_key].format(**ctx_vars)
+        except (KeyError, IndexError) as err:
+            logger.warning(
+                "[cloud_failure] action template error for "
+                "code=%s key=%s: %s — dropping action",
+                code, url_key, err,
+            )
+            return None
+    return working
+_TOAST_ACTIONS = {
+    "disk_space_low": {
+        "i18n_label_key": "toasts.actions.openStorageManager",
+        "target_url": "steam://settings/storage",
+        "fallback_url": "steam://settings",
+    },
+    "auth_expired": {
+        "i18n_label_key": "toasts.actions.signInToStore",
+        "target_url": "unifideck://auth/{store}",
+    },
+    "network_unreachable": {
+        "i18n_label_key": "toasts.actions.retrySync",
+        "target_url": "unifideck://retry-sync/{store}/{game_id}/{phase}",
+    },
+    "timed_out": {
+        "i18n_label_key": "toasts.actions.retrySync",
+        "target_url": "unifideck://retry-sync/{store}/{game_id}/{phase}",
+    },
+    "server_error": {
+        "i18n_label_key": "toasts.actions.retrySync",
+        "target_url": "unifideck://retry-sync/{store}/{game_id}/{phase}",
+    },
+    "unknown": {
+        "i18n_label_key": "toasts.actions.openSaveFolder",
+        "target_url": "unifideck://open-save-folder/{store}/{game_id}",
+    },
+    "permission_denied": {
+        "i18n_label_key": "toasts.actions.openSaveFolder",
+        "target_url": "unifideck://open-save-folder/{store}/{game_id}",
+    },
+    "cancelled": {
+        "i18n_label_key": "toasts.actions.openSaveFolder",
+        "target_url": "unifideck://open-save-folder/{store}/{game_id}",
+    },
+}

--- a/py_modules/unifideck/launcher/cloud/disk_space.py
+++ b/py_modules/unifideck/launcher/cloud/disk_space.py
@@ -1,5 +1,94 @@
-"""disk_space.py — Disk space check
-# OP-39b | py_modules/unifideck/launcher/cloud/disk_space.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+logger = logging.getLogger(__name__)
+_DEFAULT_MIN_FREE_BYTES = 1024 * 1024 * 1024
+@dataclass(frozen=True)
+class DiskSpaceCheck:
+    """Disk space check."""
+    has_space: bool
+    free_bytes: int
+    required_bytes: int
+    path: Path
+class LowDiskSpaceError(Exception):
+    """Low disk space error."""
+    def __init__(
+        self,
+        message: str,
+        free_bytes: int,
+        required_bytes: int,
+    ) -> None:
+        """Initialize the instance."""
+        super().__init__(message)
+        self.free_bytes = free_bytes
+        self.required_bytes = required_bytes
+def get_min_free_bytes(config: ConfigManager | None) -> int:
+    """Get min free bytes."""
+    if config is None or not hasattr(config, "get_int"):
+        return _DEFAULT_MIN_FREE_BYTES
+    return config.get_int(
+        "disk_space.min_free_bytes", _DEFAULT_MIN_FREE_BYTES,
+    )
+def check_disk_space(
+    path: Path, required_bytes: int,
+) -> DiskSpaceCheck:
+    """Check disk space."""
+    probe = path
+    while probe != probe.parent and not probe.exists():
+        probe = probe.parent
+    try:
+        usage = shutil.disk_usage(str(probe))
+        return DiskSpaceCheck(
+            has_space=usage.free >= required_bytes,
+            free_bytes=usage.free,
+            required_bytes=required_bytes,
+            path=probe,
+        )
+    except OSError as err:
+        logger.warning(
+            "[disk_space] disk_usage(%s) failed: %s — assuming no space",
+            probe, err,
+        )
+        return DiskSpaceCheck(
+            has_space=False,
+            free_bytes=0,
+            required_bytes=required_bytes,
+            path=probe,
+        )
+
+def assert_enough_space(
+    path: Path, config: ConfigManager | None,
+    *, store: str | None = None,
+    game_id: str | None = None,
+) -> None:
+
+    """Assert enough space."""
+    required = get_min_free_bytes(config)
+    if store and game_id:
+        try:
+            from .save_size_cache import get_observed_size
+            cached = get_observed_size(config, store, game_id)
+            if cached is not None and not cached.stale:
+                multiplier = _get_multiplier(config)
+                refined = int(cached.size_bytes * multiplier)
+                required = max(required, refined)
+        except ImportError:
+            pass
+    check = check_disk_space(path, required)
+    if not check.has_space:
+        raise LowDiskSpaceError(
+            f"low disk space at {check.path}: "
+            f"have {check.free_bytes} bytes, need {required}",
+            free_bytes=check.free_bytes,
+            required_bytes=required,
+        )
+def _get_multiplier(config: ConfigManager | None) -> float:
+    """Get multiplier."""
+    if config is None or not hasattr(config, "get_float"):
+        return 1.5
+    return cast("float", config.get_float("disk_space.size_multiplier", 1.5))

--- a/py_modules/unifideck/launcher/cloud/save_size_cache.py
+++ b/py_modules/unifideck/launcher/cloud/save_size_cache.py
@@ -1,5 +1,123 @@
-"""save_size_cache.py — Save size cache
-# OP-39c | py_modules/unifideck/launcher/cloud/save_size_cache.py | Depends: OP-04a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+logger = logging.getLogger(__name__)
+_EWMA_ALPHA = 0.3
+@dataclass(frozen=True)
+class CachedSize:
+    """Cached size."""
+    size_bytes: int
+    observed_at: float
+    sample_count: int
+    stale: bool
+def _resolve_cache_path(config: ConfigManager | None) -> str:
+    """Resolve cache path."""
+    if config is None or not hasattr(config, "get_str"):
+        raw = "~/.cache/unifideck/cloud_save_sizes.json"
+    else:
+        raw = config.get_str(
+            "disk_space.size_cache_path",
+            "~/.cache/unifideck/cloud_save_sizes.json",
+        )
+    return os.path.expanduser(raw)
+def _resolve_ttl_seconds(config: ConfigManager | None) -> int:
+    """Resolve TTL seconds."""
+    if config is None or not hasattr(config, "get_int"):
+        return 30 * 24 * 3600
+    return config.get_int(
+        "disk_space.size_cache_ttl_seconds", 30 * 24 * 3600,
+    )
+def _load(path: str) -> dict[str, Any]:
+    """Load."""
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return cast("dict[str, Any]", json.load(fh))
+    except (OSError, json.JSONDecodeError) as err:
+        logger.warning(
+            "[save_size_cache] load failed for %s: %s — "
+            "starting empty", path, err,
+        )
+        return {}
+def _save(path: str, data: dict[str, Any]) -> None:
+    """Save."""
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp_path = f"{path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        os.replace(tmp_path, path)
+    except OSError as err:
+        logger.warning("[save_size_cache] save failed for %s: %s", path, err)
+
+def get_observed_size(
+    config: ConfigManager | None, store: str, game_id: str,
+) -> CachedSize | None:
+
+    """Get observed size."""
+    path = _resolve_cache_path(config)
+    data = _load(path)
+    key = f"{store}:{game_id}"
+    entry = data.get(key)
+    if not entry:
+        return None
+    ttl = _resolve_ttl_seconds(config)
+    age = time.time() - entry.get("observed_at", 0)
+    return CachedSize(
+        size_bytes=int(entry.get("size_bytes", 0)),
+        observed_at=float(entry.get("observed_at", 0)),
+        sample_count=int(entry.get("sample_count", 0)),
+        stale=(age > ttl),
+    )
+def record_observed_size(
+    config: ConfigManager | None, store: str, game_id: str, size_bytes: int,
+) -> None:
+    """Record observed size."""
+    if size_bytes < 0:
+        logger.warning(
+            "[save_size_cache] negative size for %s:%s ignored",
+            store, game_id,
+        )
+        return
+    path = _resolve_cache_path(config)
+    data = _load(path)
+    key = f"{store}:{game_id}"
+    existing = data.get(key)
+    if existing is None or existing.get("sample_count", 0) == 0:
+        new_size = size_bytes
+        new_count = 1
+    else:
+        old = existing["size_bytes"]
+        new_size = int(_EWMA_ALPHA * size_bytes + (1 - _EWMA_ALPHA) * old)
+        new_count = existing["sample_count"] + 1
+    data[key] = {
+        "size_bytes": new_size,
+        "observed_at": time.time(),
+        "sample_count": new_count,
+    }
+    _save(path, data)
+def measure_directory_size(directory: str) -> int:
+    """Measure directory size."""
+    if not os.path.isdir(directory):
+        return 0
+    total = 0
+    try:
+        for root, _, files in os.walk(directory):
+            for name in files:
+                try:
+                    total += os.path.getsize(os.path.join(root, name))
+                except OSError:
+                    continue
+    except OSError as err:
+        logger.warning(
+            "[save_size_cache] walk failed for %s: %s", directory, err,
+        )
+        return 0
+    return total

--- a/py_modules/unifideck/launcher/diagnostics/__init__.py
+++ b/py_modules/unifideck/launcher/diagnostics/__init__.py
@@ -1,1 +1,0 @@
-# OP-40 launcher/diagnostics package

--- a/py_modules/unifideck/launcher/diagnostics/correlation.py
+++ b/py_modules/unifideck/launcher/diagnostics/correlation.py
@@ -1,5 +1,39 @@
-"""correlation.py — Launch correlation IDs
-# OP-40a | py_modules/unifideck/launcher/diagnostics/correlation.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import contextvars
+import logging
+import secrets
+from collections.abc import Iterator
+from contextlib import contextmanager
+_LAUNCH_ID: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "unifideck_launch_id",
+    default="-",
+)
+def new_launch_id() -> str:
+    """New launch ID."""
+    return secrets.token_hex(4)
+def get_launch_id() -> str:
+    """Get launch ID."""
+    return _LAUNCH_ID.get()
+@contextmanager
+def launch_id_scope(launch_id: str) -> Iterator[None]:
+    """Launch ID scope."""
+    token = _LAUNCH_ID.set(launch_id)
+    try:
+        yield
+    finally:
+        _LAUNCH_ID.reset(token)
+class LaunchIdFilter(logging.Filter):
+    """Launch ID filter."""
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Filter."""
+        record.launch_id = get_launch_id()
+        return True
+def install_launch_id_logging(
+    root_logger: logging.Logger | None = None,
+) -> None:
+    """Install launch ID logging."""
+    logger = root_logger or logging.getLogger()
+    for existing in logger.filters:
+        if isinstance(existing, LaunchIdFilter):
+            return
+    logger.addFilter(LaunchIdFilter())

--- a/py_modules/unifideck/launcher/diagnostics/log_archive.py
+++ b/py_modules/unifideck/launcher/diagnostics/log_archive.py
@@ -1,5 +1,163 @@
-"""log_archive.py — Log archive
-# OP-40d | py_modules/unifideck/launcher/diagnostics/log_archive.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+logger = logging.getLogger(__name__)
+def _resolve_archive_dir(config: ConfigManager | None) -> Path:
+    """Resolve archive dir."""
+    if config is None or not hasattr(config, "get_str"):
+        raw = "~/.local/share/unifideck/launches"
+    else:
+        raw = config.get_str(
+            "logs.archive_path",
+            "~/.local/share/unifideck/launches",
+        )
+    path = Path(os.path.expanduser(raw))
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as err:
+        logger.warning(
+            "[log_archive] failed to create %s: %s — archiving disabled",
+            path, err,
+        )
+    return path
+def _resolve_retention_seconds(config: ConfigManager | None) -> int:
+    """Resolve retention seconds."""
+    if config is None or not hasattr(config, "get_int"):
+        return 7 * 24 * 3600
+    return config.get_int("logs.retention_days", 7) * 24 * 3600
+def prune_old_launches(config: ConfigManager | None) -> int:
+    """Prune old launches."""
+    archive_dir = _resolve_archive_dir(config)
+    if not archive_dir.is_dir():
+        return 0
+    cutoff = time.time() - _resolve_retention_seconds(config)
+    removed = 0
+    try:
+        for entry in archive_dir.iterdir():
+            if not entry.is_file() or entry.suffix != ".log":
+                continue
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    entry.unlink()
+                    removed += 1
+            except OSError as err:
+                logger.warning(
+                    "[log_archive] failed to prune %s: %s",
+                    entry, err,
+                )
+    except OSError as err:
+        logger.warning(
+            "[log_archive] failed to scan %s: %s", archive_dir, err,
+        )
+    if removed > 0:
+        logger.info(
+            "[log_archive] pruned %d expired launch log(s)", removed,
+        )
+    return removed
+
+def attach_launch_handler(
+    launch_id: str, config: ConfigManager | None,
+    *, min_level: int = logging.INFO,
+) -> logging.Handler | None:
+
+    """Attach launch handler."""
+    archive_dir = _resolve_archive_dir(config)
+    path = archive_dir / f"{launch_id}.log"
+    try:
+        handler = logging.FileHandler(str(path), encoding="utf-8")
+        handler.setLevel(min_level)
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        ))
+        logging.getLogger("unifideck.launcher").addHandler(handler)
+        return handler
+    except OSError as err:
+        logger.warning(
+            "[log_archive] failed to attach handler for %s: %s",
+            path, err,
+        )
+        return None
+def detach_launch_handler(handler: logging.Handler | None) -> None:
+    """Detach launch handler."""
+    if handler is None:
+        return
+    try:
+        logging.getLogger("unifideck.launcher").removeHandler(handler)
+        handler.close()
+    except Exception:
+        logger.exception("[log_archive] detach handler failed")
+def read_launch_logs(
+    launch_id: str, config: ConfigManager | None,
+    *, max_lines: int = 500,
+) -> dict:
+    """Read launch logs."""
+    archive_dir = _resolve_archive_dir(config)
+    path = archive_dir / f"{launch_id}.log"
+    result = {
+        "exists": False, "path": str(path), "lines": [],
+        "total": 0,
+    }
+    if not path.is_file():
+        return result
+    result["exists"] = True
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            raw = fh.readlines()
+    except OSError as err:
+        logger.warning("[log_archive] read %s failed: %s", path, err)
+        return result
+    result["total"] = len(raw)
+    tail = raw[-max_lines:] if len(raw) > max_lines else raw
+    parsed = []
+    for line in tail:
+        level = "INFO"
+        if "[ERROR]" in line or "[CRITICAL]" in line:
+            level = "ERROR"
+        elif "[WARNING]" in line:
+            level = "WARNING"
+        elif "[DEBUG]" in line:
+            level = "DEBUG"
+        parsed.append({"level": level, "text": line.rstrip("\n")})
+    result["lines"] = parsed
+    return result
+
+def export_launch_logs(
+    launch_id: str, dest_path: str, config: ConfigManager | None,
+) -> dict:
+
+    """Export launch logs."""
+    import shutil
+    archive_dir = _resolve_archive_dir(config)
+    src = archive_dir / f"{launch_id}.log"
+    if not src.is_file():
+        return {
+            "success": False,
+            "error": "source_missing",
+            "dest_path": None,
+        }
+    dst = Path(os.path.expanduser(dest_path))
+    if not dst.is_absolute():
+        dst = Path.home() / dst
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(src), str(dst))
+    except OSError as err:
+        logger.warning(
+            "[log_archive] export %s → %s failed: %s",
+            src, dst, err,
+        )
+        return {
+            "success": False,
+            "error": str(err),
+            "dest_path": str(dst),
+        }
+    return {
+        "success": True,
+        "dest_path": str(dst),
+        "error": None,
+    }

--- a/py_modules/unifideck/launcher/diagnostics/save_folder_inspector.py
+++ b/py_modules/unifideck/launcher/diagnostics/save_folder_inspector.py
@@ -1,5 +1,80 @@
-"""save_folder_inspector.py — Save folder inspector
-# OP-40c | py_modules/unifideck/launcher/diagnostics/save_folder_inspector.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import os
+from typing import Any
+logger = logging.getLogger(__name__)
+def inspect_save_folder(
+    root: str,
+    *,
+    max_depth: int = 2,
+    filter_substring: str = "",
+    max_files: int = 500,
+) -> dict[str, Any]:
+    """Inspect save folder."""
+    result: dict[str, Any] = {
+        "path": root,
+        "exists": False,
+        "total_files": 0,
+        "total_size": 0,
+        "files": [],
+        "truncated_count": 0,
+        "truncated_size": 0,
+    }
+    if not os.path.isdir(root):
+        return result
+    result["exists"] = True
+    substr = filter_substring.lower() if filter_substring else ""
+    all_entries = _collect_file_entries(root, max_depth, substr)
+    result["total_files"] = len(all_entries)
+    result["total_size"] = sum(e["size"] for e in all_entries)
+    all_entries.sort(key=lambda e: e["size"], reverse=True)
+    _apply_file_cap(all_entries, max_files, result)
+    return result
+
+def _collect_file_entries(
+    root: str, max_depth: int, substr: str,
+) -> list[dict[str, Any]]:
+
+    """Collect file entries."""
+    entries: list[dict[str, Any]] = []
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            rel_dir = os.path.relpath(dirpath, root)
+            depth = 0 if rel_dir == "." else rel_dir.count(os.sep) + 1
+            if max_depth >= 0 and depth >= max_depth:
+                dirnames[:] = []
+            for name in filenames:
+                full = os.path.join(dirpath, name)
+                rel_norm = os.path.relpath(full, root).replace(
+                    os.sep, "/",
+                )
+                if substr and substr not in rel_norm.lower():
+                    continue
+                try:
+                    st = os.stat(full)
+                except OSError:
+                    continue
+                entries.append({
+                    "rel_path": rel_norm,
+                    "size": st.st_size,
+                    "mtime": st.st_mtime,
+                })
+    except OSError as err:
+        logger.warning(
+            "[save_folder_inspector] walk failed for %s: %s",
+            root, err,
+        )
+    return entries
+def _apply_file_cap(
+    entries: list[dict[str, Any]],
+    max_files: int,
+    result: dict[str, Any],
+) -> None:
+    """Apply file cap."""
+    if len(entries) > max_files:
+        result["files"] = entries[:max_files]
+        dropped = entries[max_files:]
+        result["truncated_count"] = len(dropped)
+        result["truncated_size"] = sum(e["size"] for e in dropped)
+    else:
+        result["files"] = entries

--- a/py_modules/unifideck/launcher/diagnostics/telemetry.py
+++ b/py_modules/unifideck/launcher/diagnostics/telemetry.py
@@ -1,5 +1,53 @@
-"""telemetry.py — Launch telemetry
-# OP-40b | py_modules/unifideck/launcher/diagnostics/telemetry.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+if TYPE_CHECKING:
+    from ...event_bus.event_bus import EventBus
+from .correlation import get_launch_id
+logger = logging.getLogger(__name__)
+LAUNCH_PHASE_TIMING_EVENT = "LAUNCH_PHASE_TIMING"
+class PhaseTimer:
+    """Phase timer."""
+    __slots__ = ("_bus", "_phase", "_extra", "_t0")
+    def __init__(
+        self,
+        bus: EventBus,
+        phase: str,
+        extra: dict | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        self._bus = bus
+        self._phase = phase
+        self._extra = dict(extra) if extra else {}
+        self._t0 = 0.0
+    async def __aenter__(self) -> PhaseTimer:
+        """Aenter."""
+        self._t0 = time.monotonic()
+        return self
+    async def __aexit__(
+        self, exc_type: Any, _exc_val: Any, _exc_tb: Any,
+    ) -> None:
+        """Aexit."""
+        duration_ms = int((time.monotonic() - self._t0) * 1000)
+        payload = {
+            "phase": self._phase,
+            "duration_ms": duration_ms,
+            "launch_id": get_launch_id(),
+            "success": exc_type is None,
+            **self._extra,
+        }
+        if self._bus is not None:
+            try:
+                await self._bus.emit(
+                    LAUNCH_PHASE_TIMING_EVENT, **payload,
+                )
+            except Exception:
+                logger.exception(
+                    "[telemetry] emit failed for phase=%s",
+                    self._phase,
+                )
+        logger.debug(
+            "[telemetry] phase=%s duration_ms=%d success=%s",
+            self._phase, duration_ms, exc_type is None,
+        )

--- a/py_modules/unifideck/launcher/dispatcher.py
+++ b/py_modules/unifideck/launcher/dispatcher.py
@@ -1,5 +1,216 @@
-"""dispatcher.py — Launcher CLI dispatcher (main)
-# OP-35c | py_modules/unifideck/launcher/dispatcher.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from ..core.types.results import Result
+from .types.context import LaunchContext
+from .types.errors import GameNotFoundError, LauncherError
+from .types.exit_codes import ExitCode
+logger = logging.getLogger(__name__)
+def _parse_argv(argv: list[str]) -> tuple[str, str]:
+    """Parse argv."""
+    if len(argv) < 2:
+        raise GameNotFoundError(
+            "missing store:game_id argument",
+            context={"argv": argv},
+        )
+    game_key = argv[1]
+    if ":" not in game_key:
+        raise GameNotFoundError(
+            f"malformed game key {game_key!r}, "
+            "expected 'store:game_id'",
+            context={"game_key": game_key},
+        )
+    raw_options = " ".join(argv[2:])
+    return game_key, raw_options
+def _resolve_plugin_dir() -> Path:
+    """Resolve plugin dir."""
+    from ..core.paths import resolve_plugin_dir
+    return resolve_plugin_dir(start=Path(__file__))
+async def _build_context(
+    argv: list[str],
+    shortcut_svc,
+) -> LaunchContext:
+    """Build context."""
+    game_key, raw_options = _parse_argv(argv)
+    store, game_id = game_key.split(":", 1)
+    entry = await shortcut_svc.get_entry_for_game_key(
+        store, game_id,
+    )
+    if entry is None:
+        raise GameNotFoundError(
+            f"game {game_key!r} not found in games.map",
+            context={"game_key": game_key},
+        )
+    exe_path = Path(entry.exe)
+    work_dir = Path(entry.work_dir)
+    auth_store, is_launch_action = _detect_auth_action()
+    bypass = _resolve_bypass_flag(store, game_id)
+    return LaunchContext(
+        store=store,
+        game_id=game_id,
+        exe_path=exe_path,
+        work_dir=work_dir,
+        plugin_dir=_resolve_plugin_dir(),
+        raw_options=raw_options,
+        is_launch_action=is_launch_action,
+        auth_store=auth_store,
+        bypass_circuit_breaker=bypass,
+    )
+
+def _detect_auth_action() -> tuple[str | None, bool]:
+
+    """Detect auth action."""
+    auth_env = {
+        "epic": os.environ.get("UNIFIDECK_EPIC_ACTION"),
+        "gog": os.environ.get("UNIFIDECK_GOG_ACTION"),
+        "amazon": os.environ.get("UNIFIDECK_AMAZON_ACTION"),
+    }
+    for candidate_store, action in auth_env.items():
+        if action == "auth":
+            return candidate_store, False
+    return None, True
+def _resolve_bypass_flag(store: str, game_id: str) -> bool:
+    """Resolve bypass flag."""
+    bypass_raw = os.environ.get(
+        "UNIFIDECK_BYPASS_CIRCUIT_BREAKER", "",
+    )
+    bypass_env = bypass_raw.strip().lower() in (
+        "1", "true", "yes",
+    )
+    try:
+        from ..config.config_manager import ConfigManager
+        from ..services.launch_history import (
+            LaunchHistoryService,
+        )
+        cfg = ConfigManager(
+            str(
+                _resolve_plugin_dir()
+                / "defaults" / "config.json",
+            ),
+        )
+        lh = LaunchHistoryService(cfg)
+        bypass_flag = lh.consume_bypass(f"{store}:{game_id}")
+    except Exception:
+        bypass_flag = False
+    return bypass_env or bypass_flag
+async def _run(argv: list[str]) -> int:
+    """Run."""
+    from .diagnostics.correlation import launch_id_scope, new_launch_id
+    from .diagnostics.log_archive import (
+        attach_launch_handler,
+        detach_launch_handler,
+        prune_old_launches,
+    )
+    lid = new_launch_id()
+    with launch_id_scope(lid):
+        try:
+            from ..config.config_manager import ConfigManager
+            from ..core.paths import resolve_plugin_dir
+            _cfg = ConfigManager(str(
+                resolve_plugin_dir() /
+                "defaults" /
+                "config.json"))
+        except Exception:
+            _cfg = None
+        prune_old_launches(_cfg)
+        _archive_handler = attach_launch_handler(lid, _cfg)
+        try:
+            return await _run_with_id(argv)
+        finally:
+            detach_launch_handler(_archive_handler)
+
+async def _run_with_id(argv: list[str]) -> int:
+
+    """Run with ID."""
+    try:
+        game_key, _ = _parse_argv(argv)
+        logger.info(
+            "[launcher.dispatcher] request received: %s", game_key,
+        )
+    except LauncherError as err:
+        logger.error(
+            "[launcher.dispatcher] argv parse failed: %s",
+            err.to_log_dict,
+        )
+        return int(err.exit_code)
+    try:
+        launcher_service = _bootstrap_minimal_services()
+    except Exception:
+        logger.exception("[launcher.dispatcher] bootstrap failed")
+        return int(ExitCode.DEPENDENCY_MISSING)
+    try:
+        ctx = await _build_context(argv, launcher_service._shortcut_svc)
+    except LauncherError as err:
+        logger.error(
+            "[launcher.dispatcher] context build failed: %s",
+            err.to_log_dict,
+        )
+        return int(err.exit_code)
+    try:
+        await launcher_service.start()
+        result = await launcher_service.launch(ctx)
+    except LauncherError as err:
+        logger.error(
+            "[launcher.dispatcher] launch raised: %s",
+            err.to_log_dict,
+        )
+        return int(err.exit_code)
+    finally:
+        try:
+            await launcher_service.stop()
+        except Exception:
+            logger.exception(
+                "[launcher.dispatcher] launcher_service.stop failed",
+            )
+    return _map_result_to_exitcode(result)
+def _map_result_to_exitcode(result: Result) -> int:
+    """Map result to exitcode."""
+    if result.success:
+        return int(ExitCode.SUCCESS)
+    code = result.error_code or ""
+    if code == "not_implemented":
+        return int(ExitCode.GENERIC_ERROR)
+    if code == "circuit_open":
+        return int(ExitCode.CIRCUIT_BREAKER_OPEN)
+    if code.startswith("exit_"):
+        try:
+            rc = int(code.split("_", 1)[1])
+            return rc if 0 <= rc <= 255 else int(ExitCode.GAME_FAILED)
+        except (ValueError, IndexError):
+            return int(ExitCode.GAME_FAILED)
+    return int(ExitCode.GAME_FAILED)
+def _bootstrap_minimal_services():
+    """Bootstrap minimal services."""
+    from .bootstrap import build_launcher_service
+    return build_launcher_service()
+
+def main(argv: list[str]) -> int:
+
+    """Main."""
+    from .diagnostics.correlation import install_launch_id_logging
+    logging.basicConfig(
+        format=(
+            "%(asctime)s [%(launch_id)s] %(levelname)s "
+            "%(name)s: %(message)s"
+        ),
+        level=logging.INFO,
+        stream=sys.stderr,
+    )
+    install_launch_id_logging()
+    try:
+        return int(asyncio.run(_run(argv)))
+    except KeyboardInterrupt:
+        return int(ExitCode.CANCELLED_BY_USER)
+    except asyncio.CancelledError:
+        logger.info(
+            "[launcher.dispatcher] launch cancelled by user",
+        )
+        return int(ExitCode.CANCELLED_BY_USER)
+    except Exception:
+        logger.exception("[launcher.dispatcher] uncaught exception")
+        return int(ExitCode.GENERIC_ERROR)
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/py_modules/unifideck/launcher/flows/__init__.py
+++ b/py_modules/unifideck/launcher/flows/__init__.py
@@ -1,1 +1,0 @@
-# OP-37 launcher/flows package

--- a/py_modules/unifideck/launcher/flows/auth.py
+++ b/py_modules/unifideck/launcher/flows/auth.py
@@ -1,5 +1,117 @@
-"""auth.py — Auth launch flow
-# OP-37c | py_modules/unifideck/launcher/flows/auth.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+from ...core.types import Result
+from ..types.context import LaunchContext
+from ..types.errors import DependencyMissingError, GameNotFoundError
+if TYPE_CHECKING:
+    from ...auth.edge_browser import EdgeBrowser
+logger = logging.getLogger(__name__)
+_AUTH_URL_FILES = {
+    "epic": "epic_auth_url.txt",
+    "gog": "gog_auth_url.txt",
+    "amazon": "amazon_auth_url.txt",
+}
+_AUTH_STORE_LABELS = {
+    "epic": "Epic Games",
+    "gog": "GOG",
+    "amazon": "Amazon Games",
+}
+_MAX_AUTH_SECONDS = 600
+def _read_config_int(key: str, default: int) -> int:
+    """Read config int."""
+    from ...utils.config_helpers import read_config_int_cold_start
+    return read_config_int_cold_start(key, default)
+def _read_auth_url(store: str) -> str:
+    """Read auth URL."""
+    filename = _AUTH_URL_FILES.get(store)
+    if filename is None:
+        raise GameNotFoundError(
+            f"Unknown auth store {store!r}",
+            context={"store": store},
+        )
+    url_file = Path(
+        f"~/.local/share/unifideck/{filename}",
+    ).expanduser()
+    if not url_file.is_file():
+        raise GameNotFoundError(
+            f"Auth URL file not found: {url_file}",
+            context={"store": store, "file": str(url_file)},
+        )
+    try:
+        url = url_file.read_text(encoding="utf-8").strip()
+    except OSError as e:
+        raise GameNotFoundError(
+            f"Cannot read auth URL file: {e}",
+            context={"store": store, "file": str(url_file)},
+        ) from e
+    if not url:
+        raise GameNotFoundError(
+            f"Auth URL file is empty: {url_file}",
+            context={"store": store},
+        )
+    return url
+
+async def handle_store_auth(
+ ctx: LaunchContext,
+ edge_browser: EdgeBrowser,
+) -> Result:
+
+    """Handle store auth."""
+    store = ctx.auth_store
+    if store is None:
+        raise GameNotFoundError(
+            "handle_store_auth called without auth_store set",
+            context={"game_key": ctx.game_key},
+        )
+    label = _AUTH_STORE_LABELS.get(store, store.title)
+    logger.info(
+        "[launcher.auth] launching %s OAuth flow", label,
+    )
+    if not edge_browser.is_installed:
+        raise DependencyMissingError(
+            "Microsoft Edge flatpak required for OAuth",
+            context={"store": store},
+        )
+    auth_url = _read_auth_url(store)
+    logger.info(
+        "[launcher.auth] %s auth URL resolved (%d chars)",
+        label, len(auth_url),
+    )
+    started = edge_browser.launch_auth(auth_url)
+    if not started:
+        return Result(
+            success=False,
+            error="edge_auth_launch_failed",
+            store=store,
+        )
+    await _wait_for_auth_end(edge_browser)
+    logger.info(
+        "[launcher.auth] %s auth browser closed", label,
+    )
+    return Result(success=True, store=store)
+async def _wait_for_auth_end(edge_browser: EdgeBrowser) -> None:
+    """Wait for auth end."""
+    max_seconds = _read_config_int(
+        "launcher.auth_max_seconds", _MAX_AUTH_SECONDS,
+    )
+    proc = edge_browser.process
+    if proc is not None:
+        loop = asyncio.get_event_loop()
+        try:
+            await asyncio.wait_for(
+                loop.run_in_executor(None, proc.wait),
+                timeout=max_seconds,
+            )
+        except TimeoutError:
+            logger.warning(
+                "[launcher.auth] auth flow reached %ds timeout",
+                max_seconds,
+            )
+        return
+    elapsed = 0.0
+    while elapsed < max_seconds:
+        await asyncio.sleep(5.0)
+        elapsed += 5.0

--- a/py_modules/unifideck/launcher/flows/native.py
+++ b/py_modules/unifideck/launcher/flows/native.py
@@ -1,5 +1,129 @@
-"""native.py — Native/Proton launch flow
-# OP-37b | py_modules/unifideck/launcher/flows/native.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+import os
+from pathlib import Path
+from ...core.types import Result
+from ..types.context import LaunchContext, RuntimeState
+from ..types.errors import DependencyMissingError, GameFailedError
+logger = logging.getLogger(__name__)
+STEAM_RUNTIME_CANDIDATES = [
+    "~/.steam/steam/ubuntu12_32/steam-runtime/run.sh",
+    "~/.local/share/Steam/ubuntu12_32/steam-runtime/run.sh",
+]
+def _find_steam_runtime() -> Path | None:
+    """Find steam runtime."""
+    for candidate in STEAM_RUNTIME_CANDIDATES:
+        path = Path(candidate).expanduser()
+        if path.is_file():
+            return path
+    return None
+def _restore_steam_env(env: dict[str, str]) -> None:
+    """Restore steam env."""
+    steam_env = Path("~/.steam/steam.env").expanduser()
+    if not steam_env.is_file():
+        return
+    try:
+        for line in steam_env.read_text(
+            encoding="utf-8", errors="replace",
+        ).splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            if key in ("STEAM_OVERLAY", "STEAM_INPUT"):
+                env[key] = value
+    except OSError:
+        pass
+def _is_gog_dosbox_wrapper(ctx: LaunchContext) -> bool:
+    """Is GOG dosbox wrapper."""
+    return (
+        ctx.store == "gog"
+        and ctx.exe_path.name == "start.sh"
+    )
+
+async def native_launch(
+    ctx: LaunchContext,
+    state: RuntimeState,
+) -> Result:
+
+    """Native launch."""
+    exe_path = ctx.exe_path
+    if not exe_path.is_file():
+        raise DependencyMissingError(
+            f"Native Linux executable not found: {exe_path}",
+            context={"exe": str(exe_path), "store": ctx.store},
+        )
+    try:
+        os.chmod(exe_path, 0o755)
+    except OSError:
+        pass
+    env = _prepare_launch_env(ctx)
+    argv = _build_launch_argv(ctx, state, exe_path)
+    cwd = ctx.work_dir if ctx.work_dir.is_dir() else exe_path.parent
+    logger.info(
+        "[launcher.native] spawning: argv=%s cwd=%s",
+        argv[:3],
+        cwd,
+    )
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        env=env,
+        cwd=str(cwd),
+        stdout=None,
+        stderr=None,
+        start_new_session=True,
+    )
+    rc = await proc.wait()
+    state.game_exit_code = rc
+    logger.info("[launcher.native] game exited rc=%d", rc)
+    if rc != 0:
+        raise GameFailedError(
+            f"Native Linux game exited with code {rc}",
+            subprocess_rc=rc,
+            context={
+                "store": ctx.store,
+                "game_id": ctx.game_id,
+            },
+        )
+    return Result(success=True, store=ctx.store)
+def _prepare_launch_env(ctx: LaunchContext) -> dict[str, str]:
+    """Prepare launch env."""
+    env = dict(os.environ)
+    env.update(ctx.env_overrides)
+    _restore_steam_env(env)
+    return env
+
+def _build_launch_argv(
+    ctx: LaunchContext,
+    state: RuntimeState,
+    exe_path: Path,
+) -> list[str]:
+
+    """Build launch argv."""
+    argv: list[str] = list(state.wrappers)
+    if _is_gog_dosbox_wrapper(ctx):
+        logger.info(
+            "[launcher.native] using GOG DOSBox wrapper module",
+        )
+        argv.extend([
+            "python3", "-m",
+            "unifideck.launcher.proton.gog_linux_dosbox",
+            str(exe_path),
+        ])
+    else:
+        runtime = _find_steam_runtime()
+        if runtime is not None:
+            logger.info(
+                "[launcher.native] using Steam Runtime: %s", runtime,
+            )
+            argv.extend([str(runtime), str(exe_path)])
+        else:
+            logger.info(
+                "[launcher.native] no Steam Runtime, direct exec",
+            )
+            argv.append(str(exe_path))
+    argv.extend(state.game_args)
+    return argv

--- a/py_modules/unifideck/launcher/flows/xcloud.py
+++ b/py_modules/unifideck/launcher/flows/xcloud.py
@@ -1,5 +1,98 @@
-"""xcloud.py — xCloud launch flow
-# OP-37a | py_modules/unifideck/launcher/flows/xcloud.py | Depends: OP-38b
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+from ...core.types import Result
+from ..cdp.xcloud_cdp import run_cdp_inject
+from ..types.context import LaunchContext
+from ..types.errors import DependencyMissingError
+if TYPE_CHECKING:
+    from ...auth.edge_browser import EdgeBrowser
+logger = logging.getLogger(__name__)
+_MAX_SESSION_SECONDS = 14400
+_POLL_INTERVAL_SECONDS = 5.0
+_XCLOUD_CDP_PORT = 9223
+_CDP_INJECT_TIMEOUT = 60.0
+def _read_config_int(key: str, default: int) -> int:
+    """Read config int."""
+    from ...utils.config_helpers import read_config_int_cold_start
+    return read_config_int_cold_start(key, default)
+
+async def launch_xcloud(
+    ctx: LaunchContext,
+    edge_browser: EdgeBrowser,
+) -> Result:
+
+    """Launch xcloud."""
+    target_url = str(ctx.work_dir)
+    logger.info(
+        "[launcher.xcloud] launching: %s", target_url[:80],
+    )
+    if not edge_browser.is_installed:
+        raise DependencyMissingError(
+            "Microsoft Edge flatpak required for xCloud "
+            "streaming",
+            context={
+                "game_id": ctx.game_id,
+                "url": target_url,
+            },
+        )
+    started = edge_browser.launch_xcloud(target_url)
+    if not started:
+        return Result(
+            success=False,
+            error="edge_launch_failed",
+            store=ctx.store,
+        )
+    inject_task: asyncio.Task[bool] = asyncio.create_task(
+        run_cdp_inject(
+            port=_XCLOUD_CDP_PORT,
+            launch_url=target_url,
+            timeout=_CDP_INJECT_TIMEOUT,
+            steam_controller_appid=int(ctx.steam_app_id or 0),
+        ),
+        name=f"xcloud_cdp_inject:{ctx.game_key}",
+    )
+    try:
+        await _wait_for_session_end(edge_browser)
+    finally:
+        if not inject_task.done():
+            inject_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await inject_task
+    logger.info(
+        "[launcher.xcloud] session ended: %s", ctx.game_key,
+    )
+    return Result(success=True, store=ctx.store)
+async def _wait_for_session_end(edge_browser: EdgeBrowser) -> None:
+    """Wait for session end."""
+    max_seconds = _read_config_int(
+        "launcher.xcloud_max_seconds", _MAX_SESSION_SECONDS,
+    )
+    proc = edge_browser.process
+    if proc is not None:
+        loop = asyncio.get_event_loop()
+        try:
+            await asyncio.wait_for(
+                loop.run_in_executor(None, proc.wait),
+                timeout=max_seconds,
+            )
+        except TimeoutError:
+            logger.warning(
+                "[launcher.xcloud] session reached max "
+                "duration (%ds), leaving Edge running",
+                max_seconds,
+            )
+        return
+    logger.info(
+        "[launcher.xcloud] no process handle, polling "
+        "fallback",
+    )
+    elapsed = 0.0
+    while elapsed < max_seconds:
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+        elapsed += _POLL_INTERVAL_SECONDS
+    logger.warning(
+        "[launcher.xcloud] polling fallback reached timeout",
+    )

--- a/py_modules/unifideck/launcher/packaging.py
+++ b/py_modules/unifideck/launcher/packaging.py
@@ -1,5 +1,57 @@
-"""packaging.py — Launcher argument packaging
-# OP-35d | py_modules/unifideck/launcher/packaging.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import os
+import stat
+from collections.abc import Iterable
+from pathlib import Path
+logger = logging.getLogger(__name__)
+LAUNCHER_EXECUTABLE_FILES: tuple[str, ...] = (
+ "bin/unifideck-launcher",
+)
+_EXEC_MASK = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+def ensure_executable_files(
+ plugin_dir: Path,
+ files: Iterable[str] = LAUNCHER_EXECUTABLE_FILES,
+) -> int:
+    """Ensure executable files."""
+    fixed = 0
+    for rel_path in files:
+        target = plugin_dir / rel_path
+        if not target.is_file():
+            logger.info(
+                "[packaging] skipping missing file: %s",
+                rel_path,
+            )
+            continue
+        try:
+            current_mode = target.stat().st_mode
+        except OSError as e:
+            logger.warning(
+                "[packaging] cannot stat %s: %s",
+                rel_path, e,
+            )
+            continue
+        if current_mode & _EXEC_MASK:
+            continue
+        new_mode = current_mode | _EXEC_MASK
+        try:
+            os.chmod(target, new_mode)
+            logger.info(
+                "[packaging] fixed executable bit on %s "
+                "(mode %#o → %#o)",
+                rel_path,
+                current_mode & 0o777, new_mode & 0o777,
+            )
+            fixed += 1
+        except OSError as e:
+            logger.warning(
+                "[packaging] chmod failed on %s: %s",
+                rel_path, e,
+            )
+    if fixed > 0:
+        logger.info(
+            "[packaging] executable bit self-heal: "
+            "%d file(s) fixed",
+            fixed,
+        )
+    return fixed

--- a/py_modules/unifideck/launcher/proton/__init__.py
+++ b/py_modules/unifideck/launcher/proton/__init__.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from .handlers.epic import epic_launch
+from .handlers.generic import generic_launch
+from .handlers.ubisoft import ubisoft_launch
+from .infrastructure.core import ProtonLaunchPlan, proton_prepare
+from .infrastructure.selector import (
+    find_python_3_10_plus,
+    resolve_proton_path,
+    select_proton_version,
+)
+from .infrastructure.umu_runtime import (
+    UMU_CACHE_DIR,
+    cleanup_umu_runtime_cache,
+    ensure_umu_runtime_ready,
+    run_umu_with_retry,
+)
+async def dispatch(plan: ProtonLaunchPlan) -> int:
+    """Dispatch."""
+    store = plan.context.store
+    if store == "ubisoft":
+        return await ubisoft_launch(plan)
+    if store == "epic":
+        return await epic_launch(plan)
+    return await generic_launch(plan)

--- a/py_modules/unifideck/launcher/proton/fixes/auth_args_stripper.py
+++ b/py_modules/unifideck/launcher/proton/fixes/auth_args_stripper.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import logging
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ...types.context import LaunchContext
+logger = logging.getLogger(__name__)
+_STRIP_PREFIXES: tuple[str, ...] = (
+    "-AUTH_TYPE=",
+    "-AUTH_PASSWORD=",
+)
+def strip_epic_auth_args(args: list[str]) -> tuple[list[str], list[str]]:
+    """Strip EPIC auth args."""
+    filtered: list[str] = []
+    stripped: list[str] = []
+    for arg in args:
+        if any(arg.startswith(p) for p in _STRIP_PREFIXES):
+            stripped.append(arg)
+            continue
+        filtered.append(arg)
+    if stripped:
+        logger.info(
+            "[auth_args_stripper] stripped %d Epic auth args: %s",
+            len(stripped),
+            [s.split("=", 1)[0] + "=<redacted>" for s in stripped],
+        )
+    return filtered, stripped
+def should_strip_for_launch_context(ctx: LaunchContext) -> bool:
+    """Check whether strip for launch context."""
+    try:
+        store = getattr(ctx, "store", "")
+        exe_path = str(getattr(ctx, "exe_path", ""))
+        return (
+            store == "ubisoft" and "UplayLaunch" in exe_path
+        )
+    except Exception:
+        return False

--- a/py_modules/unifideck/launcher/proton/fixes/epic_prefix_fix.py
+++ b/py_modules/unifideck/launcher/proton/fixes/epic_prefix_fix.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+import asyncio
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+logger = logging.getLogger(__name__)
+_PROTON_FALLBACK_WINE_PATHS: list[str] = [
+    "~/.steam/steam/steamapps/common/Proton - Experimental/files/bin/wine",
+    "~/.steam/steam/steamapps/common/Proton 10.0/files/bin/wine",
+    "~/.steam/steam/steamapps/common/Proton 9.0 (Beta)/files/bin/wine",
+]
+def normalize_prefix_root(prefix_path: Path) -> Path:
+    """Normalize prefix root."""
+    p = prefix_path.resolve()
+    while p.name == "pfx":
+        p = p.parent
+    return p
+
+def _copy_wrapper_to_drive_c(
+    drive_c: Path,
+    bundled_wrapper: Path,
+    label: str,
+) -> bool:
+
+    """Copy wrapper to drive c."""
+    if not bundled_wrapper.is_file():
+        logger.warning(
+            "[epic_prefix_fix] bundled wrapper missing at %s",
+            bundled_wrapper,
+        )
+        return False
+    copied = False
+    epic_dir = (
+        drive_c / "Program Files (x86)" / "Epic Games" / "Launcher"
+        / "Portal" / "Binaries" / "Win32"
+    )
+    try:
+        epic_dir.mkdir(parents=True, exist_ok=True)
+        epic_target = epic_dir / "EpicGamesLauncher.exe"
+        if epic_target.exists():
+            try:
+                epic_target.unlink()
+            except OSError:
+                pass
+        shutil.copy2(bundled_wrapper, epic_target)
+        logger.info(
+            "[epic_prefix_fix] copied wrapper to Epic dir (%s)",
+            label,
+        )
+        copied = True
+    except OSError as e:
+        logger.warning(
+            "[epic_prefix_fix] failed to copy to Epic dir "
+            "(%s): %s",
+            label, e,
+        )
+    win_command_dir = drive_c / "windows" / "command"
+    try:
+        win_command_dir.mkdir(parents=True, exist_ok=True)
+        win_target = win_command_dir / "EpicGamesLauncher.exe"
+        if win_target.exists():
+            try:
+                win_target.unlink()
+            except OSError:
+                pass
+        shutil.copy2(bundled_wrapper, win_target)
+        logger.info(
+            "[epic_prefix_fix] copied wrapper to "
+            "windows/command (%s)",
+            label,
+        )
+        copied = True
+    except OSError as e:
+        logger.warning(
+            "[epic_prefix_fix] failed to copy to "
+            "windows/command (%s): %s",
+            label, e,
+        )
+    return copied
+def _find_wine_binary() -> Path | None:
+    """Find WINE binary."""
+    proton_env = os.environ.get("PROTONPATH")
+    if proton_env:
+        candidate = Path(proton_env) / "files" / "bin" / "wine"
+        if candidate.is_file():
+            return candidate
+    for fallback in _PROTON_FALLBACK_WINE_PATHS:
+        candidate = Path(fallback).expanduser()
+        if candidate.is_file():
+            return candidate
+    system_wine = shutil.which("wine")
+    if system_wine:
+        return Path(system_wine)
+    return None
+
+def _select_registry_prefix(
+    prefix_root: Path,
+) -> Path:
+
+    """Select registry prefix."""
+    pfx_candidate = prefix_root / "pfx"
+    if not pfx_candidate.exists():
+        return prefix_root
+    try:
+        if pfx_candidate.is_symlink() and pfx_candidate.resolve() == prefix_root.resolve():
+            return prefix_root
+    except OSError:
+        pass
+    drive_c = pfx_candidate / "drive_c"
+    if drive_c.is_dir():
+        return pfx_candidate
+    return prefix_root
+async def _run_registry_inject(
+    wine_bin: Path,
+    wineprefix: Path,
+) -> bool:
+    """Run registry inject."""
+    env = dict(os.environ)
+    env["WINEPREFIX"] = str(wineprefix)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            str(wine_bin),
+            "reg", "add",
+            "HKEY_CLASSES_ROOT\\\\com.epicgames.launcher",
+            "/f",
+            env=env,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            rc = await asyncio.wait_for(proc.wait(), timeout=30)
+        except TimeoutError:
+            logger.warning(
+                "[epic_prefix_fix] wine reg add timed out, "
+                "killing",
+            )
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            return False
+        if rc == 0:
+            logger.info(
+                "[epic_prefix_fix] registry key injected",
+            )
+            return True
+        logger.warning(
+            "[epic_prefix_fix] wine reg add exited rc=%d", rc,
+        )
+        return False
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.warning(
+            "[epic_prefix_fix] registry injection failed: %s", e,
+        )
+        return False
+async def _kill_wineserver(wine_bin: Path, wineprefix: Path) -> None:
+    """Kill wineserver."""
+    wineserver = wine_bin.parent / "wineserver"
+    if not wineserver.is_file():
+        return
+    env = dict(os.environ)
+    env["WINEPREFIX"] = str(wineprefix)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            str(wineserver), "--kill",
+            env=env,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=10)
+        logger.info(
+            "[epic_prefix_fix] killed stale wineserver",
+        )
+    except (TimeoutError, OSError, subprocess.SubprocessError):
+        pass
+
+async def apply_epic_launcher_fix(
+    prefix_path: Path,
+    bundled_wrapper: Path,
+) -> bool:
+
+    """Apply EPIC launcher fix."""
+    prefix_root = normalize_prefix_root(prefix_path)
+    root_drive_c = prefix_root / "drive_c"
+    pfx_drive_c = prefix_root / "pfx" / "drive_c"
+    found_any = False
+    if root_drive_c.is_dir():
+        _copy_wrapper_to_drive_c(root_drive_c, bundled_wrapper, "root")
+        found_any = True
+        if pfx_drive_c.is_dir():
+            _copy_wrapper_to_drive_c(
+                pfx_drive_c, bundled_wrapper, "pfx",
+            )
+            found_any = True
+    if not found_any:
+        logger.info(
+            "[epic_prefix_fix] prefix not initialized yet, "
+            "skipping",
+        )
+        return False
+    wine_bin = _find_wine_binary()
+    if wine_bin is None:
+        logger.warning(
+            "[epic_prefix_fix] no wine binary found, "
+            "skipping registry injection",
+        )
+        return True
+    registry_prefix = _select_registry_prefix(prefix_root)
+    registry_ok = await _run_registry_inject(
+        wine_bin, registry_prefix,
+    )
+    await _kill_wineserver(wine_bin, registry_prefix)
+    if registry_ok:
+        logger.info("[epic_prefix_fix] quick fix complete")
+    else:
+        logger.warning(
+            "[epic_prefix_fix] quick fix completed with "
+            "registry issues (non-fatal)",
+        )
+    return True

--- a/py_modules/unifideck/launcher/proton/fixes/epic_registry.py
+++ b/py_modules/unifideck/launcher/proton/fixes/epic_registry.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+import asyncio
+import json
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+logger = logging.getLogger(__name__)
+_UPLAY_ID_RE = re.compile(r"-UplayId=\s*(\d+)")
+@dataclass(frozen=True)
+class RegistryInjectionResult:
+    """Registry injection result."""
+    success: bool
+    keys_written: int
+    reason: str = ""
+def _normalize_prefix_root(prefix_path: Path) -> Path:
+    """Normalize prefix root."""
+    p = prefix_path.resolve()
+    while p.name == "pfx":
+        p = p.parent
+    return p
+def _select_active_wineprefix(prefix_root: Path) -> Path:
+    """Select active wineprefix."""
+    pfx_path = prefix_root / "pfx"
+    try:
+        if (
+            pfx_path.is_symlink()
+            and pfx_path.resolve() == prefix_root.resolve()
+        ):
+            return prefix_root
+    except OSError:
+        pass
+    if (pfx_path / "system.reg").is_file():
+        return pfx_path
+    if (prefix_root / "system.reg").is_file():
+        return prefix_root
+    return pfx_path
+def _linux_to_wine_path(linux_path: str) -> str:
+    """Linux to WINE path."""
+    wine_path = "Z:" + linux_path.replace("/", "\\")
+    if not wine_path.endswith("\\"):
+        wine_path += "\\"
+    return wine_path
+
+def _load_installed_json(
+    legendary_config: Path,
+    game_id: str,
+) -> dict | None:
+
+    """Load installed JSON."""
+    installed_json = legendary_config / "installed.json"
+    if not installed_json.is_file():
+        logger.error(
+            "[epic_registry] installed.json not found at %s",
+            installed_json,
+        )
+        return None
+    try:
+        with installed_json.open() as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.error(
+            "[epic_registry] failed to read "
+            "installed.json: %s", e,
+        )
+        return None
+    app = data.get(game_id)
+    if not app:
+        logger.error(
+            "[epic_registry] game %s not in "
+            "installed.json", game_id,
+        )
+        return None
+    return cast("dict[Any, Any] | None", app)
+def _find_wine_binary() -> Path | None:
+    """Find WINE binary."""
+    proton_path = os.environ.get("PROTONPATH")
+    if not proton_path:
+        return None
+    wine_bin = (
+        Path(proton_path) / "files" / "bin" / "wine"
+    )
+    return wine_bin if wine_bin.is_file() else None
+
+def _build_reg_commands(
+    wine_bin: Path,
+    game_id: str,
+    wine_install_path: str,
+    uplay_id: str | None,
+) -> list[list[str]]:
+
+    """Build reg commands."""
+    commands: list[list[str]] = [
+        [
+            str(wine_bin), "reg", "add",
+            "HKEY_LOCAL_MACHINE\\Software\\Epic Games\\EpicGamesLauncher",
+            "/v", "AppDataPath", "/t", "REG_SZ",
+            "/d", "C:\\ProgramData\\Epic\\EpicGamesLauncher\\Data\\",
+            "/f",
+        ],
+        [
+            str(wine_bin), "reg", "add",
+            (
+                "HKEY_LOCAL_MACHINE\\Software\\WOW6432Node\\Epic Games"
+                "\\EpicGamesLauncher\\Manifests\\" + game_id
+            ),
+            "/v", "InstallLocation", "/t", "REG_SZ",
+            "/d", wine_install_path, "/f",
+        ],
+        [
+            str(wine_bin), "reg", "add",
+            (
+                "HKEY_CURRENT_USER\\Software\\Epic Games"
+                "\\EpicGamesLauncher\\Manifests\\" + game_id
+            ),
+            "/v", "InstallLocation", "/t", "REG_SZ",
+            "/d", wine_install_path, "/f",
+        ],
+    ]
+    if uplay_id:
+        commands.extend([
+            [
+                str(wine_bin), "reg", "add",
+                (
+                    "HKEY_LOCAL_MACHINE\\Software\\WOW6432Node\\Ubisoft"
+                    "\\Launcher\\Installs\\" + uplay_id
+                ),
+                "/v", "InstallDir", "/t", "REG_SZ",
+                "/d", wine_install_path, "/f",
+            ],
+            [
+                str(wine_bin), "reg", "add",
+                (
+                    "HKEY_LOCAL_MACHINE\\Software\\WOW6432Node\\Ubisoft"
+                    "\\Launcher\\Installs\\" + uplay_id
+                ),
+                "/v", "Language", "/t", "REG_SZ",
+                "/d", "en-US", "/f",
+            ],
+        ])
+    return commands
+
+async def _run_reg_commands(
+    commands: list[list[str]],
+    env: dict,
+) -> int:
+
+    """Run reg commands."""
+    ok_count = 0
+    for cmd in commands:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                env=env,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=30,
+                )
+            except TimeoutError:
+                logger.error(
+                    "[epic_registry] reg add timed out: %s",
+                    cmd[3],
+                )
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+                continue
+            if proc.returncode == 0:
+                ok_count += 1
+            else:
+                logger.error(
+                    "[epic_registry] reg add failed: %s: %s",
+                    cmd[3],
+                    stderr.decode(errors="replace").strip(),
+                )
+        except (OSError, subprocess.SubprocessError) as e:
+            logger.error(
+                "[epic_registry] reg add spawn error: %s", e,
+            )
+            continue
+    return ok_count
+async def _kill_wineserver(
+    wine_bin: Path, wineprefix: Path,
+) -> None:
+    """Kill wineserver."""
+    wineserver = wine_bin.parent / "wineserver"
+    if not wineserver.is_file():
+        return
+    env = dict(os.environ)
+    env["WINEPREFIX"] = str(wineprefix)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            str(wineserver), "--kill",
+            env=env,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=10)
+        logger.info(
+            "[epic_registry] killed stale wineserver "
+            "after setup",
+        )
+    except (
+        TimeoutError, OSError,
+        subprocess.SubprocessError,
+    ):
+        pass
+def _resolve_install_paths(
+    app: dict[str, Any],
+) -> tuple[str, str | None] | None:
+    """Resolve install paths."""
+    install_path = app.get("install_path")
+    if not install_path:
+        return None
+    wine_install_path = _linux_to_wine_path(install_path)
+    launch_params = app.get("launch_parameters", "") or ""
+    uplay_match = _UPLAY_ID_RE.search(launch_params)
+    uplay_id = uplay_match.group(1) if uplay_match else None
+    return wine_install_path, uplay_id
+
+def _error_result(reason: str) -> RegistryInjectionResult:
+
+    """Error result."""
+    return RegistryInjectionResult(
+        success=False, keys_written=0, reason=reason,
+    )
+async def setup_registry(
+    game_id: str,
+    prefix_path: Path,
+    legendary_config: Path,
+) -> RegistryInjectionResult:
+    """Setup registry."""
+    prefix_root = _normalize_prefix_root(prefix_path)
+    app = _load_installed_json(legendary_config, game_id)
+    if app is None:
+        return _error_result("installed_json_missing_or_unreadable")
+    paths = _resolve_install_paths(app)
+    if paths is None:
+        logger.error(
+            "[epic_registry] no install_path for %s", game_id,
+        )
+        return _error_result("no_install_path")
+    wine_install_path, uplay_id = paths
+    wine_bin = _find_wine_binary()
+    if wine_bin is None:
+        logger.error(
+            "[epic_registry] PROTONPATH not set or wine "
+            "binary missing",
+        )
+        return _error_result("wine_binary_not_found")
+    active_prefix = _select_active_wineprefix(prefix_root)
+    env = dict(os.environ)
+    env["WINEPREFIX"] = str(active_prefix)
+    commands = _build_reg_commands(
+        wine_bin=wine_bin,
+        game_id=game_id,
+        wine_install_path=wine_install_path,
+        uplay_id=uplay_id,
+    )
+    ok_count = await _run_reg_commands(commands, env)
+    await _kill_wineserver(wine_bin, active_prefix)
+    total = len(commands)
+    all_ok = ok_count == total
+    logger.info(
+        "[epic_registry] setup for %s (uplay=%s): %d/%d keys",
+        game_id, uplay_id, ok_count, total,
+    )
+    return RegistryInjectionResult(
+        success=all_ok,
+        keys_written=ok_count,
+        reason="" if all_ok else "partial_reg_add_failures",
+    )

--- a/py_modules/unifideck/launcher/proton/fixes/galaxy_stub.py
+++ b/py_modules/unifideck/launcher/proton/fixes/galaxy_stub.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+logger = logging.getLogger(__name__)
+_STUB_RELATIVE_PATH = "bin/stubs/GalaxyCommunication.exe"
+_TARGET_SUBPATH = os.path.join(
+    "ProgramData", "GOG.com", "Galaxy", "redists",
+    "GalaxyCommunication.exe",
+)
+def _resolve_drive_c(prefix_path: str) -> str | None:
+    """Resolve drive c."""
+    from ..infrastructure.prefix_layout import resolve_drive_c
+    result = resolve_drive_c(prefix_path)
+    return str(result) if result is not None else None
+def _atomic_copy_file(src: Path | str, dst: str) -> None:
+    """Atomic copy file."""
+    target_dir = os.path.dirname(dst)
+    os.makedirs(target_dir, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".GalaxyCommunication.", suffix=".tmp",
+        dir=target_dir,
+    )
+    try:
+        with os.fdopen(fd, "wb") as tmp_fh, \
+                open(str(src), "rb") as src_fh:
+            shutil.copyfileobj(src_fh, tmp_fh)
+            tmp_fh.flush()
+            os.fsync(tmp_fh.fileno())
+        os.replace(tmp_path, dst)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+def install_galaxy_stub(
+    prefix_path: str,
+    plugin_dir: Path | None = None,
+) -> bool:
+
+    """Install galaxy stub."""
+    if plugin_dir is None:
+        from ....core.paths import resolve_plugin_dir
+        plugin_dir = resolve_plugin_dir()
+    stub_src = plugin_dir / _STUB_RELATIVE_PATH
+    if not stub_src.is_file():
+        logger.warning(
+            "[galaxy_stub] stub binary missing at %s — GOG games "
+            "that check for Galaxy may fail to launch", stub_src,
+        )
+        return False
+    drive_c = _resolve_drive_c(prefix_path)
+    if drive_c is None:
+        logger.warning(
+            "[galaxy_stub] drive_c not found under %s — prefix "
+            "not yet initialised", prefix_path,
+        )
+        return False
+    target_file = os.path.join(drive_c, _TARGET_SUBPATH)
+    if os.path.exists(target_file):
+        logger.debug(
+            "[galaxy_stub] stub already installed at %s", target_file,
+        )
+        return True
+    try:
+        _atomic_copy_file(stub_src, target_file)
+    except OSError as err:
+        logger.warning(
+            "[galaxy_stub] copy %s → %s failed: %s",
+            stub_src, target_file, err,
+        )
+        return False
+    logger.info(
+        "[galaxy_stub] installed GalaxyCommunication.exe stub at %s",
+        target_file,
+    )
+    return True

--- a/py_modules/unifideck/launcher/proton/fixes/game_fixes.py
+++ b/py_modules/unifideck/launcher/proton/fixes/game_fixes.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, cast
+logger = logging.getLogger(__name__)
+@dataclass(frozen=True)
+class GameFix:
+    """Game fix."""
+    winetricks: list[str] = field(default_factory=list)
+    exe_override: str | None = None
+    notes: str = ""
+    source: str = ""
+
+GLOBAL_DEFAULTS: list[str] = [
+    "vcrun2005",
+    "vcrun2008",
+    "vcrun2010",
+    "vcrun2012",
+    "vcrun2013",
+    "vcrun2022",
+    "d3dcompiler_47",
+    "d3dcompiler_43",
+    "mfc140",
+]
+MANUAL_FIXES: dict[str, GameFix] = {
+    "Dodo": GameFix(
+        winetricks=[],
+        notes="Works with Proton + EOS only",
+        source="manual",
+    ),
+    "ea8df71f923649a193ab1c1fded7e1b3": GameFix(
+        winetricks=[
+            "vcrun2005", "vcrun2008", "vcrun2010", "vcrun2012",
+            "vcrun2013", "vcrun2022",
+        ],
+        exe_override=(
+            "Ghostrunner/Binaries/Win64/"
+            "Ghostrunner-Win64-Shipping.exe"
+        ),
+        notes=(
+            "UE4 stub bypassed — launches shipping binary "
+            "directly. The default Ghostrunner.exe is a 540KB "
+            "launcher stub that probes VC++ runtime registry "
+            "keys via MsiQueryProductState and shows a "
+            "'Microsoft Visual C++ Runtime' error even when "
+            "DLLs are present. Proton rewrites system.reg at "
+            "launch time, making registry injection impossible."
+        ),
+        source="manual",
+    ),
+    "fa5aa7e6c28c4c94aeac239eee700d5f": GameFix(
+        winetricks=[],
+        notes="EOS overlay only, no redistributables needed",
+        source="manual",
+    ),
+}
+_UMU_DATABASE_URL_FORMATS = [
+    "https://raw.githubusercontent.com/Open-Wine-Components/"
+    "umu-database/main/umu-egs-{game_id}.json",
+    "https://raw.githubusercontent.com/Open-Wine-Components/"
+    "umu-database/main/umu-epic-{game_id}.json",
+]
+_UMU_CACHE: dict[str, tuple[float, dict | None]] = {}
+_CACHE_TTL_SECONDS = 3600
+def get_exe_override(game_id: str) -> str | None:
+    """Get exe override."""
+    fix = MANUAL_FIXES.get(game_id)
+    if fix is None:
+        return None
+    return fix.exe_override
+
+async def fetch_umu_protonfixes(game_id: str) -> dict | None:
+
+    """Fetch UMU protonfixes."""
+    now = time.monotonic()
+    cached = _UMU_CACHE.get(game_id)
+    if (
+        cached is not None
+        and now - cached[0] < _CACHE_TTL_SECONDS
+    ):
+        return cached[1]
+    _UMU_CACHE[game_id] = (now, None)
+    try:
+        import aiohttp
+    except ImportError:
+        logger.info(
+            "[game_fixes] aiohttp not available, skipping "
+            "umu-database lookup for %s", game_id,
+        )
+        return None
+    timeout = aiohttp.ClientTimeout(total=10)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        for url_format in _UMU_DATABASE_URL_FORMATS:
+            url = url_format.format(game_id=game_id)
+            data = await _try_umu_url(session, url)
+            if data is not None:
+                logger.info(
+                    "[game_fixes] found umu-db "
+                    "entry for %s", game_id,
+                )
+                _UMU_CACHE[game_id] = (now, data)
+                return cast("dict[Any, Any] | None", data)
+    logger.info(
+        "[game_fixes] no umu-db entry for %s (expected "
+        "for most games)", game_id,
+    )
+    return None
+async def _try_umu_url(
+    session: Any, url: str,
+) -> dict | None:
+    """Try UMU URL."""
+    import aiohttp
+    try:
+        async with session.get(url) as response:
+            if response.status != 200:
+                return None
+            data = await response.json(content_type=None)
+            return cast("dict[Any, Any] | None", data)
+    except (aiohttp.ClientError, json.JSONDecodeError) as e:
+        logger.debug(
+            "[game_fixes] %s lookup failed: %s", url, e,
+        )
+        return None
+async def get_required_winetricks(game_id: str) -> list[str]:
+    """Get required winetricks."""
+    manual = MANUAL_FIXES.get(game_id)
+    if manual is not None:
+        logger.info(
+            "[game_fixes] manual override for %s: %s",
+            game_id, manual.winetricks,
+        )
+        return list(manual.winetricks)
+    umu_data = await fetch_umu_protonfixes(game_id)
+    if umu_data and isinstance(
+        umu_data.get("winetricks"), list,
+    ):
+        packages = umu_data["winetricks"]
+        logger.info(
+            "[game_fixes] umu-db for %s: %s",
+            game_id, packages,
+        )
+        return list(packages)
+    logger.info(
+        "[game_fixes] global defaults for %s", game_id,
+    )
+    return list(GLOBAL_DEFAULTS)
+
+async def get_game_fix(game_id: str) -> GameFix:
+
+    """Get game fix."""
+    manual = MANUAL_FIXES.get(game_id)
+    if manual is not None:
+        return manual
+    umu_data = await fetch_umu_protonfixes(game_id)
+    if umu_data:
+        return GameFix(
+            winetricks=list(
+                umu_data.get("winetricks") or [],
+            ),
+            exe_override=umu_data.get("exe_override"),
+            notes=str(umu_data.get("notes") or ""),
+            source="umu-protonfixes",
+        )
+    return GameFix(
+        winetricks=list(GLOBAL_DEFAULTS),
+        notes=(
+            "Using global defaults "
+            "(vcrun*, d3dcompiler, mfc140)"
+        ),
+        source="global_default",
+    )
+def clear_cache() -> None:
+    """Clear cache."""
+    _UMU_CACHE.clear()

--- a/py_modules/unifideck/launcher/proton/handlers/epic.py
+++ b/py_modules/unifideck/launcher/proton/handlers/epic.py
@@ -1,5 +1,173 @@
-"""epic.py — Epic Proton handler
-# OP-43b | py_modules/unifideck/launcher/proton/handlers/epic.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from ...types.errors import GameFailedError, UmuRuntimeError
+from ..infrastructure.core import ProtonLaunchPlan
+from ..infrastructure.umu_runtime import run_umu_with_retry
+logger = logging.getLogger(__name__)
+
+def _lazy_cleanup_ubisoft_artifacts(plan: ProtonLaunchPlan) -> None:
+
+    """Lazy cleanup UBISOFT artifacts."""
+    drive_cs = [plan.prefix_path / "drive_c"]
+    active = os.environ.get("ACTIVE_WINEPREFIX")
+    if active:
+        drive_cs.append(Path(active) / "drive_c")
+    targets_per_drive = [
+        "windows/command/EpicGamesLauncher.exe",
+        (
+            "Program Files (x86)/Epic Games/Launcher/"
+            "Portal/Binaries/Win32/EpicGamesLauncher.exe"
+        ),
+    ]
+    for drive_c in drive_cs:
+        if not drive_c.is_dir():
+            continue
+        for rel in targets_per_drive:
+            target = drive_c / rel
+            if target.is_file():
+                try:
+                    target.unlink()
+                    logger.info(
+                        "[launcher.proton.epic] removed stub: %s",
+                        target,
+                    )
+                except OSError:
+                    pass
+    prefix_candidates = [plan.prefix_path]
+    if active:
+        prefix_candidates.append(Path(active))
+    for prefix in prefix_candidates:
+        for reg_name in ("user.reg", "system.reg"):
+            reg = prefix / reg_name
+            if not reg.is_file():
+                continue
+            try:
+                content = reg.read_text(
+                    encoding="utf-8", errors="replace",
+                )
+            except OSError:
+                continue
+            if "com.epicgames.launcher" not in content:
+                continue
+            new_content = _strip_registry_section(
+                content, "com.epicgames.launcher",
+            )
+            if new_content != content:
+                try:
+                    reg.write_text(
+                        new_content, encoding="utf-8",
+                    )
+                    logger.info(
+                        "[launcher.proton.epic] cleaned %s "
+                        "from %s",
+                        "com.epicgames.launcher", reg.name,
+                    )
+                except OSError:
+                    pass
+
+def _strip_registry_section(content: str, section_key: str) -> str:
+
+    """Strip registry section."""
+    lines = content.splitlines(keepends=True)
+    out: list[str] = []
+    skipping = False
+    header_pat = re.compile(
+        r"^\[.*" + re.escape(section_key) + r".*\]",
+    )
+    next_section_pat = re.compile(r"^\[")
+    for line in lines:
+        if (
+            skipping
+            and next_section_pat.match(line)
+            and not header_pat.match(line)
+        ):
+            skipping = False
+            out.append(line)
+            continue
+        if header_pat.match(line):
+            skipping = True
+            continue
+        if skipping:
+            continue
+        out.append(line)
+    return "".join(out)
+def _resolve_exe_override(plan: ProtonLaunchPlan) -> Path | None:
+    """Resolve exe override."""
+    from ..fixes.game_fixes import get_exe_override
+    rel = get_exe_override(plan.context.game_id)
+    if not rel:
+        return None
+    installed = Path(
+        "~/.config/legendary/installed.json",
+    ).expanduser()
+    if not installed.is_file():
+        return None
+    try:
+        with installed.open() as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    install_path = (
+        data.get(plan.context.game_id, {}).get("install_path")
+    )
+    if not install_path:
+        return None
+    full = Path(install_path) / rel
+    return full if full.is_file() else None
+
+async def epic_launch(plan: ProtonLaunchPlan) -> int:
+
+    """Epic launch."""
+    logger.info(
+    "[launcher.proton.epic] launching %s", plan.context.game_key,
+   )
+    _lazy_cleanup_ubisoft_artifacts(plan)
+    env = dict(plan.env)
+    env["STORE"] = "none"
+    env.pop("LEGENDARY_WRAPPER_EXE", None)
+    exe_override = _resolve_exe_override(plan)
+    legendary_bin = os.environ.get("LEGENDARY_BIN", "legendary")
+    argv: list[str] = list(plan.state.wrappers)
+    argv.extend([
+    legendary_bin,
+    "launch",
+    plan.context.game_id,
+    "--no-wine",
+    "--skip-version-check",
+    "--wrapper",
+    f"{plan.python_bin} {plan.umu_wrapper}",
+    "--language",
+    os.environ.get("EPIC_LANG", "en"),
+    ])
+    if exe_override:
+        argv.extend(["--override-exe", str(exe_override)])
+        logger.info(
+            "[launcher.proton.epic] using EXE override: %s",
+            exe_override,
+        )
+    if plan.state.game_args:
+        argv.append("--")
+        argv.extend(plan.state.game_args)
+    rc = await run_umu_with_retry(
+        argv, env=env, on_start=plan.on_process_start,
+    )
+    plan.state.game_exit_code = rc
+    if rc == 0:
+        return 0
+    if rc in {2, 74}:
+        raise UmuRuntimeError(
+            f"umu-run failed with unrecoverable code {rc}",
+            context={"subprocess_rc": rc, "store": "epic"},
+        )
+    raise GameFailedError(
+        f"Epic game exited with code {rc}",
+        subprocess_rc=rc,
+        context={
+            "store": "epic",
+            "game_id": plan.context.game_id,
+        },
+    )

--- a/py_modules/unifideck/launcher/proton/handlers/generic.py
+++ b/py_modules/unifideck/launcher/proton/handlers/generic.py
@@ -1,5 +1,129 @@
-"""generic.py — Generic Proton handler
-# OP-43c | py_modules/unifideck/launcher/proton/handlers/generic.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import shutil
+from pathlib import Path
+from ...types.errors import GameFailedError, UmuRuntimeError
+from ..infrastructure.core import ProtonLaunchPlan
+from ..infrastructure.umu_runtime import run_umu_with_retry
+logger = logging.getLogger(__name__)
+def _locate_store_cli(plan: ProtonLaunchPlan, tool_name: str) -> Path | None:
+    """Locate store cli."""
+    plugin_bin = plan.context.plugin_dir / "bin" / tool_name
+    if plugin_bin.is_file():
+        return plugin_bin
+    system = shutil.which(tool_name)
+    return Path(system) if system else None
+async def _gog_launch(plan: ProtonLaunchPlan) -> int:
+    """Gog launch."""
+    try:
+        from ....config.config_manager import ConfigManager
+        from ..language_setup import apply_gog_language
+        _cfg = ConfigManager(
+            str(plan.context.plugin_dir / "defaults" / "config.json"),
+        )
+        work_dir = plan.context.work_dir or plan.context.exe_path.parent
+        apply_gog_language(
+            plan.context.game_id, str(work_dir), config=_cfg,
+        )
+    except Exception as err:
+        logger.warning(
+            "[launcher.proton.generic] GOG language setup failed: %s",
+            err,
+        )
+    try:
+        from ..fixes.galaxy_stub import install_galaxy_stub
+        install_galaxy_stub(
+            str(plan.prefix_path),
+            plugin_dir=plan.context.plugin_dir,
+        )
+    except Exception as err:
+        logger.warning(
+            "[launcher.proton.generic] Galaxy stub install failed: %s",
+            err,
+        )
+    gogdl = _locate_store_cli(plan, "gogdl")
+    if gogdl:
+        logger.info("[launcher.proton.generic] GOG via gogdl: %s", gogdl)
+        argv: list[str] = list(plan.state.wrappers)
+        argv.extend([
+            str(gogdl),
+            "launch",
+            plan.context.game_id,
+            "--wrapper",
+            f"{plan.python_bin} {plan.umu_wrapper}",
+        ])
+        if plan.state.game_args:
+            argv.append("--")
+            argv.extend(plan.state.game_args)
+        return await run_umu_with_retry(argv, env=plan.env, on_start=plan.on_process_start)
+    return await _raw_exe_launch(plan)
+
+async def _amazon_launch(plan: ProtonLaunchPlan) -> int:
+
+    """Amazon launch."""
+    try:
+        from ....config.config_manager import ConfigManager
+        from ..language_setup import apply_amazon_language
+        _cfg = ConfigManager(
+            str(plan.context.plugin_dir / "defaults" / "config.json"),
+        )
+        apply_amazon_language(str(plan.prefix_path), config=_cfg)
+    except Exception as err:
+        logger.warning(
+            "[launcher.proton.generic] Amazon language setup failed: %s",
+            err,
+        )
+    nile = _locate_store_cli(plan, "nile")
+    if nile:
+        logger.info("[launcher.proton.generic] Amazon via nile: %s", nile)
+        argv: list[str] = list(plan.state.wrappers)
+        argv.extend([
+            str(nile),
+            "launch",
+            plan.context.game_id,
+            "--wrapper",
+            f"{plan.python_bin} {plan.umu_wrapper}",
+        ])
+        if plan.state.game_args:
+            argv.append("--")
+            argv.extend(plan.state.game_args)
+        return await run_umu_with_retry(argv, env=plan.env, on_start=plan.on_process_start)
+    return await _raw_exe_launch(plan)
+async def _raw_exe_launch(plan: ProtonLaunchPlan) -> int:
+    """Raw exe launch."""
+    logger.info(
+        "[launcher.proton.generic] raw exe launch: %s", plan.context.exe_path,
+    )
+    cwd: Path | None = None
+    if plan.context.exe_path.parent.is_dir():
+        cwd = plan.context.exe_path.parent
+    argv: list[str] = list(plan.state.wrappers)
+    argv.extend([
+        str(plan.python_bin),
+        str(plan.umu_wrapper),
+        str(plan.context.exe_path),
+    ])
+    argv.extend(plan.state.game_args)
+    return await run_umu_with_retry(argv, env=plan.env, cwd=cwd, on_start=plan.on_process_start)
+async def generic_launch(plan: ProtonLaunchPlan) -> int:
+    """Generic launch."""
+    store = plan.context.store
+    if store == "gog":
+        rc = await _gog_launch(plan)
+    elif store == "amazon":
+        rc = await _amazon_launch(plan)
+    else:
+        rc = await _raw_exe_launch(plan)
+    plan.state.game_exit_code = rc
+    if rc == 0:
+        return 0
+    if rc in {2, 74}:
+        raise UmuRuntimeError(
+            f"umu-run failed with unrecoverable code {rc}",
+            context={"subprocess_rc": rc, "store": store},
+        )
+    raise GameFailedError(
+        f"{store} game exited with code {rc}",
+        subprocess_rc=rc,
+        context={"store": store, "game_id": plan.context.game_id},
+    )

--- a/py_modules/unifideck/launcher/proton/handlers/gog_linux_dosbox.py
+++ b/py_modules/unifideck/launcher/proton/handlers/gog_linux_dosbox.py
@@ -1,5 +1,135 @@
-"""gog_linux_dosbox.py — GOG DOSBox handler
-# OP-43d | py_modules/unifideck/launcher/proton/handlers/gog_linux_dosbox.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import os
+import platform
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import NoReturn
+DOSBOX_CALL_RE = re.compile(r'run_dosbox\s+((?:\"[^\"]+\"\s*)+)')
+def find_steam_runtime() -> Path | None:
+    """Find steam runtime."""
+    candidates = (
+        Path.home() / ".steam" / "steam" / "ubuntu12_32" / "steam-runtime",
+        Path.home() / ".local" / "share" / "Steam" / "ubuntu12_32" / "steam-runtime",
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+def build_runtime_library_paths(
+    runtime_root: Path, arch_dir: str,
+) -> list[str]:
+    """Build runtime library paths."""
+    paths: list[str] = []
+    for rel in (f"usr/lib/{arch_dir}", f"lib/{arch_dir}"):
+        candidate = runtime_root / rel
+        if candidate.exists():
+            paths.append(str(candidate))
+    return paths
+def parse_dosbox_conf_args(start_script: Path) -> list[str]:
+    """Parse dosbox conf args."""
+    content = start_script.read_text(encoding="utf-8", errors="ignore")
+    match = DOSBOX_CALL_RE.search(content)
+    if not match:
+        raise ValueError(
+            f"Could not find run_dosbox call in {start_script}",
+        )
+    return shlex.split(match.group(1))
+def launch_via_steam_runtime(
+    runtime_root: Path | None,
+    start_script: Path,
+    args: list[str],
+) -> NoReturn:
+    """Launch via steam runtime."""
+    if runtime_root:
+        run_sh = runtime_root / "run.sh"
+        if run_sh.exists():
+            os.execv(str(run_sh), [str(run_sh), str(start_script), *args])
+    os.execv(str(start_script), [str(start_script), *args])
+def _parse_argv() -> tuple[Path, list[str]]:
+    """Parse argv."""
+    if len(sys.argv) < 2:
+        raise SystemExit(
+            "Usage: python -m "
+            "unifideck.launcher.proton.gog_linux_dosbox "
+            "/path/to/start.sh [args...]",
+        )
+    start_script = Path(sys.argv[1]).resolve()
+    extra_args = [
+        arg for arg in sys.argv[2:]
+        if not re.match(r"^(epic|gog|amazon|ubisoft):", arg)
+    ]
+    return start_script, extra_args
+
+def _select_architecture(
+    dosbox_dir: Path,
+) -> tuple[Path, Path, str] | None:
+
+    """Select architecture."""
+    arch = platform.machine().lower()
+    if arch in {"x86_64", "amd64"}:
+        return (
+            dosbox_dir / "dosbox_x86_64",
+            dosbox_dir / "libs" / "x86_64",
+            "x86_64-linux-gnu",
+        )
+    if arch in {"i686", "i386"}:
+        return (
+            dosbox_dir / "dosbox_i686",
+            dosbox_dir / "libs" / "i686",
+            "i386-linux-gnu",
+        )
+    return None
+def _build_env(
+    bundled_lib_dir: Path,
+    runtime_root: Path | None,
+    runtime_arch_dir: str,
+) -> dict[str, str]:
+    """Build env."""
+    runtime_libs = (
+        build_runtime_library_paths(runtime_root, runtime_arch_dir)
+        if runtime_root else []
+    )
+    env = os.environ.copy()
+    ld_parts = [str(bundled_lib_dir), *runtime_libs]
+    if env.get("LD_LIBRARY_PATH"):
+        ld_parts.append(env["LD_LIBRARY_PATH"])
+    env["LD_LIBRARY_PATH"] = ":".join(
+        dict.fromkeys(part for part in ld_parts if part),
+    )
+    return env
+def main() -> None:
+    """Main."""
+    start_script, extra_args = _parse_argv()
+    runtime_root = find_steam_runtime()
+    if extra_args:
+        launch_via_steam_runtime(
+            runtime_root, start_script, extra_args,
+        )
+    root_dir = start_script.parent
+    dosbox_dir = root_dir / "dosbox"
+    if not dosbox_dir.is_dir():
+        launch_via_steam_runtime(
+            runtime_root, start_script, extra_args,
+        )
+    arch_info = _select_architecture(dosbox_dir)
+    if arch_info is None:
+        launch_via_steam_runtime(
+            runtime_root, start_script, extra_args,
+        )
+    binary, bundled_lib_dir, runtime_arch_dir = arch_info
+    if not binary.exists() or not bundled_lib_dir.is_dir():
+        launch_via_steam_runtime(
+            runtime_root, start_script, extra_args,
+        )
+    conf_args = parse_dosbox_conf_args(start_script)
+    env = _build_env(bundled_lib_dir, runtime_root, runtime_arch_dir)
+    command = [str(binary)]
+    for conf in conf_args:
+        command.extend(["-conf", conf])
+    command.extend(["-no-console", "-c", "exit"])
+    os.chdir(root_dir)
+    os.execvpe(str(binary), command, env)
+if __name__ == "__main__":
+    main()

--- a/py_modules/unifideck/launcher/proton/handlers/ubisoft.py
+++ b/py_modules/unifideck/launcher/proton/handlers/ubisoft.py
@@ -1,5 +1,185 @@
-"""ubisoft.py — Ubisoft Proton handler
-# OP-43a | py_modules/unifideck/launcher/proton/handlers/ubisoft.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import os
+from pathlib import Path
+from ...types.errors import GameFailedError, UmuRuntimeError
+from ..infrastructure.core import ProtonLaunchPlan
+from ..infrastructure.umu_runtime import run_umu_with_retry
+logger = logging.getLogger(__name__)
+async def _apply_epic_wrapper_fix(plan: ProtonLaunchPlan) -> None:
+    """Apply EPIC wrapper fix."""
+    from ..fixes.epic_prefix_fix import apply_epic_launcher_fix
+    bundled_wrapper = (
+    plan.context.plugin_dir / "bin" / "EpicGamesLauncher.exe"
+   )
+    if not bundled_wrapper.is_file():
+        logger.warning(
+        "[launcher.proton.ubisoft] EpicGamesLauncher.exe "
+        "wrapper missing at %s",
+        bundled_wrapper,
+       )
+        return
+    try:
+        await apply_epic_launcher_fix(
+            prefix_path=plan.prefix_path,
+            bundled_wrapper=bundled_wrapper,
+        )
+        logger.info(
+            "[launcher.proton.ubisoft] Epic launcher wrapper applied",
+        )
+    except Exception:
+        logger.exception(
+            "[launcher.proton.ubisoft] Epic launcher wrapper fix failed",
+        )
+async def _inject_registry_keys(plan: ProtonLaunchPlan) -> bool:
+    """Inject registry keys."""
+    from ..fixes.epic_registry import setup_registry
+    legendary_config = Path("~/.config/legendary").expanduser()
+    try:
+        result = await setup_registry(
+            game_id=plan.context.game_id,
+            prefix_path=plan.prefix_path,
+            legendary_config=legendary_config,
+        )
+        return result.success
+    except Exception:
+        logger.exception(
+            "[launcher.proton.ubisoft] registry injection crashed",
+        )
+        return False
+
+def _find_upc_exe(plan: ProtonLaunchPlan) -> Path | None:
+
+    """Find UPC exe."""
+    active_prefix = os.environ.get("ACTIVE_WINEPREFIX")
+    candidates: list[Path] = []
+    if active_prefix:
+        candidates.append(
+            Path(active_prefix)
+            / "drive_c"
+            / "Program Files (x86)"
+            / "Ubisoft"
+            / "Ubisoft Game Launcher"
+            / "upc.exe",
+        )
+    candidates.append(
+        plan.prefix_path
+        / "drive_c"
+        / "Program Files (x86)"
+        / "Ubisoft"
+        / "Ubisoft Game Launcher"
+        / "upc.exe",
+    )
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+async def ubisoft_launch(plan: ProtonLaunchPlan) -> int:
+    """Ubisoft launch."""
+    logger.info(
+        "[launcher.proton.ubisoft] launching %s",
+        plan.context.game_key,
+    )
+    await _apply_epic_wrapper_fix(plan)
+    if not await _inject_registry_keys(plan):
+        logger.warning(
+            "[launcher.proton.ubisoft] registry injection "
+            "failed or skipped",
+        )
+    _apply_language_setup(plan)
+    upc_exe = _find_upc_exe(plan)
+    uplay_id = os.environ.get("UPLAY_ID")
+    if upc_exe and uplay_id:
+        logger.info(
+            "[launcher.proton.ubisoft] direct launch: "
+            "uplay://launch/%s/0",
+            uplay_id,
+        )
+        argv = [
+            str(plan.python_bin),
+            str(plan.umu_wrapper),
+            str(upc_exe),
+            f"uplay://launch/{uplay_id}/0",
+        ]
+        env = plan.env
+    else:
+        logger.warning(
+            "[launcher.proton.ubisoft] upc.exe or UPLAY_ID "
+            "missing, falling back to Legendary path",
+        )
+        argv, env = _build_legendary_fallback_argv(plan)
+    rc = await run_umu_with_retry(
+        argv, env=env, on_start=plan.on_process_start,
+    )
+    plan.state.game_exit_code = rc
+    if rc == 0:
+        return 0
+    _raise_for_umu_rc(rc, plan)
+    return rc
+
+def _apply_language_setup(plan: ProtonLaunchPlan) -> None:
+
+    """Apply language setup."""
+    try:
+        from ....config.config_manager import ConfigManager
+        from ..language_setup import apply_ubisoft_language
+        _cfg = ConfigManager(
+            str(plan.context.plugin_dir / "defaults" / "config.json"),
+        )
+        apply_ubisoft_language(
+            str(plan.prefix_path),
+            space_id=plan.context.game_id,
+            config=_cfg,
+        )
+    except Exception as err:
+        logger.warning(
+            "[launcher.proton.ubisoft] language setup failed: %s",
+            err,
+        )
+def _build_legendary_fallback_argv(
+    plan: ProtonLaunchPlan,
+) -> tuple[list[str], dict[str, str]]:
+    """Build LEGENDARY fallback argv."""
+    env = dict(plan.env)
+    env["LEGENDARY_WRAPPER_EXE"] = (
+        "C:\\windows\\command\\EpicGamesLauncher.exe"
+    )
+    legendary_bin = os.environ.get("LEGENDARY_BIN", "legendary")
+    argv = plan.state.wrappers + [
+        legendary_bin,
+        "launch",
+        plan.context.game_id,
+        "--no-wine",
+        "--skip-version-check",
+        "--wrapper",
+        f"{plan.python_bin} {plan.umu_wrapper}",
+        "--language",
+        os.environ.get("EPIC_LANG", "en"),
+    ]
+    if plan.state.game_args:
+        argv.append("--")
+        argv.extend(plan.state.game_args)
+    try:
+        from ..fixes.auth_args_stripper import strip_epic_auth_args
+        argv, _stripped = strip_epic_auth_args(argv)
+    except Exception as err:
+        logger.warning(
+            "[launcher.proton.ubisoft] auth args strip failed: %s",
+            err,
+        )
+    return argv, env
+def _raise_for_umu_rc(rc: int, plan: ProtonLaunchPlan) -> None:
+    """Raise for UMU rc."""
+    if rc in {2, 74}:
+        raise UmuRuntimeError(
+            f"umu-run failed with unrecoverable code {rc}",
+            context={"subprocess_rc": rc, "store": "ubisoft"},
+        ) from None
+    raise GameFailedError(
+        f"Ubisoft game exited with code {rc}",
+        subprocess_rc=rc,
+        context={
+            "store": "ubisoft",
+            "game_id": plan.context.game_id,
+        },
+    ) from None

--- a/py_modules/unifideck/launcher/proton/infrastructure/core.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/core.py
@@ -1,5 +1,122 @@
-"""core.py — Proton infrastructure core
-# OP-42a | py_modules/unifideck/launcher/proton/infrastructure/core.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from ...types.context import LaunchContext, RuntimeState
+from ...types.errors import DependencyMissingError
+logger = logging.getLogger(__name__)
+STORE_TO_UMU = {
+ "epic": "egs",
+ "gog": "gog",
+ "amazon": "amazon",
+ "ubisoft": "ubisoft",
+ "microsoft": "microsoft",
+}
+@dataclass(frozen=True)
+class ProtonLaunchPlan:
+    """Proton launch plan."""
+    context: LaunchContext
+    state: RuntimeState
+    python_bin: Path
+    umu_wrapper: Path
+    prefix_path: Path
+    env: dict[str, str]
+    on_process_start: Callable[[object], None] | None = None
+def _ubisoft_prefix_path(ctx: LaunchContext, prefixes_dir: Path) -> Path:
+    """Ubisoft prefix path."""
+    import os
+    ubi_name = os.environ.get("UNIFIDECK_UBISOFT_PREFIX_NAME") or ctx.game_id
+    return prefixes_dir / "ubisoft" / ubi_name
+def _resolve_prefix(ctx: LaunchContext) -> Path:
+    """Resolve prefix."""
+    prefixes_dir = Path("~/.local/share/unifideck/prefixes").expanduser()
+    if ctx.store == "ubisoft":
+        path = _ubisoft_prefix_path(ctx, prefixes_dir)
+    else:
+        path = prefixes_dir / ctx.game_id
+        while path.name == "pfx":
+            path = path.parent
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+def _lookup_umu_id(
+ ctx: LaunchContext,
+ umu_store: str,
+ plugin_dir: Path,
+) -> str | None:
+    """Lookup UMU ID."""
+    helper = plugin_dir / "bin" / "umu_lookup.py"
+    if not helper.is_file():
+        return None
+    try:
+        out = subprocess.check_output(
+            ["python3", str(helper), ctx.game_id, umu_store],
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+        text = out.decode().strip()
+        return text or None
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+def _locate_umu_wrapper(proton_path: Path) -> Path:
+
+    """Locate UMU wrapper."""
+    bundled = proton_path.parent / "umu-run"
+    if bundled.is_file():
+        return bundled
+    system = shutil.which("umu-run")
+    if system:
+        return Path(system)
+    raise DependencyMissingError(
+        "umu-run not found (neither bundled with proton "
+        "nor in PATH)",
+        context={"proton_path": str(proton_path)},
+    )
+def proton_prepare(
+ ctx: LaunchContext,
+ state: RuntimeState,
+ *,
+ python_bin: Path,
+ proton_path: Path,
+ proton_tool_id: str,
+ on_process_start: Callable[[object], None] | None = None,
+) -> ProtonLaunchPlan:
+    """Proton prepare."""
+    import os
+    umu_store = STORE_TO_UMU.get(ctx.store, "none")
+    prefix_path = _resolve_prefix(ctx)
+    umu_id = _lookup_umu_id(ctx, umu_store, ctx.plugin_dir)
+    umu_wrapper = _locate_umu_wrapper(proton_path)
+    state.python_bin = python_bin
+    state.proton_path = proton_path
+    state.proton_tool_id = proton_tool_id
+    state.prefix_path = prefix_path
+    state.umu_store_code = umu_store
+    state.umu_id = umu_id
+    state.umu_wrapper = umu_wrapper
+    env = dict(os.environ)
+    env["GAMEID"] = umu_id or "umu-0"
+    env["STORE"] = umu_store
+    env["STEAM_COMPAT_DATA_PATH"] = str(prefix_path)
+    env["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = str(
+    Path("~/.steam/root").expanduser,
+   )
+    env["PROTON_VERB"] = "waitforexitandrun"
+    env.update(ctx.env_overrides)
+    logger.info(
+    "[launcher.proton.core] plan ready: store=%s umu_store=%s "
+    "umu_id=%s prefix=%s proton=%s",
+    ctx.store, umu_store, umu_id, prefix_path, proton_tool_id,
+   )
+    return ProtonLaunchPlan(
+    context=ctx,
+    state=state,
+    python_bin=python_bin,
+    umu_wrapper=umu_wrapper,
+    prefix_path=prefix_path,
+    env=env,
+    on_process_start=on_process_start,
+   )

--- a/py_modules/unifideck/launcher/proton/infrastructure/prefix_layout.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/prefix_layout.py
@@ -1,5 +1,37 @@
-"""prefix_layout.py — Wine prefix layout
-# OP-42d | py_modules/unifideck/launcher/proton/infrastructure/prefix_layout.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+from pathlib import Path
+logger = logging.getLogger(__name__)
+PathLike = str | Path
+def normalize_prefix_root(prefix_path: PathLike) -> Path:
+    """Normalize prefix root."""
+    p = Path(prefix_path).resolve() if isinstance(prefix_path, str) \
+        else prefix_path.resolve()
+    while p.name == "pfx":
+        p = p.parent
+    return p
+def resolve_registry_prefix(prefix_root: PathLike) -> Path:
+    """Resolve registry prefix."""
+    root = Path(prefix_root) if isinstance(prefix_root, str) \
+        else prefix_root
+    direct = root / "user.reg"
+    pfx = root / "pfx"
+    pfx_reg = pfx / "user.reg"
+    if direct.exists():
+        return root
+    if pfx_reg.exists():
+        return pfx
+    if pfx.is_dir():
+        return pfx
+    return root
+def resolve_drive_c(prefix_root: PathLike) -> Path | None:
+    """Resolve drive c."""
+    root = Path(prefix_root) if isinstance(prefix_root, str) \
+        else prefix_root
+    modern = root / "pfx" / "drive_c"
+    if modern.is_dir():
+        return modern
+    legacy = root / "drive_c"
+    if legacy.is_dir():
+        return legacy
+    return None

--- a/py_modules/unifideck/launcher/proton/infrastructure/selector.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/selector.py
@@ -1,5 +1,157 @@
-"""selector.py — Proton version selector
-# OP-42c | py_modules/unifideck/launcher/proton/infrastructure/selector.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import re
+import subprocess
+from pathlib import Path
+from ...types.errors import DependencyMissingError, ProtonUnavailableError
+logger = logging.getLogger(__name__)
+PYTHON_CANDIDATES: list[str] = [
+    "/usr/bin/python3.13",
+    "/usr/bin/python3.12",
+    "/usr/bin/python3.11",
+    "/usr/bin/python3.10",
+    "/usr/bin/python3",
+]
+ACCEPTED_VERSIONS = {"3.10", "3.11", "3.12", "3.13", "3.14"}
+def find_python_3_10_plus() -> Path:
+    """Find python 3 10 plus."""
+    for candidate in PYTHON_CANDIDATES:
+        path = Path(candidate)
+        if not path.is_file():
+            continue
+        try:
+            out = subprocess.check_output(
+                [
+                    candidate,
+                    "-c",
+                    'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")',
+                ],
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
+        except (subprocess.SubprocessError, OSError):
+            continue
+        ver = out.decode().strip()
+        if ver in ACCEPTED_VERSIONS:
+            logger.info("[launcher.proton] python selected: %s (%s)", candidate, ver)
+            return path
+    raise DependencyMissingError(
+        "No Python 3.10+ interpreter found on system",
+        context={"tried": PYTHON_CANDIDATES},
+    )
+
+STEAM_COMPAT_ROOTS: list[str] = [
+    "~/.steam/root/compatibilitytools.d",
+    "~/.local/share/Steam/compatibilitytools.d",
+]
+STEAM_LIBRARY_ROOTS: list[str] = [
+    "~/.steam/root/steamapps/common",
+    "~/.local/share/Steam/steamapps/common",
+]
+UNIFIDECK_COMPAT_DIR = "~/.local/share/unifideck/compat-tools"
+def resolve_proton_path(tool_id: str) -> Path | None:
+    """Resolve PROTON path."""
+    if not tool_id:
+        return None
+    unifideck_path = Path(UNIFIDECK_COMPAT_DIR).expanduser() / tool_id / "proton"
+    if unifideck_path.is_file():
+        return unifideck_path
+    for root in STEAM_COMPAT_ROOTS:
+        candidate = Path(root).expanduser() / tool_id / "proton"
+        if candidate.is_file():
+            return candidate
+    for lib in STEAM_LIBRARY_ROOTS:
+        candidate = Path(lib).expanduser() / tool_id / "proton"
+        if candidate.is_file():
+            return candidate
+    return None
+def get_unifideck_proton_tool() -> str | None:
+    """Get unifideck PROTON tool."""
+    config_path = Path("~/.local/share/unifideck/config.json").expanduser()
+    if not config_path.is_file():
+        return None
+    try:
+        import json
+        with config_path.open() as f:
+            cfg = json.load(f)
+        tool = cfg.get("compat", {}).get("proton_tool", "")
+        return tool or None
+    except (OSError, ValueError):
+        return None
+_COMPAT_TOOL_RE = re.compile(
+    r'"(?P<app_id>\d+)"\s*\{[^}]*?"name"\s*"(?P<name>[^"]+)"',
+    re.S,
+)
+def get_steam_compat_tool_override(app_id: str) -> str | None:
+    """Get steam compat tool override."""
+    if not app_id:
+        return None
+    userdata = Path("~/.steam/root/userdata").expanduser()
+    if not userdata.is_dir():
+        return None
+    for user_dir in userdata.iterdir():
+        cfg = user_dir / "config" / "localconfig.vdf"
+        if not cfg.is_file():
+            continue
+        try:
+            content = cfg.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for m in _COMPAT_TOOL_RE.finditer(content):
+            if m.group("app_id") == app_id:
+                return m.group("name")
+    return None
+def find_any_ge_proton() -> Path | None:
+    """Find any ge PROTON."""
+    candidates: list[Path] = []
+    for root in STEAM_COMPAT_ROOTS:
+        expanded = Path(root).expanduser()
+        if not expanded.is_dir():
+            continue
+        for entry in expanded.iterdir():
+            if entry.name.startswith("GE-Proton"):
+                proton_script = entry / "proton"
+                if proton_script.is_file():
+                    candidates.append(proton_script)
+    if not candidates:
+        return None
+    candidates.sort()
+    return candidates[-1]
+
+def select_proton_version(
+    steam_app_id: str | None = None,
+) -> tuple[Path, str]:
+
+    """Select PROTON version."""
+    tried: list[str] = []
+    if steam_app_id:
+        steam_tool = get_steam_compat_tool_override(steam_app_id)
+        if steam_tool:
+            tried.append(f"steam:{steam_tool}")
+            path = resolve_proton_path(steam_tool)
+            if path:
+                logger.info(
+                    "[launcher.proton] selected via Steam override: %s",
+                    steam_tool,
+                )
+                return path, steam_tool
+    unifideck_tool = get_unifideck_proton_tool()
+    if unifideck_tool:
+        tried.append(f"unifideck:{unifideck_tool}")
+        path = resolve_proton_path(unifideck_tool)
+        if path:
+            logger.info(
+                "[launcher.proton] selected via Unifideck default: %s",
+                unifideck_tool,
+            )
+            return path, unifideck_tool
+    fallback = find_any_ge_proton()
+    if fallback:
+        tool_id = fallback.parent.name
+        tried.append(f"fallback:{tool_id}")
+        logger.info("[launcher.proton] selected via GE-Proton fallback: %s", tool_id)
+        return fallback, tool_id
+    raise ProtonUnavailableError(
+        "No usable Proton compat tool found",
+        context={"tried": tried},
+    )

--- a/py_modules/unifideck/launcher/proton/infrastructure/umu_runtime.py
+++ b/py_modules/unifideck/launcher/proton/infrastructure/umu_runtime.py
@@ -1,5 +1,77 @@
-"""umu_runtime.py — UMU runtime management
-# OP-42b | py_modules/unifideck/launcher/proton/infrastructure/umu_runtime.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+import os
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+logger = logging.getLogger(__name__)
+UMU_CACHE_DIR = Path("~/.local/share/umu").expanduser()
+_RECOVERABLE_CODES = {2, 74}
+def cleanup_umu_runtime_cache() -> None:
+    """Cleanup UMU runtime cache."""
+    targets = [
+        UMU_CACHE_DIR / "steamrt3",
+        UMU_CACHE_DIR / "compatibilitytool.vdf",
+        UMU_CACHE_DIR / ".ref",
+    ]
+    for target in targets:
+        if target.is_dir():
+            shutil.rmtree(target, ignore_errors=True)
+        elif target.exists():
+            try:
+                target.unlink()
+            except OSError:
+                pass
+    logger.info("[launcher.umu] cache cleaned: %s", UMU_CACHE_DIR)
+def ensure_umu_runtime_ready() -> None:
+    """Ensure UMU runtime ready."""
+    UMU_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    os.environ["UMU_LOG"] = "1"
+    os.environ["UMU_NO_PROTON"] = "0"
+    config_dir = Path("~/.config/umu").expanduser()
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+async def run_umu_with_retry(
+    argv: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+    max_attempts: int = 2,
+    on_start: Callable[[object], None] | None = None,
+) -> int:
+
+    """Run UMU with retry."""
+    last_rc = 1
+    for attempt in range(1, max_attempts + 1):
+        logger.info(
+            "[launcher.umu] run attempt %d/%d: %s",
+            attempt, max_attempts, argv[:3],
+        )
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            env=env,
+            cwd=str(cwd) if cwd else None,
+            stdout=None,
+            stderr=None,
+            start_new_session=True,
+        )
+        if on_start is not None:
+            try:
+                on_start(proc)
+            except Exception:
+                logger.exception("[launcher.umu] on_start callback failed")
+        rc = await proc.wait()
+        last_rc = rc
+        logger.info("[launcher.umu] attempt %d exit code: %d", attempt, rc)
+        if rc == 0:
+            return 0
+        if rc in _RECOVERABLE_CODES and attempt < max_attempts:
+            logger.warning(
+                "[launcher.umu] recoverable rc=%d, wiping cache and retrying",
+                rc,
+            )
+            cleanup_umu_runtime_cache()
+            continue
+        return rc
+    return last_rc

--- a/py_modules/unifideck/launcher/proton/language_setup/__init__.py
+++ b/py_modules/unifideck/launcher/proton/language_setup/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+from .amazon import apply_amazon_language
+from .gog import apply_gog_language
+from .resolver import get_unifideck_language
+from .ubisoft import apply_ubisoft_language

--- a/py_modules/unifideck/launcher/proton/language_setup/amazon.py
+++ b/py_modules/unifideck/launcher/proton/language_setup/amazon.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+import logging
+from typing import TYPE_CHECKING
+from .registry_io import _apply_windows_locale
+from .resolver import get_unifideck_language
+if TYPE_CHECKING:
+    from ....config import ConfigManager
+logger = logging.getLogger(__name__)
+def apply_amazon_language(
+    prefix_path: str, config: ConfigManager | None = None,
+) -> bool:
+    """Apply AMAZON language."""
+    language = get_unifideck_language(config)
+    logger.info(
+        "[language_setup.amazon] applying %s to prefix=%s",
+        language, prefix_path,
+    )
+    return _apply_windows_locale(prefix_path, language)

--- a/py_modules/unifideck/launcher/proton/language_setup/gog.py
+++ b/py_modules/unifideck/launcher/proton/language_setup/gog.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import glob
+import json
+import logging
+import os
+from typing import TYPE_CHECKING
+from .matchers import smart_match_gog_language
+from .registry_io import _atomic_write_text
+from .resolver import GOG_DISPLAY_NAMES, get_unifideck_language
+if TYPE_CHECKING:
+    from ....config import ConfigManager
+logger = logging.getLogger(__name__)
+def _find_goggame_info(game_id: str, install_dir: str) -> str | None:
+    """Find goggame info."""
+    search_dir = install_dir
+    for _ in range(4):
+        candidate = os.path.join(search_dir, f"goggame-{game_id}.info")
+        if os.path.exists(candidate):
+            return candidate
+        candidates = glob.glob(
+            os.path.join(search_dir, "goggame-*.info"),
+        )
+        matching = [
+            c for c in candidates
+            if os.path.basename(c).startswith(f"goggame-{game_id}")
+        ]
+        if matching:
+            return matching[0]
+        parent = os.path.dirname(search_dir)
+        if parent == search_dir:
+            break
+        search_dir = parent
+    return None
+
+def apply_gog_language(
+    game_id: str, install_dir: str, config: ConfigManager | None = None,
+) -> bool:
+
+    """Apply GOG language."""
+    language = get_unifideck_language(config)
+    logger.info(
+        "[language_setup.gog] applying %s to game=%s dir=%s",
+        language, game_id, install_dir,
+    )
+    info_path = _find_goggame_info(game_id, install_dir)
+    if info_path is None:
+        logger.info(
+            "[language_setup.gog] no goggame-%s.info found (searched "
+            "4 levels up from %s), skipping", game_id, install_dir,
+        )
+        return False
+    try:
+        with open(info_path, encoding="utf-8") as fh:
+            info = json.load(fh)
+    except (OSError, json.JSONDecodeError) as err:
+        logger.warning(
+            "[language_setup.gog] read %s failed: %s", info_path, err,
+        )
+        return False
+    installed = info.get("languages", [])
+    matched = smart_match_gog_language(language, installed)
+    if matched is None:
+        matched = language
+    display_name = GOG_DISPLAY_NAMES.get(matched, matched)
+    info["language"] = display_name
+    info["languages"] = [matched]
+    try:
+        _atomic_write_text(info_path, json.dumps(info, indent=2))
+    except OSError as err:
+        logger.warning(
+            "[language_setup.gog] write %s failed: %s", info_path, err,
+        )
+        return False
+    logger.info(
+        "[language_setup.gog] set %s → %s (%s)",
+        info_path, matched, display_name,
+    )
+    return True

--- a/py_modules/unifideck/launcher/proton/language_setup/matchers.py
+++ b/py_modules/unifideck/launcher/proton/language_setup/matchers.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from .resolver import LOCALE_MAP
+def smart_match_locale(
+    target: str,
+) -> tuple[str, str, str, str] | None:
+    """Smart match locale."""
+    if not target:
+        return None
+    if target in LOCALE_MAP:
+        return LOCALE_MAP[target]
+    base = target.split("-", maxsplit=1)[0].lower()
+    for code, data in LOCALE_MAP.items():
+        if code.split("-")[0].lower() == base:
+            return data
+    return None
+def smart_match_gog_language(
+    target: str, available: list[str],
+) -> str | None:
+    """Smart match GOG language."""
+    if not target or not available:
+        return None
+    if target in available:
+        return target
+    base = target.split("-", maxsplit=1)[0].lower()
+    for lang in available:
+        if lang.split("-")[0].lower() == base:
+            return lang
+    return None

--- a/py_modules/unifideck/launcher/proton/language_setup/registry_io.py
+++ b/py_modules/unifideck/launcher/proton/language_setup/registry_io.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+import logging
+import os
+import re
+import tempfile
+from .matchers import smart_match_locale
+from .resolver import _DEFAULT_LANGUAGE, LOCALE_MAP
+logger = logging.getLogger(__name__)
+def _resolve_prefix(prefix_path: str) -> str:
+    """Resolve prefix."""
+    from ..infrastructure.prefix_layout import resolve_registry_prefix
+    return str(resolve_registry_prefix(prefix_path))
+def _atomic_write_text(path: str, content: str) -> None:
+    """Atomic write text."""
+    target_dir = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".reg.", suffix=".tmp", dir=target_dir,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+def _update_user_reg(
+    prefix_path: str,
+    lcid: str, slanguage: str, locale_name: str, scountry: str,
+) -> bool:
+
+    """Update user reg."""
+    user_reg = os.path.join(prefix_path, "user.reg")
+    if not os.path.exists(user_reg):
+        logger.warning(
+            "[language_setup] user.reg missing at %s — prefix not "
+            "initialised yet", user_reg,
+        )
+        return False
+    with open(user_reg, encoding="utf-8", errors="replace") as fh:
+        content = fh.read()
+    section_header = "[Control Panel\\\\International]"
+    new_values = {
+        "Locale": lcid,
+        "LocaleName": locale_name,
+        "sLanguage": slanguage,
+        "sCountry": scountry,
+    }
+    if section_header in content:
+        section_start = content.index(section_header)
+        body_start = section_start + len(section_header)
+        next_section = re.search(r"\n\[", content[body_start:])
+        section_end = (
+            body_start + next_section.start()
+            if next_section else len(content)
+        )
+        section_body = content[body_start:section_end]
+        for key, value in new_values.items():
+            pattern = rf'^"{re.escape(key)}"="[^"]*"'
+            replacement = f'"{key}"="{value}"'
+            new_body, count = re.subn(
+                pattern, replacement, section_body, flags=re.MULTILINE,
+            )
+            if count > 0:
+                section_body = new_body
+            else:
+                section_body = (
+                    section_body.rstrip("\n") + f'\n"{key}"="{value}"\n'
+                )
+        content = (
+            content[:body_start] + section_body + content[section_end:]
+        )
+    else:
+        section = f"\n{section_header}\n"
+        for key, value in new_values.items():
+            section += f'"{key}"="{value}"\n'
+        content += section
+    _atomic_write_text(user_reg, content)
+    logger.info(
+        "[language_setup] wrote locale=%s to %s",
+        locale_name, user_reg,
+    )
+    return True
+def _apply_windows_locale(prefix_path: str, language: str) -> bool:
+    """Apply windows locale."""
+    resolved_prefix = _resolve_prefix(prefix_path)
+    locale = smart_match_locale(language)
+    if locale is None:
+        logger.info(
+            "[language_setup] no locale mapping for %s, using %s",
+            language, _DEFAULT_LANGUAGE,
+        )
+        locale = LOCALE_MAP[_DEFAULT_LANGUAGE]
+    return _update_user_reg(resolved_prefix, *locale)

--- a/py_modules/unifideck/launcher/proton/language_setup/resolver.py
+++ b/py_modules/unifideck/launcher/proton/language_setup/resolver.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+import logging
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ....config import ConfigManager
+logger = logging.getLogger(__name__)
+LOCALE_MAP: dict[str, tuple[str, str, str, str]] = {
+    "en-US": ("00000409", "ENU", "en-US", "United States"),
+    "de-DE": ("00000407", "DEU", "de-DE", "Germany"),
+    "fr-FR": ("0000040c", "FRA", "fr-FR", "France"),
+    "es-ES": ("00000c0a", "ESN", "es-ES", "Spain"),
+    "it-IT": ("00000410", "ITA", "it-IT", "Italy"),
+    "pt-BR": ("00000416", "PTB", "pt-BR", "Brazil"),
+    "ru-RU": ("00000419", "RUS", "ru-RU", "Russia"),
+    "pl-PL": ("00000415", "PLK", "pl-PL", "Poland"),
+    "zh-CN": ("00000804", "CHS", "zh-CN", "China"),
+    "ja-JP": ("00000411", "JPN", "ja-JP", "Japan"),
+    "ko-KR": ("00000412", "KOR", "ko-KR", "Korea"),
+    "nl-NL": ("00000413", "NLD", "nl-NL", "Netherlands"),
+    "tr-TR": ("0000041f", "TRK", "tr-TR", "Turkey"),
+}
+UBISOFT_LANG_MAP: dict[str, str] = {
+    "en-US": "en", "de-DE": "de", "fr-FR": "fr", "es-ES": "es",
+    "it-IT": "it", "pt-BR": "pt", "ru-RU": "ru", "pl-PL": "pl",
+    "zh-CN": "zh", "ja-JP": "ja", "ko-KR": "ko", "nl-NL": "nl",
+    "tr-TR": "tr",
+}
+GOG_DISPLAY_NAMES: dict[str, str] = {
+    "en-US": "English",
+    "fr-FR": "French",
+    "de-DE": "German",
+    "es-ES": "Spanish",
+    "it-IT": "Italian",
+    "pt-BR": "Portuguese (Brazil)",
+    "ru-RU": "Russian",
+    "pl-PL": "Polish",
+    "zh-CN": "Chinese (Simplified)",
+    "zh-Hans": "Chinese (Simplified)",
+    "zh-TW": "Chinese (Traditional)",
+    "zh-Hant": "Chinese (Traditional)",
+    "ja-JP": "Japanese",
+    "ko-KR": "Korean",
+    "nl-NL": "Dutch",
+    "tr-TR": "Turkish",
+}
+_DEFAULT_LANGUAGE = "en-US"
+def get_unifideck_language(config: ConfigManager | None = None) -> str:
+    """Get unifideck language."""
+    if config is None:
+        logger.debug(
+            "[language_setup] no ConfigManager provided, using %s",
+            _DEFAULT_LANGUAGE,
+        )
+        return _DEFAULT_LANGUAGE
+    try:
+        from ....utils.locale import get_unifideck_locale
+        return get_unifideck_locale(config)
+    except Exception as err:
+        logger.warning(
+            "[language_setup] locale resolver failed: %s, "
+            "falling back to %s", err, _DEFAULT_LANGUAGE,
+        )
+        return _DEFAULT_LANGUAGE

--- a/py_modules/unifideck/launcher/proton/language_setup/ubisoft.py
+++ b/py_modules/unifideck/launcher/proton/language_setup/ubisoft.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+import json
+import logging
+import os
+import re
+from typing import TYPE_CHECKING
+from .registry_io import (
+    _apply_windows_locale,
+    _atomic_write_text,
+    _resolve_prefix,
+)
+from .resolver import UBISOFT_LANG_MAP, get_unifideck_language
+if TYPE_CHECKING:
+    from ....config import ConfigManager
+logger = logging.getLogger(__name__)
+def _load_ubisoft_install_id(space_id: str) -> str | None:
+    """Load UBISOFT install ID."""
+    id_map_path = os.path.expanduser(
+        "~/.local/share/unifideck/ubisoft_id_map.json",
+    )
+    if not os.path.isfile(id_map_path):
+        return None
+    try:
+        with open(id_map_path, encoding="utf-8") as fh:
+            id_map = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    entry = id_map.get(space_id, {})
+    install_id = entry.get("install_id")
+    return install_id if isinstance(install_id, str) else None
+def _patch_upc_language_section(
+    content: str, install_id: str, ubi_lang: str,
+) -> str:
+    """Patch UPC language section."""
+    section = (
+        f"[Software\\\\WOW6432Node\\\\Ubisoft\\\\Launcher\\\\"
+        f"Installs\\\\{install_id}]"
+    )
+    if section not in content:
+        return content + f'\n{section}\n"Language"="{ubi_lang}"\n'
+    sec_start = content.index(section)
+    body_start = sec_start + len(section)
+    next_sec = re.search(r"\n\[", content[body_start:])
+    sec_end = (
+        body_start + next_sec.start()
+        if next_sec else len(content)
+    )
+    sec_body = content[body_start:sec_end]
+    pattern = r'^"Language"="[^"]*"'
+    replacement = f'"Language"="{ubi_lang}"'
+    new_body, count = re.subn(
+        pattern, replacement, sec_body, flags=re.MULTILINE,
+    )
+    if count > 0:
+        sec_body = new_body
+    else:
+        sec_body = (
+            sec_body.rstrip("\n") + f'\n"Language"="{ubi_lang}"\n'
+        )
+    return content[:body_start] + sec_body + content[sec_end:]
+
+def _apply_ubisoft_upc_language(
+    prefix_path: str, space_id: str, language: str,
+) -> bool:
+
+    """Apply UBISOFT UPC language."""
+    install_id = _load_ubisoft_install_id(space_id)
+    if not install_id:
+        logger.info(
+            "[language_setup.ubisoft] no install_id for space_id=%s, "
+            "skipping UPC language", space_id,
+        )
+        return False
+    system_reg = os.path.join(prefix_path, "system.reg")
+    if not os.path.isfile(system_reg):
+        logger.info(
+            "[language_setup.ubisoft] system.reg missing at %s, "
+            "skipping UPC language", system_reg,
+        )
+        return False
+    with open(system_reg, encoding="utf-8", errors="replace") as fh:
+        content = fh.read()
+    ubi_lang = UBISOFT_LANG_MAP.get(
+        language, language.split("-", maxsplit=1)[0],
+    )
+    content = _patch_upc_language_section(content, install_id, ubi_lang)
+    _atomic_write_text(system_reg, content)
+    logger.info(
+        "[language_setup.ubisoft] UPC Language=%s written "
+        "(install_id=%s)", ubi_lang, install_id,
+    )
+    return True
+def apply_ubisoft_language(
+    prefix_path: str, space_id: str = "",
+    config: ConfigManager | None = None,
+) -> bool:
+    """Apply UBISOFT language."""
+    language = get_unifideck_language(config)
+    logger.info(
+        "[language_setup.ubisoft] applying %s to prefix=%s space_id=%s",
+        language, prefix_path, space_id,
+    )
+    resolved_prefix = _resolve_prefix(prefix_path)
+    windows_ok = _apply_windows_locale(prefix_path, language)
+    if space_id:
+        _apply_ubisoft_upc_language(resolved_prefix, space_id, language)
+    return windows_ok

--- a/py_modules/unifideck/launcher/rpc.py
+++ b/py_modules/unifideck/launcher/rpc.py
@@ -1,5 +1,62 @@
-"""rpc.py — Launcher RPC bridge
-# OP-35b | py_modules/unifideck/launcher/rpc.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+from typing import TYPE_CHECKING
+from ..core.types import Events
+if TYPE_CHECKING:
+    from ..event_bus import EventBus
+logger = logging.getLogger(__name__)
+async def emit_game_launched(
+ bus: EventBus,
+ *,
+ store: str,
+ game_id: str,
+) -> None:
+    """Emit game launched."""
+    logger.info(
+    "[launcher.rpc] emit GAME_LAUNCHED store=%s game=%s", store, game_id,
+   )
+    await bus.emit(
+    Events.GAME_LAUNCHED,
+    store=store,
+    game_id=game_id,
+   )
+async def emit_game_stopped(
+ bus: EventBus,
+ *,
+ store: str,
+ game_id: str,
+ exit_code: int,
+ elapsed_seconds: float = 0.0,
+ terminated_by_signal: bool = False,
+) -> None:
+    """Emit game stopped."""
+    logger.info(
+    "[launcher.rpc] emit GAME_STOPPED store=%s game=%s rc=%d elapsed=%.1fs signal=%s",
+    store, game_id, exit_code, elapsed_seconds, terminated_by_signal,
+   )
+    await bus.emit(
+    Events.GAME_STOPPED,
+    store=store,
+    game_id=game_id,
+    exit_code=exit_code,
+    elapsed_seconds=elapsed_seconds,
+    terminated_by_signal=terminated_by_signal,
+   )
+async def emit_stage(
+ bus: EventBus,
+ *,
+ i18n_key: str,
+ game_title: str,
+ priority: str = "low",
+) -> None:
+    """Emit stage."""
+    logger.debug(
+    "[launcher.rpc] stage: key=%s game=%s prio=%s",
+    i18n_key, game_title, priority,
+   )
+    await bus.emit(
+    Events.LAUNCHER_STAGE,
+    i18n_key=i18n_key,
+    game_title=game_title,
+    priority=priority,
+   )

--- a/py_modules/unifideck/launcher/signals.py
+++ b/py_modules/unifideck/launcher/signals.py
@@ -1,5 +1,68 @@
-"""signals.py — Launcher signal definitions
-# OP-35a | py_modules/unifideck/launcher/signals.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import os
+import signal
+import subprocess
+from dataclasses import dataclass, field
+logger = logging.getLogger(__name__)
+CLEANUP_PATTERNS = (
+    "steam-runtime-launch-client",
+    "umu-run",
+)
+@dataclass
+class SignalState:
+    """Signal state."""
+    terminated_by_signal: bool = False
+    pending_pids: set[int] = field(default_factory=set)
+class GameProcessRegistry:
+    """Game process registry."""
+    def __init__(self, state: SignalState) -> None:
+        """Initialize the instance."""
+        self._state = state
+    def track(self, proc: subprocess.Popen) -> None:
+        """Track."""
+        if proc.pid:
+            self._state.pending_pids.add(proc.pid)
+    def untrack(self, proc: subprocess.Popen) -> None:
+        """Untrack."""
+        self._state.pending_pids.discard(proc.pid)
+    def terminate_all(self) -> None:
+        """Terminate all."""
+        self._state.terminated_by_signal = True
+        for pid in list(self._state.pending_pids):
+            try:
+                os.killpg(pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                pass
+            except OSError:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except (ProcessLookupError, PermissionError):
+                    pass
+        for pattern in CLEANUP_PATTERNS:
+            try:
+                subprocess.run(
+                    ["pkill", "-TERM", "-f", pattern],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=2,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                pass
+
+def install_signal_handlers(
+    registry: GameProcessRegistry,
+) -> SignalState:
+
+    """Install signal handlers."""
+    state = registry._state
+    def _handler(signum: int, _frame: object | None) -> None:
+        """Handler."""
+        logger.info(
+            "[launcher.signals] received signal %d, terminating games",
+            signum,
+        )
+        registry.terminate_all()
+    signal.signal(signal.SIGTERM, _handler)
+    signal.signal(signal.SIGINT, _handler)
+    return state

--- a/py_modules/unifideck/launcher/types/__init__.py
+++ b/py_modules/unifideck/launcher/types/__init__.py
@@ -1,1 +1,0 @@
-# OP-36 launcher/types package

--- a/py_modules/unifideck/launcher/types/context.py
+++ b/py_modules/unifideck/launcher/types/context.py
@@ -1,5 +1,87 @@
-"""context.py — Launch context dataclass
-# OP-36c | py_modules/unifideck/launcher/types/context.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+KNOWN_STORES: tuple[str, ...] = (
+    "epic",
+    "gog",
+    "amazon",
+    "microsoft",
+    "ubisoft",
+)
+@dataclass(frozen=True)
+class LaunchContext:
+    """Launch context."""
+    store: str
+    game_id: str
+    exe_path: Path
+    work_dir: Path
+    plugin_dir: Path
+    raw_options: str = ""
+    env_overrides: dict[str, str] = field(default_factory=dict)
+    is_launch_action: bool = True
+    auth_store: str | None = None
+    bypass_circuit_breaker: bool = False
+    steam_app_id: str | None = None
+    @property
+    def is_xcloud(self) -> bool:
+        """Check whether xcloud."""
+        return str(self.exe_path) == "xcloud"
+    @property
+    def is_windows_game(self) -> bool:
+        """Check whether windows game."""
+        if self.store == "ubisoft":
+            return True
+        exe_str = str(self.exe_path).lower()
+        return exe_str.endswith((".exe", ".cmd", ".bat"))
+    @property
+    def is_native_linux(self) -> bool:
+        """Check whether native linux."""
+        return not self.is_xcloud and not self.is_windows_game
+    @property
+    def game_key(self) -> str:
+        """Game key."""
+        return f"{self.store}:{self.game_id}"
+    def to_log_dict(self) -> dict[str, Any]:
+        """To log dict."""
+        return {
+            "store": self.store,
+            "game_id": self.game_id,
+            "exe_path": str(self.exe_path),
+            "work_dir": str(self.work_dir),
+            "is_xcloud": self.is_xcloud,
+            "is_windows_game": self.is_windows_game,
+            "is_launch_action": self.is_launch_action,
+            "auth_store": self.auth_store,
+            "bypass_circuit_breaker": self.bypass_circuit_breaker,
+        }
+
+@dataclass
+class RuntimeState:
+    """Runtime state."""
+    proton_path: Path | None = None
+    proton_tool_id: str | None = None
+    prefix_path: Path | None = None
+    umu_store_code: str | None = None
+    umu_id: str | None = None
+    umu_wrapper: Path | None = None
+    python_bin: Path | None = None
+    wrappers: list[str] = field(default_factory=list)
+    game_args: list[str] = field(default_factory=list)
+    lsfg_requested: bool = False
+    game_exit_code: int | None = None
+    terminated_by_signal: bool = False
+    def to_log_dict(self) -> dict[str, Any]:
+        """To log dict."""
+        return {
+            "proton_path": str(self.proton_path) if self.proton_path else None,
+            "proton_tool_id": self.proton_tool_id,
+            "prefix_path": str(self.prefix_path) if self.prefix_path else None,
+            "umu_store_code": self.umu_store_code,
+            "umu_id": self.umu_id,
+            "lsfg_requested": self.lsfg_requested,
+            "game_exit_code": self.game_exit_code,
+            "terminated_by_signal": self.terminated_by_signal,
+            "wrappers_count": len(self.wrappers),
+            "game_args_count": len(self.game_args),
+        }

--- a/py_modules/unifideck/launcher/types/errors.py
+++ b/py_modules/unifideck/launcher/types/errors.py
@@ -1,5 +1,60 @@
-"""errors.py — Launcher error types
-# OP-36b | py_modules/unifideck/launcher/types/errors.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+from typing import Any
+from .exit_codes import ExitCode
+class LauncherError(Exception):
+    """Launcher error."""
+    exit_code: ExitCode = ExitCode.GENERIC_ERROR
+    def __init__(
+        self,
+        message: str,
+        *,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        super().__init__(message)
+        self.context: dict[str, Any] = dict(context or {})
+    def with_context(self, **fields: Any) -> LauncherError:
+        """With context."""
+        self.context.update(fields)
+        return self
+    def to_log_dict(self) -> dict[str, Any]:
+        """To log dict."""
+        return {
+            "type": type(self).__name__,
+            "message": str(self),
+            "exit_code": int(self.exit_code),
+            "context": self.context,
+        }
+class LaunchAbortedError(LauncherError):
+    """Launch aborted error."""
+    exit_code = ExitCode.CANCELLED_BY_USER
+class DependencyMissingError(LauncherError):
+    """Dependency missing error."""
+    exit_code = ExitCode.DEPENDENCY_MISSING
+class GameNotFoundError(LauncherError):
+    """Game not found error."""
+    exit_code = ExitCode.CONFIG_INVALID
+class PrefixCorruptedError(LauncherError):
+    """Prefix corrupted error."""
+    exit_code = ExitCode.PREFIX_CORRUPTED
+class ProtonUnavailableError(LauncherError):
+    """Proton unavailable error."""
+    exit_code = ExitCode.DEPENDENCY_MISSING
+class UmuRuntimeError(LauncherError):
+    """Umu runtime error."""
+    exit_code = ExitCode.GAME_FAILED
+class GameFailedError(LauncherError):
+    """Game failed error."""
+    exit_code = ExitCode.GAME_FAILED
+    def __init__(
+        self,
+        message: str,
+        *,
+        subprocess_rc: int,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        merged = dict(context or {})
+        merged.setdefault("subprocess_rc", subprocess_rc)
+        super().__init__(message, context=merged)
+        self.subprocess_rc = subprocess_rc

--- a/py_modules/unifideck/launcher/types/exit_codes.py
+++ b/py_modules/unifideck/launcher/types/exit_codes.py
@@ -1,5 +1,31 @@
-"""exit_codes.py — Launcher exit codes
-# OP-36a | py_modules/unifideck/launcher/types/exit_codes.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+from enum import IntEnum
+class ExitCode(IntEnum):
+    """Exit code."""
+    SUCCESS = 0
+    GENERIC_ERROR = 1
+    CONFIG_INVALID = 2
+    DEPENDENCY_MISSING = 3
+    NETWORK_ERROR = 4
+    CANCELLED_BY_USER = 5
+    TIMED_OUT = 6
+    PREFIX_CORRUPTED = 7
+    GAME_FAILED = 8
+    CIRCUIT_BREAKER_OPEN = 9
+    SIGTERM_EQUIVALENT = 143
+    def user_message_key(self) -> str:
+        """User message key."""
+        mapping = {
+        ExitCode.SUCCESS: "",
+        ExitCode.GENERIC_ERROR: "toasts.launcher.errorGeneric",
+        ExitCode.CONFIG_INVALID: "toasts.launcher.errorConfig",
+        ExitCode.DEPENDENCY_MISSING: "toasts.launcher.errorMissingDep",
+        ExitCode.NETWORK_ERROR: "toasts.launcher.errorNetwork",
+        ExitCode.CANCELLED_BY_USER: "toasts.launcher.cancelled",
+        ExitCode.TIMED_OUT: "toasts.launcher.errorTimeout",
+        ExitCode.PREFIX_CORRUPTED: "toasts.launcher.errorPrefix",
+        ExitCode.GAME_FAILED: "toasts.launcher.errorGameFailed",
+        ExitCode.CIRCUIT_BREAKER_OPEN: "toasts.launcher.errorCircuitBreakerOpen",
+        ExitCode.SIGTERM_EQUIVALENT: "toasts.launcher.cancelled",
+        }
+        return mapping.get(self, "toasts.launcher.errorGeneric")

--- a/py_modules/unifideck/launcher/types/options.py
+++ b/py_modules/unifideck/launcher/types/options.py
@@ -1,5 +1,116 @@
-"""options.py — Launch option dataclasses
-# OP-36d | py_modules/unifideck/launcher/types/options.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import os
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+_ENV_TOKEN_RE = re.compile(r"^([A-Z_][A-Z0-9_]*)=(.*)$")
+_LSFG_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)$")
+@dataclass
+class ParsedOptions:
+    """Parsed options."""
+    wrappers: list[str] = field(default_factory=list)
+    game_args: list[str] = field(default_factory=list)
+    env_overrides: dict[str, str] = field(default_factory=dict)
+    lsfg_requested: bool = False
+def parse_launch_options(raw: str) -> ParsedOptions:
+    """Parse launch options."""
+    result = ParsedOptions()
+    if not raw or not raw.strip():
+        return result
+    try:
+        tokens = shlex.split(raw)
+    except ValueError:
+        tokens = raw.split()
+    remaining: list[str] = []
+    for tok in tokens:
+        m = _ENV_TOKEN_RE.match(tok)
+        if m:
+            result.env_overrides[m.group(1)] = m.group(2)
+        else:
+            remaining.append(tok)
+    home = os.path.expanduser("~")
+    lsfg_filtered: list[str] = []
+    for tok in remaining:
+        expanded = (
+            tok.replace("~", home, 1)
+            if tok.startswith("~") else tok
+        )
+        if expanded.endswith("/lsfg"):
+            result.lsfg_requested = True
+        else:
+            lsfg_filtered.append(tok)
+    if result.env_overrides.get("LSFG") == "1":
+        result.lsfg_requested = True
+    if result.env_overrides.get("ENABLE_LSFG") == "1":
+        result.lsfg_requested = True
+    _split_tokens_around_command(lsfg_filtered, result)
+    return result
+
+def _split_tokens_around_command(
+    tokens: list[str], result: ParsedOptions,
+) -> None:
+
+    """Split tokens around command."""
+    found_cmd = False
+    for tok in tokens:
+        if tok == "%command%":
+            found_cmd = True
+            continue
+        if tok == "#%command%":
+            continue
+        if found_cmd:
+            result.game_args.append(tok)
+        else:
+            result.wrappers.append(tok)
+    if (
+        not found_cmd
+        and result.wrappers
+        and not result.game_args
+    ):
+        result.game_args = result.wrappers
+        result.wrappers = []
+def apply_lsfg_env(
+    opts: ParsedOptions,
+    lsfg_script: Path | None = None,
+) -> dict[str, str]:
+    """Apply lsfg env."""
+    if not opts.lsfg_requested:
+        return {}
+    if lsfg_script is None:
+        lsfg_script = Path(os.path.expanduser("~/lsfg"))
+    if not lsfg_script.is_file():
+        return {}
+    overlay: dict[str, str] = {"ENABLE_LSFG": "1"}
+    try:
+        content = lsfg_script.read_text(
+            encoding="utf-8", errors="replace",
+        )
+    except OSError:
+        return overlay
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if (
+            not line
+            or line.startswith("#")
+            or line.startswith("#!")
+        ):
+            continue
+        if line.startswith("exec "):
+            continue
+        if not line.startswith("export "):
+            continue
+        kv = line[len("export "):]
+        if "=" not in kv:
+            continue
+        key, _, value = kv.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and (
+            (value[0] == '"' and value[-1] == '"')
+            or (value[0] == "'" and value[-1] == "'")
+        ):
+            value = value[1:-1]
+        if _LSFG_KEY_RE.match(key):
+            overlay[key] = value
+    return overlay


### PR DESCRIPTION
<html><head></head><body><h1>Add <code>launcher</code> backend module</h1>
<blockquote>
<p>Branch: <code>new-architecture</code> ← (this branch)
Layer: 5 — Infrastructure services (game launcher subsystem)
Reference: Operational Plan v1.3 — OP-35 .. OP-45</p>
</blockquote>
<h2>Summary</h2>
<p>This PR ports the new <code>launcher</code> subpackage to
<code>py_modules/unifideck/</code>. It is the dedicated subsystem that runs
when a game is started — a long-lived child process spawned by
the plugin, responsible for setting up the Wine prefix, launching
the game through <code>umu-run</code>, watching it, capturing exit reasons
and emitting telemetry / RPC events back to the plugin.</p>
<p>The launcher is structured as a self-contained module with no
back-reference to <code>Plugin</code> ; it communicates with the plugin
exclusively through RPC and the EventBus.</p>
<p>The <code>launcher/cdp/</code> subpackage is <strong>not</strong> part of this PR — it
was landed separately so the Steam-controller-popup work could be
reviewed on its own merits.</p>

Subpackage | Files | Lines | Purpose
-- | -- | -- | --
launcher/ | 6 | 484 | Entry point, signal handling, dispatcher, RPC bridge
launcher/types/ | 5 | 291 | Typed LaunchContext, errors hierarchy, parsed options
launcher/flows/ | 4 | 336 | High-level flows : native, xCloud, store auth
launcher/cloud/ | 4 | 392 | Cloud-save failure handling, disk-space checks
launcher/diagnostics/ | 5 | 329 | Per-launch correlation IDs, telemetry, log archives
launcher/proton/infrastructure/ | 5 | 386 | Proton selection, umu-run runtime, prefix layout
launcher/proton/handlers/ | 5 | 608 | Per-store launch handlers (Epic, Ubisoft, GOG, generic)
launcher/proton/fixes/ | 6 | 773 | Per-store prefix patches (Galaxy stub, Epic registry, etc.)
launcher/proton/language_setup/ | 7 | 392 | Per-store locale registry injection
Total | 48 | 4015 |  


<h2>What's added</h2>
<h3><code>launcher/</code> — entry point — OP-35</h3>
<ul>
<li><strong><code>dispatcher.py</code></strong> (<code>main</code>) — module entry point. Parses CLI
options, builds the <code>LaunchContext</code>, picks the right flow
(native / xCloud / auth), runs it, reports the result.</li>
<li><strong><code>signals.py</code></strong> — <code>SignalState</code>, <code>GameProcessRegistry</code>,
<code>install_signal_handlers</code>. Catches SIGINT / SIGTERM and
forwards them to the spawned game process so Steam's "stop"
button works correctly.</li>
<li><strong><code>rpc.py</code></strong> — <code>emit_game_launched</code>, <code>emit_game_stopped</code>,
<code>emit_stage</code>. Thin wrappers that publish lifecycle events on
the EventBus from inside the launcher process.</li>
<li><strong><code>packaging.py</code></strong> — <code>ensure_executable_files</code>. Marks the
bundled launcher scripts as executable on first run.</li>
<li><strong><code>bootstrap.py</code></strong> — <code>build_launcher_service</code>. Wires the
service container the dispatcher uses (config, paths,
EventBus client, …).</li>
</ul>
<h3><code>launcher/types/</code> — typed launcher contracts — OP-36</h3>
<ul>
<li><strong><code>exit_codes.py</code></strong> — <code>ExitCode</code> enum mapping launcher exit
codes to semantic reasons (<code>OK</code>, <code>USER_CANCEL</code>,
<code>DEPENDENCY_MISSING</code>, <code>GAME_FAILED</code>, …).</li>
<li><strong><code>errors.py</code></strong> — typed exception hierarchy : <code>LauncherError</code>,
<code>LaunchAbortedError</code>, <code>DependencyMissingError</code>,
<code>GameNotFoundError</code>, <code>PrefixCorruptedError</code>,
<code>ProtonUnavailableError</code>, <code>UmuRuntimeError</code>, <code>GameFailedError</code>.</li>
<li><strong><code>context.py</code></strong> — <code>LaunchContext</code>, <code>RuntimeState</code>. The
carrier object every launcher function takes.</li>
<li><strong><code>options.py</code></strong> — <code>ParsedOptions</code>, <code>parse_launch_options</code>,
<code>apply_lsfg_env</code>. CLI parsing + LSFG (Linux SteamGen Frame
Generation) environment setup.</li>
</ul>
<h3><code>launcher/flows/</code> — top-level flows — OP-37</h3>
<ul>
<li><strong><code>native.py</code></strong> (<code>native_launch</code>) — the standard flow : Proton
prefix, store-specific handler, run game, watch process.</li>
<li><strong><code>xcloud.py</code></strong> (<code>launch_xcloud</code>) — xCloud streaming flow :
open Edge in the prefix, dispatch to <code>launcher/cdp/</code> for
CDP injection, exit when the streaming tab closes.</li>
<li><strong><code>auth.py</code></strong> (<code>handle_store_auth</code>) — runs the store auth
flow inside a prefix (Ubisoft, Microsoft, …) when the plugin
asks for an interactive login.</li>
</ul>
<h3><code>launcher/cloud/</code> — cloud-save resilience — OP-39</h3>
<ul>
<li><strong><code>cloud_failure.py</code></strong> — <code>classify_cloud_error</code>,
<code>get_failure_behavior</code>, <code>handle_cloud_sync_failure</code>. Decides
whether a failed cloud sync should abort the launch or warn
the user and continue.</li>
<li><strong><code>disk_space.py</code></strong> — <code>DiskSpaceCheck</code>, <code>LowDiskSpaceError</code>,
<code>get_min_free_bytes</code>, <code>check_disk_space</code>, <code>assert_enough_space</code>.
Pre-flight check before pulling cloud saves.</li>
<li><strong><code>save_size_cache.py</code></strong> — <code>CachedSize</code>, <code>get_observed_size</code>,
<code>record_observed_size</code>, <code>measure_directory_size</code>. Per-game
observed-size cache so the disk-space check is accurate
without re-walking the save folder every time.</li>
</ul>
<h3><code>launcher/diagnostics/</code> — observability — OP-40</h3>
<ul>
<li><strong><code>correlation.py</code></strong> — <code>LaunchIdFilter</code>, <code>new_launch_id</code>,
<code>launch_id_scope</code>, <code>install_launch_id_logging</code>. Stamps every
log line of a single launch with the same correlation ID so
log archives can be filtered post-mortem.</li>
<li><strong><code>telemetry.py</code></strong> — <code>PhaseTimer</code>. Times each launch phase
(prefix prepare, fixes apply, game run, …) and emits the
numbers on the EventBus.</li>
<li><strong><code>save_folder_inspector.py</code></strong> (<code>inspect_save_folder</code>) — used
on cloud-sync failure to gather diagnostic info about the
user's save directory.</li>
<li><strong><code>log_archive.py</code></strong> — <code>prune_old_launches</code>,
<code>attach_launch_handler</code>, <code>detach_launch_handler</code>,
<code>read_launch_logs</code>, <code>export_launch_logs</code>. Per-launch log
retention and export.</li>
</ul>
<h3><code>launcher/proton/</code> — Proton + umu-run subsystem — OP-41 .. OP-45</h3>
<p>The launch pipeline is split into four self-contained sub-areas :</p>
<ul>
<li><strong><code>infrastructure/</code></strong> (OP-42) — <code>proton_prepare</code>,
<code>ProtonLaunchPlan</code>, <code>cleanup_umu_runtime_cache</code>,
<code>ensure_umu_runtime_ready</code>, <code>run_umu_with_retry</code>,
<code>find_python_3_10_plus</code>, <code>resolve_proton_path</code>,
<code>get_unifideck_proton_tool</code>, <code>get_steam_compat_tool_override</code>,
<code>find_any_ge_proton</code>, <code>select_proton_version</code>,
<code>normalize_prefix_root</code>, <code>resolve_registry_prefix</code>,
<code>resolve_drive_c</code>. Picks Proton, sets up umu, normalises the
prefix layout.</li>
<li><strong><code>handlers/</code></strong> (OP-43) — <code>epic_launch</code>, <code>gog_linux_dosbox</code>,
<code>generic_launch</code>, <code>ubisoft_launch</code>. One handler per store
with store-specific quirks (Epic auth args stripping, GOG
Linux runtime, Ubisoft prefix bootstrap, …).</li>
<li><strong><code>fixes/</code></strong> (OP-44) — <code>GameFix</code>, <code>get_game_fix</code>,
<code>install_galaxy_stub</code>, <code>apply_epic_launcher_fix</code>,
<code>setup_registry</code>, <code>strip_epic_auth_args</code>,
<code>should_strip_for_launch_context</code>,
<code>fetch_umu_protonfixes</code>, <code>get_required_winetricks</code>. The fix
registry consulted before launch (per-game and per-store
prefix patches).</li>
<li><strong><code>language_setup/</code></strong> (OP-45) — <code>apply_amazon_language</code>,
<code>apply_gog_language</code>, <code>apply_ubisoft_language</code>,
<code>get_unifideck_language</code>, <code>smart_match_locale</code>,
<code>smart_match_gog_language</code>. Writes the user's preferred UI
language into the per-game registry / config files at launch
time.</li>
</ul>
<h2>Architectural compliance</h2>
<p>The launcher follows the layered-architecture rules of the
operational plan :</p>
<ul>
<li><strong>Zero coupling to <code>Plugin</code></strong> — the launcher runs as a separate
Python process spawned by the plugin. Communication is
EventBus-only ; no shared state, no plugin imports.</li>
<li><strong>Typed public surface</strong> — every flow takes a <code>LaunchContext</code>
and returns an <code>ExitCode</code>. Error paths surface typed exceptions
from <code>launcher.types.errors</code>, never bare <code>Exception</code>.</li>
<li><strong>Single responsibility per file</strong> — no file exceeds the
550-line cap, no function exceeds 80 lines.</li>
<li><strong>Documented</strong> — every public class and every public function
carries a docstring.</li>
<li><strong>Async-safe I/O</strong> — every filesystem and subprocess interaction
runs through <code>asyncio</code> ; no blocking I/O on the launcher loop.</li>
</ul>
<h2>Out of scope / follow-ups</h2>
<ul>
<li><strong><code>launcher/cdp/</code></strong> — already landed as a separate PR.</li>
<li><strong>Wire-up into <code>Plugin</code></strong> — a follow-up PR will replace the
inline launch code in <code>main.py</code> with a <code>subprocess.Popen</code> of
<code>launcher/dispatcher.py</code>, and subscribe <code>services/launcher/</code>
to the launcher's RPC events.</li>
<li><strong>Migration of legacy launch helpers</strong> — the legacy launch
scripts under <code>bin/</code> will be removed once the new launcher
has been validated on every store.</li>
</ul>
<h2>Migration notes</h2>
<p>This module is <strong>additive</strong>. The current launch code in <code>main.py</code>
keeps working untouched. The next PR will switch the plugin to
spawn <code>launcher/dispatcher.py</code> ; until then the new module sits
unused but importable.</p>
<h2>Checklist</h2>
<ul>
<li>[x] Code added under <code>py_modules/unifideck/launcher/</code> matching
the operational plan layout</li>
<li>[x] All public symbols documented</li>
<li>[x] <code>launcher/cdp/</code> excluded (separate PR)</li>
<li>[ ] Wire-up into <code>Plugin</code> (follow-up PR)</li>
</ul></body></html>