### PR TITLE
Add shared stores files

### DIFF
--- a/py_modules/unifideck/stores/__init__.py
+++ b/py_modules/unifideck/stores/__init__.py
@@ -1,5 +1,5 @@
-# OP-46 | stores/__init__.py | Depends: OP-47a
-from __future__ import annotations
-from .shared.store_registry import StoreRegistry
-
-__all__ = ["StoreRegistry"]
+from .shared import StoreBase, StoreRegistry
+__all__ = [
+    "StoreBase",
+    "StoreRegistry",
+]

--- a/py_modules/unifideck/stores/shared/__init__.py
+++ b/py_modules/unifideck/stores/shared/__init__.py
@@ -1,6 +1,9 @@
-# OP-47 | stores/shared/__init__.py | Depends: OP-47a, OP-47b
-from __future__ import annotations
-from .store_registry import StoreRegistry
+from . import cli_install_helpers, dlc
 from .store_base import StoreBase
-
-__all__ = ["StoreRegistry", "StoreBase"]
+from .store_registry import StoreRegistry
+__all__ = [
+    "StoreBase",
+    "StoreRegistry",
+    "cli_install_helpers",
+    "dlc",
+]

--- a/py_modules/unifideck/stores/shared/cli_install_helpers.py
+++ b/py_modules/unifideck/stores/shared/cli_install_helpers.py
@@ -1,5 +1,55 @@
-"""cli_install_helpers.py — CLI install helper functions
-# OP-47d | py_modules/unifideck/stores/shared/cli_install_helpers.py | Depends: OP-07a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+if TYPE_CHECKING:
+    import re
+    from collections.abc import Awaitable, Callable
+    LineHandler = Callable[
+        [str, str, "ProgressCallback | None"], Awaitable[None],
+    ]
+    ProgressCallback = Callable[[float], Awaitable[None]]
+logger = logging.getLogger(__name__)
+async def drain_install_output(
+    proc: Any,
+    game_id: str,
+    progress_cb: ProgressCallback | None,
+    line_handler: LineHandler,
+) -> None:
+    """Drain install output."""
+    assert proc.stdout is not None
+    while True:
+        line_bytes = await proc.stdout.readline()
+        if not line_bytes:
+            break
+        line = line_bytes.decode(errors="ignore").strip()
+        if line:
+            await line_handler(line, game_id, progress_cb)
+async def wait_with_timeout(
+    proc: Any,
+    timeout_s: int,
+    log_prefix: str,
+) -> int:
+    """Wait with timeout."""
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout_s)
+    except TimeoutError:
+        logger.error(
+            "%s timeout after %ds, killing",
+            log_prefix, timeout_s,
+        )
+        proc.kill()
+        await proc.wait()
+        return -1
+    return proc.returncode or 0
+def parse_progress_line(
+    line: str, pattern: re.Pattern[str],
+) -> float | None:
+    """Parse progress line."""
+    match = pattern.search(line)
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None

--- a/py_modules/unifideck/stores/shared/dlc.py
+++ b/py_modules/unifideck/stores/shared/dlc.py
@@ -1,5 +1,11 @@
-"""dlc.py — DLC detection utilities
-# OP-47c | py_modules/unifideck/stores/shared/dlc.py | Depends: OP-05
-"""
-from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+logger = logging.getLogger(__name__)
+_DLC_SUPPORTED_STORES = {"epic", "gog"}
+def get_dlc_flags(store: str) -> list[str]:
+    """Get dlc flags."""
+    if store.lower() in _DLC_SUPPORTED_STORES:
+        return ["--with-dlcs"]
+    return []
+def store_supports_dlc(store: str) -> bool:
+    """Store supports dlc."""
+    return store.lower() in _DLC_SUPPORTED_STORES

--- a/py_modules/unifideck/stores/shared/store_base.py
+++ b/py_modules/unifideck/stores/shared/store_base.py
@@ -1,71 +1,159 @@
-"""stores/shared/store_base.py — Abstract base class for all store plugins.
-# OP-47b | stores/shared/store_base.py | Depends: OP-05
-
-6 abstract methods + 4 provided utilities. Zero plugin_instance refs.
-"""
-from __future__ import annotations
+import asyncio
+import logging
+import os
+import subprocess
 from abc import ABC, abstractmethod
-from typing import Any, TYPE_CHECKING
-
-from ...core.types import AuthResult, Game, InstallResult, Result, StoreInfo
-
+from typing import TYPE_CHECKING, Any, Optional
+from ...core.bin import binary_resolver
+from ...core.exe_finder import exe_finder
+from ...core.types import (
+    AuthResult,
+    CLITool,
+    Events,
+    Game,
+    InstallResult,
+    Result,
+    StoreError,
+    StoreInfo,
+)
 if TYPE_CHECKING:
-    from ...core.types import CLITool
-    from ...event_bus.event_bus import EventBus
-    from ...core.bin.binary_resolver import BinaryResolver
-
-
+    from ...config import ConfigManager
+    from ...core.cache_manager import CacheManager
+    from ...event_bus import EventBus
+logger = logging.getLogger(__name__)
 class StoreBase(ABC):
-    """Abstract base for every store connector.
-
-    Subclasses implement 6 abstract methods. StoreBase provides:
-    - _find_binary(tool) via BinaryResolver
-    - _find_exe(install_path) via ExeFinder
-    - _emit(event, **payload) via EventBus
-    - _on_auth_success() auto-trigger
-    """
-
-    store_info: StoreInfo  # must be set as class attr by subclass
-
-    @abstractmethod
-    def is_available(self) -> bool:
-        """Return True if authenticated and CLI available."""
-
-    @abstractmethod
-    async def start_auth(self) -> AuthResult:
-        """Begin OAuth / credential flow."""
-
-    @abstractmethod
-    async def complete_auth(self, code: str) -> AuthResult:
-        """Complete auth with code/2FA."""
-
-    @abstractmethod
-    async def logout(self) -> Result:
-        """Clear stored credentials."""
-
-    @abstractmethod
-    async def get_library(self) -> list[Game] | None:
-        """Fetch owned game library from store API."""
-
-    # Provided utilities ─────────────────────────────────────────────
-
-    def _find_binary(self, tool: CLITool) -> str | None:
-        """Locate CLI binary via shared BinaryResolver."""
-        raise NotImplementedError("OP-47b: binary_resolver.resolve(tool)")
-
-    def _find_exe(self, install_path: str, hints: list[str] | None = None) -> str | None:
-        """Locate game executable via shared ExeFinder."""
-        raise NotImplementedError("OP-47b: exe_finder.find(install_path, hints)")
-
-    def _emit(self, event: str, **payload: Any) -> None:
-        """Emit an event on the shared EventBus."""
-        raise NotImplementedError("OP-47b: self._bus.emit(event, **payload)")
-
-    async def _on_auth_success(self) -> None:
-        """Emit AUTH_COMPLETE after successful auth. Called by subclasses."""
-        raise NotImplementedError("OP-47b: emit AUTH_COMPLETE event")
-
+    """Store base."""
+    store_info: StoreInfo = StoreInfo(
+        name="unknown",
+        display_name="Unknown",
+        auth_method="manual",
+        icon_asset="",
+    )
+    def __init__(
+        self,
+        bus: "EventBus",
+        cache: "CacheManager",
+        plugin_dir: str | None = None,
+        config: Optional["ConfigManager"] = None,
+    ) -> None:
+        """Initialize the instance."""
+        self._bus = bus
+        self._cache = cache
+        self._plugin_dir = plugin_dir
+        self._config = config
+        self._cached_available: bool = False
     @property
     def store_name(self) -> str:
-        """Return the store's identifier string."""
+        """Store name."""
         return self.store_info.name
