### PR TITLE
implement actions subpackage

### DIFF
--- a/py_modules/unifideck/actions/dispatch.py
+++ b/py_modules/unifideck/actions/dispatch.py
@@ -1,5 +1,94 @@
-"""dispatch.py — Action dispatcher
-# OP-27b | py_modules/unifideck/actions/dispatch.py | Depends: OP-27a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF page referenced in OP-27b
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+from unifideck.actions.unifideck_uri import (SCOPE_FRONTEND, parse_unifideck_uri)
+from unifideck.rpc import RpcError
+
+if TYPE_CHECKING:
+    from unifideck.core.sync_service import SyncService
+    from unifideck.services.cloud_save import CloudSaveService
+    from unifideck.stores import StoreRegistry
+
+logger = logging.getLogger(__name__)
+
+async def dispatch_backend_action(*, uri: str, registry: StoreRegistry,
+    cloudsave: CloudSaveService | None, sync_service: SyncService | None) -> Any:
+    """Dispatch backend action."""
+    action = parse_unifideck_uri(uri)
+    if not action.valid:
+        raise RpcError("invalid_uri", reason=action.error, uri=uri)
+    if action.scope == SCOPE_FRONTEND:
+        raise RpcError(
+            "frontend_scope_verb",
+            verb=action.verb,
+            hint="frontend should handle settings/* locally",
+        )
+    if action.verb == "auth":
+        return await _dispatch_auth(action, registry)
+    if action.verb == "retry-sync":
+        return await _dispatch_retry_sync(action, cloudsave)
+    if action.verb == "refresh-library":
+        return _dispatch_refresh_library(action, sync_service)
+    if action.verb == "refresh-all-libraries":
+        return _dispatch_refresh_all(sync_service)
+    raise RpcError(
+        "unhandled_backend_verb",
+        verb=action.verb,
+        hint="add a handler in dispatch_backend_action",
+    )
+
+async def _dispatch_auth(action: Any, registry: StoreRegistry) -> Any:
+    """Dispatch auth."""
+    store = action.args[0]
+    return await registry.auth_action(store, "start")
+
+async def _dispatch_retry_sync(action: Any,
+    cloudsave: CloudSaveService | None) -> dict[str, Any]:
+
+    """Dispatch retry sync."""
+    if cloudsave is None:
+        raise RpcError("service_unavailable", service="cloudsave")
+    store, game_id, phase = action.args
+    if phase == "sync_down":
+        result = await cloudsave.sync_down(store, game_id)
+    elif phase == "sync_up":
+        result = await cloudsave.sync_up(store, game_id)
+    else:
+        raise RpcError(
+            "invalid_phase",
+            phase=phase,
+            supported=["sync_down", "sync_up"],
+        )
+    return {
+        "success": result.success,
+        "error": result.error,
+        "store": store,
+        "game_id": game_id,
+        "phase": phase,
+    }
+
+def _dispatch_refresh_library(action: Any,
+    sync_service: SyncService | None) -> dict[str, Any]:
+    """Dispatch refresh library."""
+    if sync_service is None:
+        raise RpcError("service_unavailable", service="sync_service")
+    store = action.args[0]
+    asyncio.create_task(
+        sync_service.sync_single_store(store),
+        name=f"refresh-library-{store}",
+    )
+
+    return {"success": True, "store": store, "status": "scheduled"}
+
+def _dispatch_refresh_all(sync_service: SyncService | None) -> dict[str, Any]:
+    """Dispatch refresh all."""
+    if sync_service is None:
+        raise RpcError("service_unavailable", service="sync_service")
+
+    asyncio.create_task(
+        sync_service.sync_all(),
+        name="refresh-all-libraries",
+    )
+
+    return {"success": True, "status": "scheduled"}

--- a/py_modules/unifideck/actions/unifideck_uri.py
+++ b/py_modules/unifideck/actions/unifideck_uri.py
@@ -1,5 +1,110 @@
-"""unifideck_uri.py — unifideck:// URI handler
-# OP-27a | py_modules/unifideck/actions/unifideck_uri.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF page referenced in OP-27a
+import logging
+from dataclasses import dataclass, field
+from urllib.parse import parse_qs, urlparse
+
+logger = logging.getLogger(__name__)
+SCOPE_BACKEND = "backend"
+SCOPE_FRONTEND = "frontend"
+
+@dataclass(frozen=True)
+class ParsedAction:
+    """Parsed action."""
+    valid: bool
+    verb: str = ""
+    scope: str = ""
+    args: tuple[str, ...] = ()
+    query: dict[str, str] = field(default_factory=dict)
+    error: str = ""
+
+_VERB_REGISTRY: dict[str, tuple[str, int, int, str]] = {
+    "auth": (
+        SCOPE_BACKEND, 1, 1,
+        "Start OAuth flow for a store. Args: <store>.",
+    ),
+    "retry-sync": (
+        SCOPE_BACKEND, 3, 3,
+        "Retry a cloud save sync. Args: <store> <game_id> <phase>. "
+        "Phase is 'sync_down' or 'sync_up'.",
+    ),
+    "refresh-library": (
+        SCOPE_BACKEND, 1, 1,
+        "Refresh the game library for a single store. Args: "
+        "<store>. Fire-and-forget: the RPC returns immediately "
+        "and the sync runs in the background; the UI Library "
+        "view picks up the result through its own SYNC_PROGRESS "
+        "event subscription.",
+    ),
+    "refresh-all-libraries": (
+        SCOPE_BACKEND, 0, 0,
+        "Refresh every registered store's library. Args: none. "
+        "Fire-and-forget same as refresh-library, but drives "
+        "SyncService.sync_all() across all stores in parallel. "
+        "Wired to the 'Refresh all libraries' button in the "
+        "UnifideckSettingsPanel.",
+    ),
+    "open-save-folder": (
+        SCOPE_FRONTEND, 2, 2,
+        "Open the SaveFolderModal for a game. Args: <store> "
+        "<game_id>. Frontend-only: the listener component "
+        "opens the modal via Decky's showModal helper; the "
+        "modal itself calls the backend list_save_folder RPC "
+        "to populate its data.",
+    ),
+    "show-logs": (
+        SCOPE_FRONTEND, 1, 1,
+        "Open the LaunchLogsModal for a past launch. Args: "
+        "<launch_id>. Frontend-only: the listener component "
+        "opens the modal, which fetches logs via the backend "
+        "get_launch_logs RPC. Used by launcher-failure toast "
+        "actions on errorCircuitBreakerOpen and generic "
+        "LAUNCHER_ERROR codes.",
+    ),
+    "settings": (
+        SCOPE_FRONTEND, 1, 2,
+        "Navigate to a settings section. Args: <section> "
+        "[<focus_target>]. Frontend-only.",
+    ),
+}
+
+def list_supported_verbs() -> list[str]:
+    """List supported verbs."""
+    return sorted(_VERB_REGISTRY.keys())
+
+def parse_unifideck_uri(uri: str) -> ParsedAction:
+    """Parse unifideck URI."""
+    if not uri:
+        return ParsedAction(valid=False, error="empty_uri")
+    try:
+        parsed = urlparse(uri)
+    except Exception as err:
+        return ParsedAction(valid=False, error=f"parse_error:{err}")
+    if parsed.scheme != "unifideck":
+        return ParsedAction(
+            valid=False,
+            error=f"wrong_scheme:{parsed.scheme}"
+        )
+    verb = parsed.netloc
+    if not verb:
+        return ParsedAction(valid=False, error="missing_verb")
+    if verb not in _VERB_REGISTRY:
+        return ParsedAction(
+            valid=False, verb=verb,
+            error=f"unknown_verb:{verb}",
+        )
+    scope, min_args, max_args, _doc = _VERB_REGISTRY[verb]
+    raw_path = parsed.path.lstrip("/")
+    args = tuple(p for p in raw_path.split("/") if p) if raw_path else ()
+    if not (min_args <= len(args) <= max_args):
+        return ParsedAction(
+            valid=False, verb=verb, scope=scope,
+            error=(
+                f"wrong_arg_count:got_{len(args)}_"
+                f"expected_{min_args}_to_{max_args}"
+            ),
+        )
+    raw_query = parse_qs(parsed.query) if parsed.query else {}
+    query = {k: v[0] for k, v in raw_query.items() if v}
+    return ParsedAction(
+        valid=True, verb=verb, scope=scope, args=args, query=query,
+    )