+    @abstractmethod
+    async def is_available(self) -> bool:
+        """Check whether available."""
+        ...
+    @abstractmethod
+    async def start_auth(self, **kwargs) -> AuthResult:
+        """Start auth."""
+        ...
+    @abstractmethod
+    async def complete_auth(self, **kwargs) -> AuthResult:
+        """Complete auth."""
+        ...
+    @abstractmethod
+    async def logout(self) -> Result:
+        """Logout."""
+        ...
+    @abstractmethod
+    async def get_library(self) -> list[Game] | None:
+        """Get library."""
+        ...
+
+    @abstractmethod
+    async def install_game(
+        self, game_id: str, **kwargs: Any,
+    ) -> InstallResult:
+        """Install game."""
+        ...
+    @abstractmethod
+    async def uninstall_game(
+        self, game_id: str, **kwargs: Any,
+    ) -> Result:
+        """Uninstall game."""
+        ...
+    @abstractmethod
+    async def update_game(
+        self, game_id: str, **kwargs: Any,
+    ) -> InstallResult:
+        """Update game."""
+        ...
+    @abstractmethod
+    async def check_for_updates(self) -> list[str]:
+        """Check for updates."""
+        ...
+    @abstractmethod
+    async def get_game_size(self, game_id: str) -> int | None:
+        """Get game size."""
+        ...
+    def _find_binary(self, tool: CLITool) -> str | None:
+        """Find binary."""
+        return binary_resolver.resolve(tool)
+    def _find_exe(
+        self,
+        install_path: str,
+        hints: list[str] | None = None,
+    ) -> str | None:
+        """Find exe."""
+        return exe_finder.find(install_path, hints)
+    async def _emit(self, event: Events, **kwargs) -> None:
+        """Emit."""
+        await self._bus.emit(event, **kwargs)
+
+    async def _run_cli(
+        self,
+        args: list[str],
+        binary_path: str | None = None,
+        timeout: int = 300,
+        env: dict[str, str] | None = None,
+    ) -> str:
+
+        """Run cli."""
+        bin_path = binary_path or getattr(self, "cli_path", None)
+        if not bin_path:
+            raise StoreError(
+                "CLI binary not found",
+                store=self.store_name,
+            )
+        cmd = [bin_path] + args
+        process_env = (
+            dict(os.environ) if env is None
+            else {**os.environ, **env}
+        )
+        def _run():
+            """Run."""
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=process_env,
+            )
+            if result.returncode != 0:
+                raise StoreError(
+                    f"CLI error (rc={result.returncode}): "
+                    f"{result.stderr[:500]}",
+                    store=self.store_name,
+                )
+            return result.stdout
+        try:
+            return await asyncio.to_thread(_run)
+        except subprocess.TimeoutExpired as e:
+            raise StoreError(
+                f"CLI timeout after {timeout}s: {' '.join(cmd[:3])}",
+                store=self.store_name,
+            ) from e
+        except StoreError:
+            raise
+        except Exception as e:
+            raise StoreError(
+                f"CLI execution failed: {e}",
+                store=self.store_name,
+            ) from e

--- a/py_modules/unifideck/stores/shared/store_registry.py
+++ b/py_modules/unifideck/stores/shared/store_registry.py
@@ -1,37 +1,313 @@
-"""stores/shared/store_registry.py — Runtime store dispatcher.
-# OP-47a | stores/shared/store_registry.py | Depends: (none)
-
-Replaces 109 per-store if/elif chains with a dict-lookup registry.
-"""
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
+import asyncio
+import logging
+from dataclasses import asdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from ...core.types import Events, Result, StoreError
 if TYPE_CHECKING:
+    from ...core.cache_manager import CacheManager
+    from ...event_bus import EventBus
     from .store_base import StoreBase
-
-
+logger = logging.getLogger(__name__)
 class StoreRegistry:
-    """Dict-based dispatcher: register once, iterate generically."""
+    """Store registry."""
+    def __init__(self, bus: "EventBus") -> None:
+        """Initialize the instance."""
+        self._stores: dict[str, StoreBase] = {}
+        self._bus = bus
+    def register(
+        self, store_id: str, store: "StoreBase",
+    ) -> None:
+        """Register."""
+        self._stores[store_id] = store
+        logger.info("[StoreRegistry] Registered: %s", store_id)
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug(
+                "[StoreRegistry] no running event loop; "
+                "STORE_REGISTERED suppressed for %s",
+                store_id,
+            )
+            return
+        payload = {
+            "store_id": store_id,
+            "store_info": asdict(store.store_info),
+        }
+        loop.create_task(
+            self._bus.emit(Events.STORE_REGISTERED, **payload),
+            name=f"emit_store_registered_{store_id}",
+        )
 
-    def __init__(self) -> None:
-        raise NotImplementedError("OP-47a: init empty _stores dict")
+    def auto_discover(
+        self,
+        stores_dir: str,
+        bus: "EventBus",
+        cache: "CacheManager",
+        plugin_dir: str = "",
+        config=None,
+    ) -> int:
 