### PR DESCRIPTION
<html><head></head><body><h1><code>actions/</code> — <code>unifideck://</code> URI dispatch</h1>
<p>This subpackage implements the <code>unifideck://</code> URI scheme used as the
<strong>single command-dispatch entry point</strong> of the plugin. Frontend events,
toast action buttons, deep links from settings panels, and any backend-
triggered action all flow through one URI format that this package parses
and routes.</p>
<h2>Files</h2>

File | OP-code | Lines | Role
-- | -- | -- | --
unifideck_uri.py | OP-27a | 105 | Parser + verb registry
dispatch.py | OP-27b | 97 | Backend dispatcher
__init__.py | OP-27 | — | Public re-exports


<h2>Linked OP-codes</h2>
<ul>
<li><strong><code>OP-13a</code></strong> <code>RpcError</code> — the typed error envelope every dispatch failure uses</li>
<li><strong><code>OP-15a</code></strong> <code>StoreRegistry</code> — target of <code>auth</code></li>
<li><strong><code>OP-10b</code></strong> <code>CloudSaveService</code> — target of <code>retry-sync</code></li>
<li><strong><code>OP-04d</code></strong> <code>SyncService</code> — target of <code>refresh-library</code> and <code>refresh-all-libraries</code></li>
</ul>

This subpackage implements the `unifideck://` URI scheme used as the
**single command-dispatch entry point** of the plugin. Frontend events,
toast action buttons, deep links from settings panels, and any backend-
triggered action all flow through one URI format that this package parses
and routes.