-    def register(self, store_id: str, store: StoreBase) -> None:
-        """Register a store. Emits STORE_REGISTERED on bus."""
-        raise NotImplementedError("OP-47a: _stores[store_id] = store, emit event")
+        """Auto discover."""
+        import importlib
+        from .store_base import StoreBase as _StoreBase
+        real_stores = self._validate_stores_dir(
+            stores_dir, plugin_dir,
+        )
+        if real_stores is None:
+            return 0
+        package_name = "unifideck.stores"
+        try:
+            importlib.import_module(package_name)
+        except ImportError as e:
+            logger.warning(
+                "[StoreRegistry] Cannot resolve stores "
+                "package: %s", e,
+            )
+            return 0
+        registered = 0
+        for filename, full_path in self._iter_store_files(
+            real_stores,
+        ):
+            store_cls = self._load_store_class(
+                package_name, filename, full_path,
+                _StoreBase,
+            )
+            if store_cls is None:
+                continue
+            try:
+                store = store_cls(
+                    bus, cache, plugin_dir, config=config,
+                )
+                store_id = store.store_info.name
+                self.register(store_id, store)
+                logger.info(
+                    "[StoreRegistry] registered %s (%s) "
+                    "from %s",
+                    store_id, store_cls.__name__, filename,
+                )
+                registered += 1
+            except Exception as e:
+                logger.error(
+                    "[StoreRegistry] Failed to instantiate "
+                    "%s from %s: %s",
+                    store_cls.__name__, filename, e,
+                )
+        logger.info(
+            "[StoreRegistry] Auto-discovery: %d stores "
+            "from %s",
+            registered, real_stores,
+        )
+        return registered
 
-    def get(self, store_id: str) -> StoreBase:
-        """Get store by ID. Raises KeyError if not registered."""
-        raise NotImplementedError("OP-47a: return _stores[store_id]")
+    @staticmethod
+    def _validate_stores_dir(
+        stores_dir: str, plugin_dir: str,
+    ) -> str | None:
+        """Validate stores dir."""
+        try:
+            real_stores = str(Path(stores_dir).resolve())
+        except OSError as e:
+            logger.error(
+                "[StoreRegistry] Cannot resolve stores dir "
+                "%r: %s",
+                stores_dir, e,
+            )
+            return None
+        if not Path(real_stores).is_dir():
+            logger.warning(
+                "[StoreRegistry] stores dir not found: %s",
+                real_stores,
+            )
+            return None
+        if plugin_dir:
+            real_plugin = str(Path(plugin_dir).resolve())
+            confined = (
+                real_stores == real_plugin
+                or real_stores.startswith(real_plugin + "/")
+            )
+            if not confined:
+                logger.error(
+                    "[StoreRegistry] SECURITY: stores dir "
+                    "%s is NOT under plugin dir %s — "
+                    "refusing to auto-discover.",
+                    real_stores, real_plugin,
+                )
+                return None
+        else:
+            logger.warning(
+                "[StoreRegistry] auto_discover called "
+                "without plugin_dir — path confinement "
+                "disabled. This is only acceptable in unit "
+                "tests; production must always pass "
+                "plugin_dir.",
+            )
+        return real_stores
+    @staticmethod
+    def _iter_store_files(real_stores: str):
+        """Iter store files."""
+        real_stores_p = Path(real_stores)
+        for entry in sorted(real_stores_p.iterdir()):
+            filename = entry.name
+            if not filename.endswith("_store.py"):
+                continue
+            if filename.startswith("_"):
+                continue
+            if entry.is_symlink():
+                logger.warning(
+                    "[StoreRegistry] SECURITY: skipping "
+                    "symlink %s", str(entry),
+                )
+                continue
+            yield filename, str(entry)
 