## Files

| File | OP-code | Lines | Role |
|---|---|---|---|
| `unifideck_uri.py` | `OP-27a` | 105 | Parser + verb registry |
| `dispatch.py` | `OP-27b` |  97 | Backend dispatcher |
| `__init__.py` | `OP-27` |   — | Public re-exports |

## URI format

```
unifideck://<verb>/<arg1>[/<arg2>…]?<key1>=<value1>&<key2>=<value2>
```

`parse_unifideck_uri()` turns a string into a frozen `ParsedAction`
dataclass with five fields : `valid`, `verb`, `scope`, `args`, `query`
(plus `error` when `valid is False`).

## Verb registry

`_VERB_REGISTRY` in `unifideck_uri.py` is the **canonical list** of
supported verbs. Each entry declares its scope, accepted argument-count
range, and a docstring used by `list_supported_verbs()`.

### Backend verbs

Handled by `dispatch_backend_action()` in `dispatch.py`.

| Verb | Args | Effect |
|---|---|---|
| `auth` | `<store>` | `registry.auth_action(store, "start")` |
| `retry-sync` | `<store> <game_id> <phase>` | `cloudsave.sync_down` / `sync_up` |
| `refresh-library` | `<store>` | `sync_service.sync_single_store(store)` — fire-and-forget |
| `refresh-all-libraries` | *(none)* | `sync_service.sync_all()` — fire-and-forget |

Fire-and-forget verbs return `{"status": "scheduled"}` immediately and
let the UI listen to `SYNC_PROGRESS` events for completion.

### Frontend verbs

Resolved client-side. The backend refuses them with `frontend_scope_verb`
should one ever leak through — they are listed here so the registry stays
the single source of truth for the URI vocabulary.

| Verb | Args | UI effect |
|---|---|---|
| `open-save-folder` | `<store> <game_id>` | Opens `SaveFolderModal` |
| `show-logs` | `<launch_id>` | Opens `LaunchLogsModal` |
| `settings` | `<section> [<focus_target>]` | Navigates to a settings section |

## Adding a new verb

1. Add an entry to `_VERB_REGISTRY` in `unifideck_uri.py` with its scope,
   `(min_args, max_args)`, and a docstring.
2. If the verb is backend-scope, add a branch in `dispatch_backend_action`
   and an `_dispatch_<verb>` helper next to the existing ones.
3. Cover the new verb according to the matching fiche in
   `docs/test-coverage-companion.pdf` (`OP-27a` for parsing, `OP-27b` for
   dispatch).
4. Document the verb in any relevant frontend listener so the UI side
   stays in sync.

## Error model

Every dispatch failure raises an `RpcError` from `unifideck.rpc`. The
codes reachable from this subpackage are :

| Code | When |
|---|---|
| `invalid_uri` | Malformed URI, unsupported scheme, unknown verb, wrong arg count |
| `frontend_scope_verb` | Backend received a frontend-only verb |
| `service_unavailable` | A required service (cloudsave, sync_service) was not injected |
| `invalid_phase` | `retry-sync` received a phase other than `sync_down` / `sync_up` |
| `unhandled_backend_verb` | Verb is in the registry but `dispatch_backend_action` has no branch — programmer error |