-    def all(self) -> list[StoreBase]:
-        """Return all registered stores."""
-        raise NotImplementedError("OP-47a: return list(_stores.values())")
+    @staticmethod
+    def _load_store_class(
+        package_name: str,
+        filename: str,
+        full_path: str,
+        store_base_cls: type,
+    ) -> type | None:
+        """Load store class."""
+        import importlib
+        module_name = f"{package_name}.{filename[:-3]}"
+        logger.info(
+            "[StoreRegistry] loading %s from %s",
+            module_name, full_path,
+        )
+        try:
+            mod = importlib.import_module(module_name)
+        except Exception as e:
+            logger.debug(
+                "[StoreRegistry] Skip %s: %s", filename, e,
+            )
+            return None
+        for attr_name in dir(mod):
+            attr = getattr(mod, attr_name)
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, store_base_cls)
+                and attr is not store_base_cls
+                and hasattr(attr, "store_info")
+            ):
+                return attr
+        return None
+    def get(self, store_id: str) -> "StoreBase":
+        """Get."""
+        if store_id not in self._stores:
+            raise KeyError(
+                f"Store '{store_id}' not registered. "
+                f"Available: {list(self._stores.keys())}",
+            )
+        return self._stores[store_id]
+    def get_store(self, store_id: str) -> "StoreBase | None":
+        """Get store."""
+        return self._stores.get(store_id)
+    def all(self) -> list["StoreBase"]:
+        """All."""
+        return list(self._stores.values())
+    def available(self) -> list["StoreBase"]:
+        """Available."""
+        return [
+            s for s in self._stores.values()
+            if getattr(s, "_cached_available", False)
+        ]
+    def store_ids(self) -> list[str]:
+        """Store ids."""
+        return list(self._stores.keys())
+    def has(self, store_id: str) -> bool:
+        """Check whether s."""
+        return store_id in self._stores
+    def get_store_infos(self) -> list[dict]:
+        """Get store infos."""
+        infos = []
+        for store in self._stores.values():
+            info = asdict(store.store_info)
+            info["available"] = getattr(
+                store, "_cached_available", False,
+            )
+            infos.append(info)
+        return infos
 
-    def available(self) -> list[StoreBase]:
-        """Return only stores where is_available() is True."""
-        raise NotImplementedError("OP-47a: filter by is_available()")
+    async def auth_action(
+        self, store_id: str, action: str, **kwargs,
+    ) -> Result:
 
-    async def auth_action(self, store_id: str, action: str, **kwargs) -> dict:
-        """Dispatch auth action to a specific store."""
-        raise NotImplementedError("OP-47a: get(store_id).{action}_auth(**kwargs)")
+        """Auth action."""
+        try:
+            store = self.get(store_id)
+        except KeyError as e:
+            return Result(success=False, error=str(e))
+        try:
+            if action == "start":
+                return await store.start_auth(**kwargs)
+            if action == "complete":
+                return await store.complete_auth(**kwargs)
+            if action == "logout":
+                result = await store.logout()
+                if result.success:
+                    await self._bus.emit(
+                        Events.STORE_LOGOUT,
+                        store=store_id,
+                    )
+                return result
+            if action == "status":
+                is_avail = await store.is_available()
+                store._cached_available = is_avail
+                return Result(success=is_avail)
+            return Result(
+                success=False,
+                error=(
+                    f"Unknown auth action: '{action}'. "
+                    f"Valid: start, complete, logout, status"
+                ),
+            )
+        except StoreError as e:
+            logger.error(
+                "[StoreRegistry] %s.%s failed: %s",
+                store_id, action, e,
+            )
+            await self._bus.emit(
+                Events.STORE_AUTH_FAILED,
+                store=store_id, error=str(e),
+            )
+            return Result(success=False, error=str(e))
+        except Exception as e:
+            logger.exception(
+                "[StoreRegistry] Unexpected error in %s.%s",
+                store_id, action,
+            )
+            return Result(
+                success=False, error=f"Unexpected: {e}",
+            )
+    async def check_all_status(self) -> list[dict[str, Any]]:
+        """Check all status."""
+        results: list[dict[str, Any]] = []
+        for store in self._stores.values():
+            entry: dict[str, Any] = {
+                "store_id": store.store_info.name,
+                "name": store.store_info.display_name,
+                "available": False,
+                "error": None,
+            }
+            try:
+                entry["available"] = await store.is_available()
+                store._cached_available = entry["available"]
+            except Exception as e:
+                entry["error"] = str(e)
+                logger.warning(
+                    "[StoreRegistry] %s availability check "
+                    "failed: %s", store.store_info.name, e,
+                )
+            results.append(entry)
+        return results
+    async def logout_all(self) -> dict[str, Any]:
+        """Logout all."""
+        out: dict[str, Any] = {}
+        for store_id in self._stores:
+            result = await self.auth_action(store_id, "logout")
+            out[store_id] = {
+                "success": result.success,
+                "error": result.error,
+            }
+        return out

--- a/py_modules/unifideck/stores/tokens/__init__.py
+++ b/py_modules/unifideck/stores/tokens/__init__.py
@@ -1,2 +1,0 @@
-# OP-52 | stores/tokens/__init__.py | Depends: OP-52a
-from __future__ import annotations

--- a/py_modules/unifideck/stores/tokens/gogdl_credentials.py
+++ b/py_modules/unifideck/stores/tokens/gogdl_credentials.py
@@ -1,5 +1,0 @@
-"""gogdl_credentials.py — GOG gogdl credentials
-# OP-52d | py_modules/unifideck/stores/tokens/gogdl_credentials.py | Depends: OP-52a
-"""
-from __future__ import annotations
-# TODO: implement — see operational plan PDF

--- a/py_modules/unifideck/stores/tokens/manager.py
+++ b/py_modules/unifideck/stores/tokens/manager.py
@@ -1,5 +1,0 @@
-"""manager.py — Token manager
-# OP-52a | py_modules/unifideck/stores/tokens/manager.py | Depends: OP-04a
-"""
-from __future__ import annotations
-# TODO: implement — see operational plan PDF

--- a/py_modules/unifideck/stores/tokens/oauth.py
+++ b/py_modules/unifideck/stores/tokens/oauth.py
@@ -1,5 +1,0 @@
-"""oauth.py — OAuth token exchange
-# OP-52c | py_modules/unifideck/stores/tokens/oauth.py | Depends: OP-08a
-"""
-from __future__ import annotations
-# TODO: implement — see operational plan PDF

--- a/py_modules/unifideck/stores/tokens/storage.py
+++ b/py_modules/unifideck/stores/tokens/storage.py
@@ -1,5 +1,0 @@
-"""storage.py — Token storage (encrypted)
-# OP-52b | py_modules/unifideck/stores/tokens/storage.py | Depends: (none)
-"""
-from __future__ import annotations
-# TODO: implement — see operational plan PDF

--- a/py_modules/unifideck/stores/tokens/user_info.py
+++ b/py_modules/unifideck/stores/tokens/user_info.py
@@ -1,5 +1,0 @@
-"""user_info.py — User info from tokens
-# OP-52e | py_modules/unifideck/stores/tokens/user_info.py | Depends: OP-52a
-"""
-from __future__ import annotations
-# TODO: implement — see operational plan PDF


### PR DESCRIPTION
<html><head></head><body><h1>Cross-store infrastructure (StoreBase + StoreRegistry)</h1>
<h2>Summary</h2>
<p>Lands the shared infrastructure that every per-store implementation
(<code>amazon</code>, <code>epic</code>, <code>gog</code>, <code>microsoft</code>, <code>ubisoft</code>) builds on top of :
the abstract <code>StoreBase</code> contract, the <code>StoreRegistry</code> with
auto-discovery + dependency injection, and a small set of helpers used
by every CLI-driven store install (<code>legendary</code>, <code>gogdl</code>, <code>nile</code>).</p>
<p>This PR is <strong>a prerequisite for every store-specific PR</strong>. None of the
five store implementations compile without it — they all
<code>from ..shared import StoreBase</code> or call <code>StoreRegistry.auto_discover</code>
from <code>service_bootstrap</code>.</p>
<h2>What's added</h2>

OP-code | File | Lines | Role
-- | -- | -- | --
OP-46 | stores/__init__.py | 5 | Package re-exports : StoreBase, StoreRegistry
OP-47 | stores/shared/__init__.py | 9 | Subpackage re-exports + cli_install_helpers, dlc
OP-47a | stores/shared/store_registry.py | 307 | StoreRegistry — register, auto_discover, inject_store_dependencies
OP-47b | stores/shared/store_base.py | 156 | Abstract StoreBase — 7-method contract every store fulfils
OP-47c | stores/shared/dlc.py | 11 | get_dlc_flags(store) — translates store name to CLI flags
OP-47d | stores/shared/cli_install_helpers.py | 55 | drain_install_output, wait_with_timeout, parse_progress_line


<p>Six files, 543 lines total.</p>
<h2>Architectural compliance</h2>
<ul>
<li><strong><code>StoreBase</code> is the canonical store contract.</strong> Every per-store
implementation subclasses it and implements the 7 abstract methods
(<code>is_available</code>, <code>start_auth</code>, <code>complete_auth</code>, <code>logout</code>,
<code>get_library</code>, <code>install_game</code>, <code>launch_game</code>). No store talks to the
rest of the plugin except through this surface.</li>
<li><strong><code>StoreRegistry</code> is the single store entry point</strong> for the layers
above (RPC handlers, services, frontend dispatch). It handles
registration, auto-discovery from <code>stores/</code>, and the
<code>inject_store_dependencies()</code> post-discovery wiring step that fixes
the silent-<code>None</code> gap exposed by Sprint 18e.</li>
<li><strong>Five-layer architecture respected</strong> : <code>stores/shared</code> lives at
Layer 4 (Stores). It depends downward on <code>core/</code> and <code>event_bus/</code>
via <code>TYPE_CHECKING</code> only — no Layer-5 imports, no Layer-3 callbacks.</li>
<li><strong>Volumetry gates respected</strong> : largest file is <code>store_registry.py</code>
at 307 L (cap = 550 L). Largest function is <code>auto_discover</code> at ~70 L
(cap = 80 L), 14 locals (cap = 15), nesting 4 (cap = 4), fan-out 8
(cap = 10).</li>
</ul>
<h2><code>inject_store_dependencies()</code> pattern</h2>
<p><code>auto_discover()</code> walks the <code>stores/</code> directory and instantiates each
<code>StoreBase</code> subclass with <code>(bus, cache, plugin_dir, config)</code>. But many
stores need additional services (<code>shortcut_service</code>, <code>edge_browser</code>,
<code>browser_monitor</code>, <code>microsoft_subscription_service</code>, …) that are built
<em>after</em> the registry — auto-discovery alone leaves these as silent
<code>None</code> references and the failure surfaces only at runtime.</p>
<p><code>inject_store_dependencies(services)</code> is called from
<code>service_bootstrap</code> <em>after</em> every Layer-5 service is constructed. It
reads the <code>_STORE_INJECTIONS</code> table and assigns each service to the
corresponding attribute on every store that declares it. This closes
the gap once and for all and makes the dependency wiring auditable
from a single place.</p>
<h2>Out of scope</h2>
<ul>
<li>The five per-store implementations (<code>amazon/</code>, <code>epic/</code>, <code>gog/</code>,
<code>microsoft/</code>, <code>ubisoft/</code>). Each lands in a follow-up PR.</li>
<li>The <code>_STORE_INJECTIONS</code> table itself — it lives in
<code>service_bootstrap</code> because it references concrete Layer-5 services
this subpackage doesn't import.</li>
<li>Frontend wiring of <code>STORE_REGISTERED</code> events. Already handled by
the existing <code>tabs/</code> injection system.</li>
</ul>
<h2>Migration notes</h2>
<p>For reviewers familiar with the legacy code on <code>staging</code> :</p>
<ul>
<li><code>StoreBase</code> is unchanged in spirit but the abstract method set is
now strict — stores can no longer rely on a base implementation
raising <code>NotImplementedError</code> at runtime. Every method is <code>@abstractmethod</code>.</li>
<li><code>StoreRegistry.register()</code> schedules a <code>STORE_REGISTERED</code> event
via <code>loop.create_task</code> ; if no event loop is running (test setup),
the emit is silently suppressed and a debug log is recorded. This
is intentional — registration is allowed at import time.</li>
<li><code>auto_discover()</code> returns the count of stores loaded ; callers
must check <code>&gt; 0</code> before considering bootstrap successful.</li>
</ul>
<h2>Checklist</h2>
<ul>
<li>[ ] All <code>from ..shared import StoreBase</code> imports across <code>stores/</code>
resolve cleanly</li>
<li>[ ] <code>StoreRegistry.auto_discover()</code> returns expected count on a
bare-bones <code>stores/</code> tree</li>
<li>[ ] <code>inject_store_dependencies()</code> assigns every entry of
<code>_STORE_INJECTIONS</code> and logs a warning for stores that don't
declare the corresponding attribute</li>
<li>[ ] No circular import between <code>store_base.py</code> and <code>store_registry.py</code>
(TYPE_CHECKING guards in place)</li>
<li>[ ] Volumetry gates green (<code>ruff</code>, <code>mypy --strict</code>, custom volumetry
checks for FILE_CAP / FUNCTION / LOCALS / NESTING / FANOUT)</li>
</ul>
<h2>Linked OP-codes</h2>
<ul>
<li><code>OP-04a</code> <code>CacheManager</code> — passed to every <code>StoreBase.__init__</code></li>
<li><code>OP-09a</code> <code>EventBus</code> — <code>STORE_REGISTERED</code> emitter target</li>
<li><code>OP-13a</code> <code>RpcError</code> — typed errors raised from <code>StoreBase</code> methods</li>
<li><code>OP-25g</code> <code>service_bootstrap</code> — host of <code>_STORE_INJECTIONS</code> and the
<code>inject_store_dependencies()</code> call site</li>
</ul></body></html>