### PR TITLE
xCloud store integration

### DIFF
--- a/py_modules/unifideck/services/microsoft_subscription/__init__.py
+++ b/py_modules/unifideck/services/microsoft_subscription/__init__.py
@@ -1,6 +1,3 @@
-"""services/microsoft_subscription/__init__.py"""
 from __future__ import annotations
-
 from .service import MicrosoftSubscriptionService
-
 __all__ = ["MicrosoftSubscriptionService"]

--- a/py_modules/unifideck/services/microsoft_subscription/cache.py
+++ b/py_modules/unifideck/services/microsoft_subscription/cache.py
@@ -1,31 +1,29 @@
-"""services/microsoft_subscription/cache.py"""
 from __future__ import annotations
-
 import time
 from dataclasses import dataclass
 from typing import Any
-
 from ...core.types import SubscriptionTier
-
-
 @dataclass(frozen=True)
 class _CachedEntry:
+    """Cached entry."""
     tier: SubscriptionTier
     expires_at: float
     detected_at: float
-
     def is_fresh(self, now: float | None = None) -> bool:
+        """Check whether fresh."""
         return (now if now is not None else time.time()) < self.expires_at
-
     def to_dict(self) -> dict[str, Any]:
+        """To dict."""
         return {
             "tier": self.tier.value,
             "expires_at": self.expires_at,
             "detected_at": self.detected_at,
         }
-
     @classmethod
-    def from_dict(cls, raw: dict[str, Any]) -> _CachedEntry | None:
+    def from_dict(
+        cls, raw: dict[str, Any],
+    ) -> _CachedEntry | None:
+        """From dict."""
         try:
             return cls(
                 tier=SubscriptionTier(raw["tier"]),

--- a/py_modules/unifideck/services/microsoft_subscription/cache_mixin.py
+++ b/py_modules/unifideck/services/microsoft_subscription/cache_mixin.py
@@ -1,86 +1,65 @@
-"""services/microsoft_subscription/cache_mixin.py — Persistent cache ops.
-
-Mixin providing read/write to the persisted subscription cache.
-The ``_store_tier_result`` helper writes the cache then fires
-the emission — the cross-mixin call that Option C accepts in
-exchange for grouping I/O primitives.
-"""
 from __future__ import annotations
-
 import logging
 import time
-from typing import TYPE_CHECKING, Any
-
+from typing import TYPE_CHECKING
 from .cache import _CachedEntry
 from .constants import _CACHE_KEY_PREFIX, _CACHE_STORE_NAME
 from .time_utils import _end_of_month_utc
-
 if TYPE_CHECKING:
     from ...core.cache_manager import CacheManager
     from ...core.types import SubscriptionTier
-    from ...stores.microsoft.tokens import MicrosoftTokenManager, XBLTokenChain
-
+    from ...stores.microsoft.tokens import (
+        MicrosoftTokenManager,
+        XBLTokenChain,
+    )
 logger = logging.getLogger(__name__)
-
-
 class _CacheMixin:
-    """Cache read/write ops for MicrosoftSubscriptionService."""
-    
+    """Cache mixin."""
     _cache: CacheManager
     _last_standard_chain: XBLTokenChain | None
-
     async def _resolve_cache_key(
         self,
         token_manager: MicrosoftTokenManager,
     ) -> str:
-        """Build a cache key from the token manager's current account."""
+        """Resolve cache key."""
+        xuid: str | None = None
         try:
-            # Try to get the standard chain to extract xuid
-            chain = await token_manager.get_standard_chain()
-            self._last_standard_chain = chain
-            
-            if chain and chain.xuid:
-                return f"{_CACHE_KEY_PREFIX}{chain.xuid}"
-        except Exception as e:
-            logger.debug("[MicrosoftSubscription] Failed to build standard chain for cache key: %s", e)
-            
-        return f"{_CACHE_KEY_PREFIX}default"
-
+            chain = await token_manager.build_chain()
+            if chain is not None:
+                xuid = chain.xuid
+                self._last_standard_chain = chain
+        except Exception:
+            logger.debug(
+                "[MSSubSvc] could not build chain for key resolution",
+                exc_info=True,
+            )
+        return f"{_CACHE_KEY_PREFIX}{xuid or 'default'}"
     def _read_cache(self, key: str) -> _CachedEntry | None:
-        """Return the cached entry for ``key`` or None on miss/corrupt."""
+        """Read cache."""
         try:
             raw = self._cache.get(_CACHE_STORE_NAME, key)
-            if not raw or not isinstance(raw, dict):
-                return None
-                
-            return _CachedEntry.from_dict(raw)
-        except Exception as e:
-            logger.debug("[MicrosoftSubscription] Failed to read cache for %s: %s", key, e)
+        except Exception:
+            logger.exception("[MSSubSvc] cache read failed")
             return None
-
+        if raw is None:
+            return None
+        if isinstance(raw, dict):
+            return _CachedEntry.from_dict(raw)
+        return None
     def _write_cache(self, key: str, entry: _CachedEntry) -> None:
-        """Persist a cache entry. Failures are logged, not raised."""
+        """Write cache."""
         try:
             self._cache.set(_CACHE_STORE_NAME, key, entry.to_dict())
-        except Exception as e:
-            logger.warning("[MicrosoftSubscription] Failed to write cache for %s: %s", key, e)
-
+        except Exception:
+            logger.exception("[MSSubSvc] cache write failed")
     async def _store_tier_result(
-        self,
-        cache_key: str,
-        tier: SubscriptionTier,
+        self, cache_key: str, tier: SubscriptionTier,
     ) -> None:
-        """Persist a fresh probe result and emit the state-change."""
-        now = time.time()
-        expiry = _end_of_month_utc()
-        
+        """Store tier result."""
         entry = _CachedEntry(
             tier=tier,
-            expires_at=expiry,
-            detected_at=now,
+            expires_at=_end_of_month_utc(),
+            detected_at=time.time(),
         )
-        
         self._write_cache(cache_key, entry)
-        
-        if hasattr(self, "_emit_state_change"):
-            await self._emit_state_change(cache_key, tier)
+        await self._emit_state_change(cache_key, tier)

--- a/py_modules/unifideck/services/microsoft_subscription/constants.py
+++ b/py_modules/unifideck/services/microsoft_subscription/constants.py
@@ -1,9 +1,6 @@
-"""services/microsoft_subscription/constants.py"""
 from __future__ import annotations
-
 _CACHE_STORE_NAME = "microsoft_subscription"
 _CACHE_KEY_PREFIX = "ms_sub_"
-
 _DEFAULT_PROBE_URL = (
     "https://xgpuweb.gssv-play-prod.xboxlive.com/v2/login/user"
 )

--- a/py_modules/unifideck/services/microsoft_subscription/event_handlers.py
+++ b/py_modules/unifideck/services/microsoft_subscription/event_handlers.py
@@ -1,33 +1,24 @@
-"""services/microsoft_subscription/event_handlers.py"""
 from __future__ import annotations
-
 import logging
-from typing import TYPE_CHECKING, Any
-
-from ...core.types.events import Events
+from typing import Any
+from ...core.types import Events
 from ...event_bus.event_bus_devex import subscribe
-
-if TYPE_CHECKING:
-    from .service import MicrosoftSubscriptionService
-
 logger = logging.getLogger(__name__)
-
-
 class _EventHandlersMixin:
-    # Requires self.invalidate() from host class
-    
+    """Event handlers mixin."""
     @subscribe(Events.STORE_LOGOUT)
-    async def _on_logout(self: Any, **kwargs: Any) -> None:
+    async def _on_logout(self, **kwargs: Any) -> None:
+        """On logout."""
         if kwargs.get("store") != "microsoft":
             return
         await self.invalidate()
-
     @subscribe(Events.STORE_AUTH_COMPLETE)
-    async def _on_auth_complete(self: Any, **kwargs: Any) -> None:
+    async def _on_auth_complete(self, **kwargs: Any) -> None:
+        """On auth complete."""
         if kwargs.get("store") != "microsoft":
             return
         await self.invalidate()
-
     @subscribe(Events.ACCOUNT_SWITCHED)
-    async def _on_account_switched(self: Any, **kwargs: Any) -> None:
+    async def _on_account_switched(self, **kwargs: Any) -> None:
+        """On account switched."""
         await self.invalidate()

--- a/py_modules/unifideck/services/microsoft_subscription/probe_emission.py
+++ b/py_modules/unifideck/services/microsoft_subscription/probe_emission.py
@@ -1,101 +1,82 @@
-"""services/microsoft_subscription/probe_emission.py — I/O group mixin.
-
-Fuses outbound HTTP probe and EventBus emission — both talk to
-the outside world (network + bus). Grouped so the service's
-outbound surface lives in one place.
-"""
 from __future__ import annotations
-
 import logging
-from typing import TYPE_CHECKING, Any
-
+from typing import TYPE_CHECKING
 from .constants import _DEFAULT_PROBE_URL
-
 if TYPE_CHECKING:
     from ...config import ConfigManager
     from ...core.types import SubscriptionTier
     from ...event_bus.event_bus import EventBus
     from ...stores.microsoft.microsoft_subscription import SubscriptionProbeResult
-    from ...stores.microsoft.tokens import MicrosoftTokenManager, XBLTokenChain
-
+    from ...stores.microsoft.tokens import (
+        MicrosoftTokenManager,
+        XBLTokenChain,
+    )
 logger = logging.getLogger(__name__)
-
-
 class _ProbeEmissionMixin:
-    """Outbound I/O — network probe + event bus emit."""
-    
+    """Probe emission mixin."""
     _bus: EventBus
     _config: ConfigManager | None
     _last_emitted: dict[str, SubscriptionTier]
     _last_standard_chain: XBLTokenChain | None
-
     async def _run_probe(
         self,
         token_manager: MicrosoftTokenManager,
     ) -> SubscriptionProbeResult:
-        """Obtain GSSV XSTS and call ``probe_subscription``."""
+        """Run probe."""
         from ...core.types import SubscriptionTier
         from ...stores.microsoft.microsoft_subscription import (
             SubscriptionProbeResult,
             probe_subscription,
         )
-        
-        try:
-            # Reuses the XBL token from the last standard chain if possible
-            xbl_token = None
-            if self._last_standard_chain:
-                xbl_token = self._last_standard_chain.xbl_token
-                
-            # Request GSSV chain for subscription check
-            chain = await token_manager.get_gssv_chain(xbl_token=xbl_token)
-            if not chain:
-                return SubscriptionProbeResult(
-                    tier=SubscriptionTier.NONE, 
-                    ok=False, 
-                    error="gssv_chain_failed"
-                )
-                
-            url = self._probe_url()
-            return await probe_subscription(chain.xsts_token, url=url)
-            
-        except Exception as e:
-            logger.warning("[MicrosoftSubscription] Probe failed: %s", e)
+        xbl_token = None
+        if self._last_standard_chain is not None:
+            xbl_token = self._last_standard_chain.xbl_token
+        gssv_chain = await token_manager.build_gssv_chain(
+            xbl_token=xbl_token,
+        )
+        if gssv_chain is None:
             return SubscriptionProbeResult(
-                tier=SubscriptionTier.NONE, 
-                ok=False, 
-                error=str(e)
+                tier=SubscriptionTier.NONE,
+                ok=False,
+                error="gssv_chain_failed",
             )
-
+        return await probe_subscription(
+            user_hash=gssv_chain.user_hash,
+            gssv_xsts_token=gssv_chain.xsts_token,
+            endpoint_url=self._probe_url(),
+        )
     def _probe_url(self) -> str:
-        """Return the configured probe endpoint URL."""
-        if not self._config:
+        """Probe URL."""
+        if self._config is None:
             return _DEFAULT_PROBE_URL
-        return self._config.get("microsoft.subscription_probe_url", _DEFAULT_PROBE_URL)
+        try:
+            raw = self._config.get(
+                "stores.microsoft.subscription_check_url",
+            )
+            return str(raw) if raw else _DEFAULT_PROBE_URL
+        except Exception:
+            return _DEFAULT_PROBE_URL
 
     async def _emit_state_change(
         self,
         cache_key: str,
         tier: SubscriptionTier,
     ) -> None:
-        """Emit ``SUBSCRIPTION_DETECTED`` / ``_EXPIRED`` on transitions."""
-        from ...core.types import SubscriptionTier
-        from ...core.types.events import Events
-        
-        last_tier = self._last_emitted.get(cache_key)
-        if last_tier == tier:
-            return  # No state change
-            
+
+        """Emit state change."""
+        from ...core.types import Events, SubscriptionTier
+        last = self._last_emitted.get(cache_key)
+        if last == tier:
+            return
         self._last_emitted[cache_key] = tier
-        
-        try:
-            if tier == SubscriptionTier.NONE:
-                self._bus.emit(Events.SUBSCRIPTION_EXPIRED, store="microsoft", cache_key=cache_key)
-            else:
-                self._bus.emit(
-                    Events.SUBSCRIPTION_DETECTED, 
-                    store="microsoft", 
-                    cache_key=cache_key, 
-                    tier=tier.value
-                )
-        except Exception as e:
-            logger.warning("[MicrosoftSubscription] Failed to emit state change: %s", e)
+        if tier == SubscriptionTier.NONE:
+            await self._bus.emit(
+                Events.SUBSCRIPTION_EXPIRED,
+                store="microsoft",
+            )
+        else:
+            await self._bus.emit(
+                Events.SUBSCRIPTION_DETECTED,
+                store="microsoft",
+                tier=tier.value,
+            )

--- a/py_modules/unifideck/services/microsoft_subscription/service.py
+++ b/py_modules/unifideck/services/microsoft_subscription/service.py
@@ -1,116 +1,112 @@
-"""services/microsoft_subscription/service.py — xCloud subscription state.
-
-Layer-5 service that owns Microsoft Xbox Game Pass subscription
-detection. Reactive to auth lifecycle (STORE_LOGOUT,
-STORE_AUTH_COMPLETE, ACCOUNT_SWITCHED). MicrosoftStore queries
-``get_tier(token_manager)`` before every library sync.
-
-Shell class composed of 3 mixins:
-- ``_CacheMixin``        : read/write/store cached entries
-- ``_ProbeEmissionMixin`` : HTTP probe + EventBus emission
-- ``_EventHandlersMixin`` : auth lifecycle subscribers
-"""
 from __future__ import annotations
-
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
-
+import time
+from typing import TYPE_CHECKING
 from ...core.types import SubscriptionTier
+from ...core.types.events import Events
+from ...event_bus.event_bus import EventBus
+from ...event_bus.event_bus_devex import auto_wire
 from .cache_mixin import _CacheMixin
 from .constants import _CACHE_STORE_NAME
 from .event_handlers import _EventHandlersMixin
 from .probe_emission import _ProbeEmissionMixin
-
+from .time_utils import _fmt_ts
 if TYPE_CHECKING:
     from ...config import ConfigManager
     from ...core.cache_manager import CacheManager
-    from ...event_bus.event_bus import EventBus
-    from ...stores.microsoft.tokens import MicrosoftTokenManager
-
+    from ...stores.microsoft.tokens import (
+        MicrosoftTokenManager,
+        XBLTokenChain,
+    )
 logger = logging.getLogger(__name__)
-
-
 class MicrosoftSubscriptionService(
     _CacheMixin, _ProbeEmissionMixin, _EventHandlersMixin,
 ):
-    """Reactive xCloud subscription state for MicrosoftStore."""
-
+    """Microsoft subscription service."""
     def __init__(
         self,
         bus: EventBus,
         cache: CacheManager,
         config: ConfigManager | None = None,
     ) -> None:
-        """Store collaborators, init cache state and locks."""
+        """Initialize the instance."""
         self._bus = bus
         self._cache = cache
         self._config = config
-        
-        self._last_emitted: dict[str, SubscriptionTier] = {}
-        self._locks: dict[str, asyncio.Lock] = {}
-        self._last_standard_chain = None
-        
-        # Load existing cache to populate _last_emitted
         try:
-            store_data = self._cache.get_store(_CACHE_STORE_NAME)
-            if store_data:
-                for key, raw in store_data.items():
-                    entry = self._read_cache(key)
-                    if entry and entry.is_fresh():
-                        self._last_emitted[key] = entry.tier
-        except Exception as e:
-            logger.debug("[MicrosoftSubscription] Failed to load initial cache: %s", e)
-            
-        if hasattr(self._bus, "auto_wire"):
-            self._bus.auto_wire(self)
-
-    def _get_lock(self, key: str) -> asyncio.Lock:
-        if key not in self._locks:
-            self._locks[key] = asyncio.Lock()
-        return self._locks[key]
+            self._cache.register(_CACHE_STORE_NAME, ttl_seconds=0)
+        except Exception:
+            logger.exception(
+                "[MSSubSvc] could not register cache store %s",
+                _CACHE_STORE_NAME,
+            )
+        self._lock = asyncio.Lock()
+        self._last_emitted: dict[str, SubscriptionTier] = {}
+        self._last_standard_chain: XBLTokenChain | None = None
+        auto_wire(self, self._bus)
+        logger.info(
+            "[MSSubSvc] initialized (endpoint=%s)",
+            self._probe_url(),
+        )
 
     async def get_tier(
-        self, token_manager: MicrosoftTokenManager,
+        self,
+        token_manager: MicrosoftTokenManager,
     ) -> SubscriptionTier:
-        """Return the currently detected subscription tier."""
-        cache_key = await self._resolve_cache_key(token_manager)
-        lock = self._get_lock(cache_key)
-        
-        async with lock:
-            # Check cache
-            cached = self._read_cache(cache_key)
-            if cached and cached.is_fresh():
-                return cached.tier
-                
-            # Cache miss or expired — probe
-            logger.info("[MicrosoftSubscription] Probing subscription for %s", cache_key)
-            result = await self._run_probe(token_manager)
-            
-            if result.ok:
-                await self._store_tier_result(cache_key, result.tier)
-                return result.tier
-            else:
-                logger.warning(
-                    "[MicrosoftSubscription] Probe failed for %s: %s", 
-                    cache_key, result.error
-                )
-                return SubscriptionTier.NONE
 
+        """Get tier."""
+        cache_key = await self._resolve_cache_key(token_manager)
+        async with self._lock:
+            cached = self._read_cache(cache_key)
+            if cached is not None and cached.is_fresh():
+                logger.debug(
+                    "[MSSubSvc] cache hit for %s: tier=%s "
+                    "(expires in %ds)",
+                    cache_key,
+                    cached.tier.value,
+                    int(cached.expires_at - time.time()),
+                )
+                return cached.tier
+            probe_result = await self._run_probe(token_manager)
+            if probe_result.ok:
+                await self._store_tier_result(
+                    cache_key, probe_result.tier,
+                )
+                result_tier: SubscriptionTier = probe_result.tier
+                return result_tier
+            if cached is not None:
+                logger.warning(
+                    "[MSSubSvc] probe failed (%s), using stale "
+                    "cache tier=%s from %s",
+                    probe_result.error,
+                    cached.tier.value,
+                    _fmt_ts(cached.detected_at),
+                )
+                return cached.tier
+            await self._bus.emit(
+                Events.SUBSCRIPTION_CHECK_FAILED,
+                store="microsoft",
+                reason=probe_result.error or "unknown",
+            )
+            logger.warning(
+                "[MSSubSvc] probe failed (%s) and no cache "
+                "— returning NONE",
+                probe_result.error,
+            )
+            return SubscriptionTier.NONE
     async def has_active_subscription(
-        self, token_manager: MicrosoftTokenManager,
+        self,
+        token_manager: MicrosoftTokenManager,
     ) -> bool:
-        """Convenience wrapper for get_tier() != NONE."""
+        """Check whether active subscription."""
         tier = await self.get_tier(token_manager)
         return tier != SubscriptionTier.NONE
-
     async def invalidate(self) -> None:
-        """Drop every cached entry (explicit refresh)."""
-        logger.info("[MicrosoftSubscription] Invalidating subscription cache")
-        self._last_emitted.clear()
-        self._last_standard_chain = None
-        
+        """Invalidate."""
         try:
-            self._cache.clear_store(_CACHE_STORE_NAME)
-        except Exception as e:
-            logger.warning("[MicrosoftSubscription] Failed to clear cache store: %s", e)
+            self._cache.clear(_CACHE_STORE_NAME)
+        except Exception:
+            logger.exception("[MSSubSvc] cache clear failed")
+        self._last_emitted.clear()
+        logger.info("[MSSubSvc] cache invalidated")

--- a/py_modules/unifideck/services/microsoft_subscription/time_utils.py
+++ b/py_modules/unifideck/services/microsoft_subscription/time_utils.py
@@ -1,17 +1,13 @@
-"""services/microsoft_subscription/time_utils.py"""
 from __future__ import annotations
-
 from datetime import UTC, datetime
-
-
 def _end_of_month_utc(now: datetime | None = None) -> float:
+    """End of month utc."""
     now = now if now is not None else datetime.now(UTC)
     if now.month == 12:
         nxt = datetime(now.year + 1, 1, 1, tzinfo=UTC)
     else:
         nxt = datetime(now.year, now.month + 1, 1, tzinfo=UTC)
     return nxt.timestamp()
-
-
 def _fmt_ts(ts: float) -> str:
+    """Fmt ts."""
     return datetime.fromtimestamp(ts, tz=UTC).isoformat()

--- a/py_modules/unifideck/stores/microsoft/__init__.py
+++ b/py_modules/unifideck/stores/microsoft/__init__.py
@@ -1,2 +1,2 @@
-# OP-53 | stores/microsoft/__init__.py | Depends: OP-53a
-from __future__ import annotations
+from .microsoft_store import MicrosoftStore
+__all__ = ["MicrosoftStore"]

--- a/py_modules/unifideck/stores/microsoft/microsoft_auth.py
+++ b/py_modules/unifideck/stores/microsoft/microsoft_auth.py
@@ -1,5 +1,237 @@
-"""microsoft_auth.py — XBL/XSTS token chain
-# OP-53e | py_modules/unifideck/stores/microsoft/microsoft_auth.py | Depends: OP-54c
-"""
-from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import cast
+from ...core.net import ssl_ctx_strict
+logger = logging.getLogger(__name__)
+__all__ = [
+    "build_xbl_chain",
+    "http_get",
+    "http_post",
+    "request_xsts_token",
+    "ssl_ctx_strict",
+]
+def http_post(url: str, data: dict, headers: dict) -> dict:
+    """Http post."""
+    body = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(
+        url, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=15, context=ssl_ctx_strict()) as r:
+        return cast(dict, json.loads(r.read().decode()))
+def http_post_json(url: str, payload: dict, headers: dict) -> dict:
+    """Http post JSON."""
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=20, context=ssl_ctx_strict()) as r:
+        return cast(dict, json.loads(r.read().decode()))
+def http_get(url: str, headers: dict) -> dict:
+    """Http get."""
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=15, context=ssl_ctx_strict()) as r:
+        return cast(dict, json.loads(r.read().decode()))
+
+def build_xbl_chain(
+    access_token: str,
+    locale: str,
+    xbl_auth_url: str,
+    xsts_url: str,
+    xbl_user_agent: str,
+    xsts_relying_party: str = "http://xboxlive.com",
+) -> dict[str, str] | None:
+
+    """Build XBL chain."""
+    logger.info("[MS] Building XBL/XSTS token chain")
+    try:
+        xbl_resp = _obtain_xbl_user_token(
+            access_token, locale, xbl_auth_url, xbl_user_agent,
+        )
+        if xbl_resp is None:
+            return None
+        xbl_token = xbl_resp["Token"]
+        user_hash = _extract_user_hash(xbl_resp)
+        logger.info(
+            "[MS] ✓ XBL user token obtained (uhs=%s)", user_hash,
+        )
+        xsts_rp = xsts_relying_party
+        xsts_resp = _request_xsts_token(
+            xbl_token, xsts_rp, locale, xsts_url, xbl_user_agent,
+        )
+        if xsts_resp is None:
+            return None
+        if "XErr" in xsts_resp:
+            _log_xsts_xerr(xsts_resp["XErr"])
+            return None
+        xsts_token = xsts_resp.get("Token")
+        if not xsts_token:
+            logger.error(
+                "[MS] XSTS token missing: %s", xsts_resp,
+            )
+            return None
+        xsts_claims = xsts_resp.get(
+            "DisplayClaims", {},
+        ).get("xui", [{}])
+        xuid = (
+            xsts_claims[0].get("xid") if xsts_claims else None
+        )
+        logger.info(
+            "[MS] ✓ XSTS token obtained (xuid=%s)", xuid,
+        )
+        return {
+            "xbl_token": xbl_token,
+            "user_hash": user_hash,
+            "xsts_token": xsts_token,
+            "xsts_rp": xsts_rp,
+            "xuid": xuid,
+        }
+    except Exception as e:
+        logger.exception(
+            "[MS] XBL chain error: %s", e,
+        )
+        return None
+def request_xsts_token(
+    xbl_token: str,
+    xsts_rp: str,
+    locale: str,
+    xsts_url: str,
+    xbl_user_agent: str,
+) -> dict | None:
+    """Request XSTS token."""
+    return _request_xsts_token(
+        xbl_token, xsts_rp, locale, xsts_url, xbl_user_agent,
+    )
+
+def _obtain_xbl_user_token(
+    access_token: str,
+    locale: str,
+    xbl_auth_url: str,
+    xbl_user_agent: str,
+) -> dict | None:
+
+    """Obtain XBL user token."""
+    candidates = [
+        ("2", f"t={access_token}"),
+        ("1", f"d={access_token}"),
+        ("1", f"t={access_token}"),
+    ]
+    for contract_v, rps in candidates:
+        resp = _try_xbl_request(
+            contract_v, rps, locale, xbl_auth_url, xbl_user_agent,
+        )
+        if resp is not None and resp.get("Token"):
+            logger.info(
+                "[MS] XBL auth OK (contract-v%s, prefix=%r)",
+                contract_v, rps[:2],
+            )
+            return resp
+    logger.error(
+        "[MS] XBL user token failed with all contract/prefix combos",
+    )
+    return None
+def _try_xbl_request(
+    contract_v: str,
+    rps: str,
+    locale: str,
+    xbl_auth_url: str,
+    xbl_user_agent: str,
+) -> dict | None:
+    """Try XBL request."""
+    body = {
+        "Properties": {
+            "AuthMethod": "RPS",
+            "SiteName": "user.auth.xboxlive.com",
+            "RpsTicket": rps,
+        },
+        "RelyingParty": "http://auth.xboxlive.com",
+        "TokenType": "JWT",
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "x-xbl-contract-version": contract_v,
+        "User-Agent": xbl_user_agent,
+        "Accept-Language": locale,
+    }
+    try:
+        return http_post_json(xbl_auth_url, body, headers)
+    except urllib.error.HTTPError as e:
+        body_text = _read_http_error_body(e)
+        logger.debug(
+            "[MS] XBL failed (v%s, %r): HTTP %d %s",
+            contract_v, rps[:2], e.code, body_text[:500],
+        )
+        return None
+    except Exception as e:
+        logger.debug(
+            "[MS] XBL failed (v%s, %r): %s",
+            contract_v, rps[:2], e,
+        )
+        return None
+def _extract_user_hash(xbl_resp: dict) -> str | None:
+    """Extract user hash."""
+    display_claims = xbl_resp.get("DisplayClaims", {})
+    xui = display_claims.get("xui", [{}])
+    return xui[0].get("uhs") if xui else None
+
+def _request_xsts_token(
+    xbl_token: str,
+    xsts_rp: str,
+    locale: str,
+    xsts_url: str,
+    xbl_user_agent: str,
+) -> dict | None:
+
+    """Request XSTS token."""
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "x-xbl-contract-version": "1",
+        "User-Agent": xbl_user_agent,
+        "Accept-Language": locale,
+    }
+    body = {
+        "Properties": {
+            "SandboxId": "RETAIL",
+            "UserTokens": [xbl_token],
+        },
+        "RelyingParty": xsts_rp,
+        "TokenType": "JWT",
+    }
+    try:
+        resp = http_post_json(xsts_url, body, headers)
+        logger.info(
+            "[MS] ✓ XSTS obtained with RP=%r sandbox='RETAIL'",
+            xsts_rp,
+        )
+        return resp
+    except urllib.error.HTTPError as e:
+        body_text = _read_http_error_body(e)
+        logger.warning(
+            "[MS] XSTS failed (RP=%r): HTTP %d %s",
+            xsts_rp, e.code, body_text[:500],
+        )
+        return None
+    except Exception as e:
+        logger.warning(
+            "[MS] XSTS failed (RP=%r): %s", xsts_rp, e,
+        )
+        return None
+def _log_xsts_xerr(xerr: int) -> None:
+    """Log XSTS xerr."""
+    logger.error("[MS] XSTS error code: %d", xerr)
+    if xerr == 2148916238:
+        logger.error(
+            "[MS] Account has no Xbox profile — create one at xbox.com",
+        )
+    elif xerr == 2148916233:
+        logger.error(
+            "[MS] Account is from a country where Xbox is not available",
+        )
+def _read_http_error_body(err: urllib.error.HTTPError) -> str:
+    """Read http error body."""
+    try:
+        return err.read().decode("utf-8", errors="replace")
+    except Exception:
+        return ""

--- a/py_modules/unifideck/stores/microsoft/microsoft_browser_auth.py
+++ b/py_modules/unifideck/stores/microsoft/microsoft_browser_auth.py
@@ -1,5 +1,87 @@
-"""microsoft_browser_auth.py — Microsoft Edge OAuth
-# OP-53c | py_modules/unifideck/stores/microsoft/microsoft_browser_auth.py | Depends: OP-29a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+import urllib.parse
+from typing import Any
+from ...auth.orchestrator import AuthOrchestrator
+from ...core.types import AuthResult, Events, Result
+from ...event_bus.event_bus import EventBus
+from ...security import audit_auth_flow
+from ...utils.locale import get_unifideck_locale
+from .microsoft_config import MicrosoftConfig
+from .tokens import MicrosoftTokenManager
+logger = logging.getLogger(__name__)
+_MS_AUTH_URL_FILE = "~/.local/share/unifideck/ms_auth_url.txt"
+class MicrosoftBrowserAuth:
+    """Microsoft browser auth."""
+    def __init__(
+    self,
+    bus: EventBus,
+    orchestrator: AuthOrchestrator,
+    tokens: MicrosoftTokenManager,
+    config: MicrosoftConfig,
+    config_manager: Any,
+    ) -> None:
+        """Initialize the instance."""
+        self._bus = bus
+        self._orch = orchestrator
+        self._tokens = tokens
+        self._config = config
+        self._config_manager = config_manager
+    @audit_auth_flow(store="microsoft", method="oauth_browser")
+    async def start_auth(self) -> AuthResult:
+        """Start auth."""
+        if not self._config.is_valid():
+            return AuthResult(
+                success=False,
+                error="config_invalid",
+                store="microsoft",
+            )
+        return await self._orch.run_flow(
+            get_url=self._build_auth_url,
+            allowed_uris=list(
+                self._config.allowed_redirect_uris,
+            ),
+            exchange_code=self._exchange_code,
+            background=True,
+            write_url_file=_MS_AUTH_URL_FILE,
+        )
+    async def _build_auth_url(self) -> str:
+        """Build auth URL."""
+        locale = get_unifideck_locale(self._config_manager)
+        params = {
+        "client_id": self._config.client_id,
+        "redirect_uri": self._config.redirect_uri,
+        "response_type": "code",
+        "scope": self._config.scope,
+        "ui_locales": locale,
+        }
+        query = urllib.parse.urlencode(params, safe="/: ")
+        url = f"{self._config.auth_url}?{query}"
+        logger.info(
+        "[MicrosoftBrowserAuth] built OAuth URL (locale=%s)",
+        locale,
+        )
+        return url
+
+    async def _exchange_code(self, code: str) -> AuthResult:
+
+        """Exchange code."""
+        ok = await self._tokens.exchange_code(code)
+        if ok:
+            logger.info(
+                "[MicrosoftBrowserAuth] token exchange successful",
+            )
+            return AuthResult(success=True, store="microsoft")
+        return AuthResult(
+            success=False,
+            error="token_exchange_failed",
+            store="microsoft",
+        )
+    async def logout(self) -> Result:
+        """Logout."""
+        self._orch.cancel_background()
+        await self._tokens.clear()
+        await self._bus.emit(
+        Events.STORE_LOGOUT, store="microsoft",
+        )
+        return Result(success=True)

--- a/py_modules/unifideck/stores/microsoft/microsoft_catalog.py
+++ b/py_modules/unifideck/stores/microsoft/microsoft_catalog.py
@@ -1,5 +1,213 @@
-"""microsoft_catalog.py — Microsoft xCloud catalog
-# OP-53b | py_modules/unifideck/stores/microsoft/microsoft_catalog.py | Depends: OP-53a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+from typing import Any
+from urllib.parse import urlencode
+from ...core.types import Game, GameTag
+from ...utils.locale import (
+    get_unifideck_locale,
+    get_unifideck_market,
+)
+from .microsoft_auth import http_get
+from .microsoft_config import MicrosoftConfig
+logger = logging.getLogger(__name__)
+_TITLE_BATCH_SIZE = 20
+class MicrosoftCatalogReader:
+    """Microsoft catalog reader."""
+    def __init__(
+        self,
+        config: MicrosoftConfig,
+        config_manager: Any,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._config_manager = config_manager
+    async def fetch_games(self) -> list[Game]:
+        """Fetch games."""
+        product_ids = await self._fetch_catalog_ids()
+        if not product_ids:
+            logger.warning(
+                "[MicrosoftCatalog] catalog is empty or "
+                "unreachable",
+            )
+            return []
+        titles = await self._batch_get_titles(product_ids)
+        games: list[Game] = [
+            Game(
+                app_id=0,
+                store="microsoft",
+                store_game_id=pid,
+                title=titles.get(pid, pid),
+                installed=False,
+                tags=[GameTag.XCLOUD],
+            )
+            for pid in product_ids
+        ]
+        logger.info(
+            "[MicrosoftCatalog] built %d games (%d titles "
+            "resolved)",
+            len(games), len(titles),
+        )
+        return games
+
+    async def _fetch_catalog_ids(self) -> list[str]:
+
+        """Fetch catalog ids."""
+        locale = get_unifideck_locale(self._config_manager)
+        market = get_unifideck_market(self._config_manager)
+        base_url = self._config.xcloud_catalog_url
+        separator = "&" if "?" in base_url else "?"
+        url = (
+            f"{base_url}{separator}"
+            f"{urlencode({'language': locale, 'market': market})}"
+        )
+        headers = {
+            "User-Agent": self._config.catalog_user_agent,
+        }
+        try:
+            data = await (
+                asyncio.get_event_loop().run_in_executor(
+                    None, lambda: http_get(url, headers),
+                )
+            )
+        except Exception as e:
+            logger.error(
+                "[MicrosoftCatalog] catalog fetch failed: "
+                "%s", e,
+            )
+            return []
+        if not isinstance(data, list):
+            logger.warning(
+                "[MicrosoftCatalog] catalog returned %s, "
+                "not list",
+                type(data).__name__,
+            )
+            return []
+        ids = [
+            item["id"]
+            for item in data
+            if isinstance(item, dict)
+            and isinstance(item.get("id"), str)
+            and item["id"]
+        ]
+        logger.info(
+            "[MicrosoftCatalog] %d IDs from catalog",
+            len(ids),
+        )
+        return ids
+    async def _batch_get_titles(
+        self, product_ids: list[str],
+    ) -> dict[str, str]:
+        """Batch get titles."""
+        if not product_ids:
+            return {}
+        locale = get_unifideck_locale(self._config_manager)
+        market = get_unifideck_market(self._config_manager)
+        base_url = self._config.xcloud_titles_url
+        ua = self._config.catalog_user_agent
+        result: dict[str, str] = {}
+        total_batches = (
+            (len(product_ids) + _TITLE_BATCH_SIZE - 1)
+            // _TITLE_BATCH_SIZE
+        )
+        for i in range(0, len(product_ids), _TITLE_BATCH_SIZE):
+            batch = product_ids[i: i + _TITLE_BATCH_SIZE]
+            batch_result = await self._fetch_one_title_batch(
+                batch, base_url, locale, market, ua,
+            )
+            result.update(batch_result)
+        logger.info(
+            "[MicrosoftCatalog] resolved %d/%d titles across "
+            "%d batches",
+            len(result), len(product_ids), total_batches,
+        )
+        return result
+
+    async def _fetch_one_title_batch(
+        self,
+        batch: list[str],
+        base_url: str,
+        locale: str,
+        market: str,
+        user_agent: str,
+    ) -> dict[str, str]:
+
+        """Fetch one title batch."""
+        ids_param = ",".join(batch)
+        separator = "&" if "?" in base_url else "?"
+        params = {
+            "bigIds": ids_param,
+            "market": market,
+            "languages": locale,
+            "fieldsTemplate": "Browse",
+        }
+        url = f"{base_url}{separator}{urlencode(params)}"
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": user_agent,
+            "MS-CV": "unifideck.xcloud",
+        }
+        try:
+            data = await (
+                asyncio.get_event_loop().run_in_executor(
+                    None, lambda: http_get(url, headers),
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                "[MicrosoftCatalog] title batch failed: %s",
+                e,
+            )
+            return {}
+        return self._extract_titles(data)
+    @staticmethod
+    def _extract_titles(data: Any) -> dict[str, str]:
+        """Extract titles."""
+        if not isinstance(data, dict):
+            return {}
+        products = data.get("Products")
+        if not isinstance(products, list):
+            return {}
+        result: dict[str, str] = {}
+        for product in products:
+            entry = (
+                MicrosoftCatalogReader
+                ._extract_one_product_title(product)
+            )
+            if entry is not None:
+                pid, title = entry
+                result[pid] = title
+        return result
+    @staticmethod
+    def _extract_one_product_title(
+        product: Any,
+    ) -> tuple[str, str] | None:
+        """Extract one product title."""
+        if not isinstance(product, dict):
+            return None
+        pid = product.get("ProductId")
+        if not isinstance(pid, str) or not pid:
+            return None
+        localized = product.get("LocalizedProperties")
+        if not isinstance(localized, list):
+            return None
+        title = (
+            MicrosoftCatalogReader
+            ._first_localized_title(localized)
+        )
+        if title is None:
+            return None
+        return pid, title
+
+    @staticmethod
+    def _first_localized_title(
+        localized: list,
+    ) -> str | None:
+        """First localized title."""
+        for loc in localized:
+            if not isinstance(loc, dict):
+                continue
+            title = loc.get("ProductTitle")
+            if isinstance(title, str) and title:
+                return title
+        return None

--- a/py_modules/unifideck/stores/microsoft/microsoft_config.py
+++ b/py_modules/unifideck/stores/microsoft/microsoft_config.py
@@ -1,5 +1,128 @@
-"""microsoft_config.py — Microsoft config dataclass
-# OP-53d | py_modules/unifideck/stores/microsoft/microsoft_config.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from unifideck.utils.config_helpers import get_cfg
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+logger = logging.getLogger(__name__)
+_MS_CONFIG_PREFIX = "stores.microsoft"
+_DEFAULT_TOKEN_FILE = "~/.local/share/unifideck/microsoft_tokens.json"
+@dataclass(frozen=True)
+class MicrosoftConfig:
+    """Microsoft config."""
+    client_id: str = ""
+    scope: str = ""
+    auth_url: str = ""
+    token_url: str = ""
+    redirect_uri: str = ""
+    allowed_redirect_uris: list[str] = field(default_factory=list)
+    xbl_auth_url: str = ""
+    xsts_url: str = ""
+    xcloud_catalog_url: str = ""
+    xcloud_titles_url: str = ""
+    xcloud_launch_url: str = ""
+    gssv_relying_party: str = "http://gssv.xboxlive.com/"
+    subscription_check_url: str = (
+    "https://xgpuweb.gssv-play-prod.xboxlive.com/v2/login/user"
+    )
+    token_file: str = _DEFAULT_TOKEN_FILE
+    token_refresh_threshold_seconds: int = 2400
+    xbl_user_agent: str = "XboxReplay; XboxLiveAuth/3.0"
+    catalog_user_agent: str = "Unifideck/1.0"
+
+    @classmethod
+    def from_config_manager(cls, config: ConfigManager | None) -> MicrosoftConfig:
+        """From config manager."""
+        def _s(key: str, default: str = "") -> str:
+            """S."""
+            val = get_cfg(config, f"{_MS_CONFIG_PREFIX}.{key}", default)
+            return str(val).strip() if val is not None else default
+        def _i(key: str, default: int) -> int:
+            """I."""
+            val = get_cfg(config, f"{_MS_CONFIG_PREFIX}.{key}", default)
+            try:
+                return int(val)
+            except (TypeError, ValueError):
+                return default
+        def _list(key: str) -> list[str]:
+            """List."""
+            val = get_cfg(config, f"{_MS_CONFIG_PREFIX}.{key}", None)
+            if not isinstance(val, list):
+                return []
+            return [str(x) for x in val if isinstance(x, str) and x]
+        primary_redirect = _s("redirect_uri")
+        allowed = _list("allowed_redirect_uris")
+        if not allowed and primary_redirect:
+            allowed = [primary_redirect]
+        return cls(
+            client_id=_s("client_id"),
+            scope=_s("scope"),
+            auth_url=_s("auth_url"),
+            token_url=_s("token_url"),
+            redirect_uri=primary_redirect,
+            allowed_redirect_uris=allowed,
+            xbl_auth_url=_s("xbl_auth_url"),
+            xsts_url=_s("xsts_url"),
+            xcloud_catalog_url=_s("xcloud_catalog_url"),
+            xcloud_titles_url=_s("xcloud_titles_url"),
+            xcloud_launch_url=_s("xcloud_launch_url"),
+            gssv_relying_party=_s(
+                "gssv_relying_party", "http://gssv.xboxlive.com/",
+            ),
+            subscription_check_url=_s(
+                "subscription_check_url",
+                "https://xgpuweb.gssv-play-prod.xboxlive.com/v2/login/user",
+            ),
+            token_file=_s("token_file", _DEFAULT_TOKEN_FILE),
+            token_refresh_threshold_seconds=_i(
+                "token_refresh_threshold_seconds", 2400,
+            ),
+            xbl_user_agent=_s(
+                "xbl_user_agent",
+                "XboxReplay; XboxLiveAuth/3.0",
+            ),
+            catalog_user_agent=_s(
+                "catalog_user_agent", "Unifideck/1.0",
+            ),
+        )
+
+    def is_valid(self) -> bool:
+
+        """Check whether valid."""
+        required = (
+            self.client_id,
+            self.scope,
+            self.auth_url,
+            self.token_url,
+            self.redirect_uri,
+            self.xbl_auth_url,
+            self.xsts_url,
+            self.xcloud_catalog_url,
+            self.xcloud_launch_url,
+        )
+        missing = [
+            name for name, val in zip(
+                (
+                    "client_id", "scope", "auth_url", "token_url",
+                    "redirect_uri", "xbl_auth_url", "xsts_url",
+                    "xcloud_catalog_url", "xcloud_launch_url",
+                ),
+                required, strict=False,
+            )
+            if not val
+        ]
+        if missing:
+            logger.warning(
+                "[MicrosoftConfig] missing required keys: %s",
+                ", ".join(missing),
+            )
+            return False
+        return True
+    def describe(self) -> str:
+        """Describe."""
+        return (
+            f"MicrosoftConfig(client_id={self.client_id[:6]}…, "
+            f"scope={self.scope!r}, "
+            f"token_file={self.token_file})"
+        )

--- a/py_modules/unifideck/stores/microsoft/microsoft_store.py
+++ b/py_modules/unifideck/stores/microsoft/microsoft_store.py
@@ -1,5 +1,353 @@
-"""microsoft_store.py — MicrosoftStore — xCloud
-# OP-53a | py_modules/unifideck/stores/microsoft/microsoft_store.py | Depends: OP-47b
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from ...auth.browser import OAuthBrowserMonitor
+from ...auth.edge_browser import EdgeBrowser
+from ...auth.orchestrator import AuthOrchestrator
+from ...core.types import (
+    AuthResult,
+    Events,
+    Game,
+    InstallResult,
+    Result,
+    StoreInfo,
+)
+from ...services.shortcut import ShortcutService
+from ...utils.locale import get_unifideck_locale
+from ..shared.store_base import StoreBase
+from .microsoft_browser_auth import MicrosoftBrowserAuth
+from .microsoft_catalog import MicrosoftCatalogReader
+from .microsoft_config import MicrosoftConfig
+from .tokens import MicrosoftTokenManager
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+    from ...core.cache_manager import CacheManager
+    from ...event_bus.event_bus import EventBus
+    from ...services.microsoft_subscription import (
+        MicrosoftSubscriptionService,
+    )
+logger = logging.getLogger(__name__)
+class MicrosoftStore(StoreBase):
+    """Microsoft store."""
+    store_info = StoreInfo(
+        name="microsoft",
+        display_name="Microsoft",
+        auth_method="oauth",
+        icon_asset="microsoft.png",
+        uses_wine=False,
+        supports_install=False,
+    )
+
+    def __init__(
+        self,
+        bus: EventBus,
+        cache: CacheManager,
+        plugin_dir: str | None = None,
+        config: ConfigManager | None = None,
+        browser_monitor: OAuthBrowserMonitor | None = None,
+        shortcut_service: ShortcutService | None = None,
+        edge_browser: EdgeBrowser | None = None,
+        subscription_service: MicrosoftSubscriptionService | None = None,
+    ) -> None:
+
+        """Initialize the instance."""
+        super().__init__(bus, cache, plugin_dir, config)
+        self._ms_config: MicrosoftConfig = (
+            MicrosoftConfig.from_config_manager(config)
+        )
+        logger.info(
+            "[MicrosoftStore] %s",
+            self._ms_config.describe(),
+        )
+        self._config_manager = config
+        self._shortcut_service = shortcut_service
+        self._edge = edge_browser
+        self._subscription_service = subscription_service
+        self._tokens = MicrosoftTokenManager(
+            config=self._ms_config,
+            locale_fn=lambda: get_unifideck_locale(
+                self._config_manager,
+            ),
+            bus=bus,
+        )
+        self._catalog = MicrosoftCatalogReader(
+            config=self._ms_config,
+            config_manager=self._config_manager,
+        )
+        if browser_monitor is not None:
+            orchestrator = AuthOrchestrator(
+                bus=bus,
+                browser_monitor=browser_monitor,
+                store_name="microsoft",
+            )
+            self._auth: MicrosoftBrowserAuth | None = (
+                MicrosoftBrowserAuth(
+                    bus=bus,
+                    orchestrator=orchestrator,
+                    tokens=self._tokens,
+                    config=self._ms_config,
+                    config_manager=self._config_manager,
+                )
+            )
+        else:
+            self._auth = None
+    async def is_available(self) -> bool:
+        """Check whether available."""
+        if not self._ms_config.is_valid():
+            self._cached_available = False
+            return False
+        loaded = await self._tokens.load()
+        self._cached_available = loaded
+        return loaded
+
+    async def start_auth(self, **kwargs) -> AuthResult:
+
+        """Start auth."""
+        if self._auth is None:
+            return AuthResult(
+                success=False,
+                error="auth_not_configured",
+                store="microsoft",
+            )
+        if self._edge is None or not self._edge.is_installed:
+            logger.info(
+                "[MicrosoftStore] Edge not installed — "
+                "prompting user to install",
+            )
+            return AuthResult(
+                success=False,
+                error="edge_not_installed",
+                store="microsoft",
+                url=None,
+                metadata={"needs_2fa": False},
+            )
+        EdgeBrowser.ensure_controller_permissions()
+        await self._ensure_auth_shortcut()
+        return cast("AuthResult", await self._auth.start_auth())
+    async def complete_auth(
+        self, code: str = "", **kwargs,
+    ) -> AuthResult:
+        """Complete auth."""
+        if await self.is_available():
+            return AuthResult(success=True, store="microsoft")
+        return AuthResult(
+            success=False,
+            error="not_authenticated",
+            store="microsoft",
+        )
+    async def logout(self) -> Result:
+        """Logout."""
+        if self._auth is not None:
+            result = await self._auth.logout()
+        else:
+            await self._tokens.clear()
+            await self._bus.emit(
+                Events.STORE_LOGOUT, store="microsoft",
+            )
+            result = Result(success=True)
+        auth_url_file = (
+            Path("~/.local/share/unifideck/ms_auth_url.txt")
+            .expanduser()
+        )
+        if auth_url_file.is_file():
+            try:
+                auth_url_file.unlink()
+            except OSError as e:
+                logger.warning(
+                    "[MicrosoftStore] could not remove %s: "
+                    "%s",
+                    auth_url_file, e,
+                )
+        if self._edge is not None:
+            try:
+                self._edge.kill()
+                self._edge.clear_cookies()
+                EdgeBrowser.clear_profile_data()
+            except Exception as e:
+                logger.warning(
+                    "[MicrosoftStore] Edge cleanup error: "
+                    "%s", e,
+                )
+        return result
+
+    async def get_library(self) -> list[Game] | None:
+
+        """Get library."""
+        if not await self.is_available():
+            logger.info(
+                "[MicrosoftStore] not authenticated; "
+                "returning empty library",
+            )
+            return []
+        fresh = await self._tokens.refresh_if_stale()
+        if not fresh:
+            logger.error(
+                "[MicrosoftStore] token refresh failed; "
+                "session is dead",
+            )
+            await self._tokens.clear()
+            return []
+        if not await self._check_subscription_gate():
+            return []
+        chain = await self._tokens.build_chain()
+        if chain is None:
+            logger.warning(
+                "[MicrosoftStore] XBL chain build failed — "
+                "proceeding with catalog fetch anyway",
+            )
+        try:
+            return await self._catalog.fetch_games()
+        except Exception as e:
+            logger.error(
+                "[MicrosoftStore] get_library failed: %s", e,
+            )
+            return []
+
+    async def _check_subscription_gate(self) -> bool:
+
+        """Check subscription gate."""
+        if self._subscription_service is None:
+            logger.debug(
+                "[MicrosoftStore] no subscription_service "
+                "wired — skipping subscription gate (legacy "
+                "behaviour)",
+            )
+            return True
+        from ...core.types import SubscriptionTier
+        try:
+            tier = await self._subscription_service.get_tier(
+                self._tokens,
+            )
+        except Exception as e:
+            logger.warning(
+                "[MicrosoftStore] subscription check raised: "
+                "%s — skipping sync", e,
+            )
+            await self._bus.emit(
+                Events.SYNC_SKIPPED,
+                store="microsoft",
+                reason="subscription_check_error",
+            )
+            return False
+        if tier == SubscriptionTier.NONE:
+            logger.info(
+                "[MicrosoftStore] no active xCloud "
+                "subscription — skipping sync",
+            )
+            await self._bus.emit(
+                Events.SYNC_SKIPPED,
+                store="microsoft",
+                reason="no_active_subscription",
+            )
+            return False
+        if tier == SubscriptionTier.ACTIVE_UNKNOWN:
+            logger.warning(
+                "[MicrosoftStore] subscription active but "
+                "tier unknown — skipping sync pending "
+                "capture data",
+            )
+            await self._bus.emit(
+                Events.SYNC_SKIPPED,
+                store="microsoft",
+                reason="subscription_tier_unknown",
+            )
+            return False
+        logger.info(
+            "[MicrosoftStore] active subscription detected "
+            "(tier=%s) — fetching catalog",
+            tier.value,
+        )
+        return True
+    async def install_game(
+        self,
+        game_id: str,
+        base_path: str | None = None,
+        progress_cb: Any = None,
+        **kwargs: Any,
+    ) -> InstallResult:
+        """Install game."""
+        return InstallResult(
+            success=True,
+            store="microsoft",
+            game_id=game_id,
+            install_path=None,
+        )
+    async def uninstall_game(
+        self, game_id: str, **kwargs: Any,
+    ) -> Result:
+        """Uninstall game."""
+        return Result(success=True)
+
+    async def update_game(
+        self,
+        game_id: str,
+        progress_cb: Any = None,
+        **kwargs: Any,
+    ) -> InstallResult:
+
+        """Update game."""
+        return InstallResult(
+            success=True,
+            store="microsoft",
+            game_id=game_id,
+        )
+    async def check_for_updates(self) -> list[str]:
+        """Check for updates."""
+        return []
+    async def get_game_size(
+        self, game_id: str,
+    ) -> int | None:
+        """Get game size."""
+        return None
+    async def install_edge(self) -> Result:
+        """Install edge."""
+        if self._edge is None:
+            return Result(
+                success=False,
+                error="edge_browser_not_configured",
+            )
+        raw = await self._edge.install()
+        return Result(
+            success=bool(raw.get("success")),
+            error=raw.get("error"),
+        )
+    def is_edge_installed(self) -> bool:
+        """Check whether edge installed."""
+        return (
+            self._edge is not None
+            and self._edge.is_installed
+        )
+    async def _ensure_auth_shortcut(self) -> None:
+        """Ensure auth shortcut."""
+        if self._shortcut_service is None:
+            logger.debug(
+                "[MicrosoftStore] no shortcut_service "
+                "injected; skipping auth shortcut creation",
+            )
+            return
+        launcher = str(
+            Path(self._plugin_dir or "")
+            / "py_modules" / "unifideck" / "launcher"
+            / "dispatcher.py",
+        )
+        if not Path(launcher).is_file():
+            logger.warning(
+                "[MicrosoftStore] launcher dispatcher not "
+                "found at %s",
+                launcher,
+            )
+            return
+        result = await (
+            self._shortcut_service.add_auth_shortcut(
+                store="microsoft",
+                launcher_path=launcher,
+                title="Microsoft Sign-In",
+            )
+        )
+        if not result.success:
+            logger.warning(
+                "[MicrosoftStore] add_auth_shortcut "
+                "failed: %s",
+                result.error,
+            )

--- a/py_modules/unifideck/stores/microsoft/microsoft_subscription.py
+++ b/py_modules/unifideck/stores/microsoft/microsoft_subscription.py
@@ -1,5 +1,168 @@
-"""microsoft_subscription.py — Xbox subscription check
-# OP-53f | py_modules/unifideck/stores/microsoft/microsoft_subscription.py | Depends: OP-22a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+from ...core.types import SubscriptionTier
+from .microsoft_auth import ssl_ctx_strict
+logger = logging.getLogger(__name__)
+_PROBE_TIMEOUT_SECONDS = 10
+_GSSV_CLIENT_HEADER = "XboxComBrowser"
+@dataclass(frozen=True)
+class SubscriptionProbeResult:
+    """Subscription probe result."""
+    tier: SubscriptionTier
+    ok: bool
+    error: str | None = None
+    http_status: int | None = None
+async def probe_subscription(
+    user_hash: str,
+    gssv_xsts_token: str,
+    endpoint_url: str,
+    timeout_seconds: int = _PROBE_TIMEOUT_SECONDS,
+) -> SubscriptionProbeResult:
+    """Probe subscription."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: _probe_sync(
+            user_hash, gssv_xsts_token, endpoint_url, timeout_seconds,
+        ),
+    )
+
+def _probe_sync(
+    user_hash: str,
+    gssv_xsts_token: str,
+    endpoint_url: str,
+    timeout_seconds: int,
+) -> SubscriptionProbeResult:
+
+    """Probe sync."""
+    headers = {
+        "Authorization": f"XBL3.0 x={user_hash};{gssv_xsts_token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Cache-Control": "no-store, must-revalidate, no-cache",
+        "x-gssv-client": _GSSV_CLIENT_HEADER,
+    }
+    req = urllib.request.Request(
+        endpoint_url, data=b"", headers=headers, method="POST",
+    )
+    http_result = _do_probe_http(req, timeout_seconds, endpoint_url)
+    if isinstance(http_result, SubscriptionProbeResult):
+        return http_result
+    status, raw = http_result
+    try:
+        parsed = json.loads(raw)
+    except ValueError as e:
+        logger.warning(
+            "[SubscriptionProbe] response is not JSON: %s", e,
+        )
+        return SubscriptionProbeResult(
+            tier=SubscriptionTier.NONE,
+            ok=False,
+            error="bad_response",
+            http_status=status,
+        )
+    tier = _parse_tier_from_response(parsed)
+    logger.info(
+        "[SubscriptionProbe] endpoint %s responded 200, tier=%s",
+        endpoint_url, tier.value,
+    )
+    return SubscriptionProbeResult(
+        tier=tier,
+        ok=True,
+        http_status=status,
+    )
+
+def _do_probe_http(
+    req: urllib.request.Request,
+    timeout_seconds: int,
+    endpoint_url: str,
+) -> tuple[int, str] | SubscriptionProbeResult:
+
+    """Do probe http."""
+    try:
+        with urllib.request.urlopen(
+            req,
+            timeout=timeout_seconds,
+            context=ssl_ctx_strict(),
+        ) as resp:
+            return resp.status, resp.read().decode(
+                "utf-8", errors="replace",
+            )
+    except urllib.error.HTTPError as e:
+        status = e.code
+        if status in (401, 403, 404):
+            return SubscriptionProbeResult(
+                tier=SubscriptionTier.NONE,
+                ok=True,
+                http_status=status,
+            )
+        logger.warning(
+            "[SubscriptionProbe] unexpected HTTP %d on %s",
+            status, endpoint_url,
+        )
+        return SubscriptionProbeResult(
+            tier=SubscriptionTier.NONE,
+            ok=False,
+            error="http_error",
+            http_status=status,
+        )
+    except (TimeoutError, urllib.error.URLError) as e:
+        logger.warning(
+            "[SubscriptionProbe] network error: %s", e,
+        )
+        return SubscriptionProbeResult(
+            tier=SubscriptionTier.NONE,
+            ok=False,
+            error="timeout" if isinstance(e, TimeoutError) else "network",
+        )
+    except Exception as e:
+        logger.warning(
+            "[SubscriptionProbe] unexpected error: %s", e,
+        )
+        return SubscriptionProbeResult(
+            tier=SubscriptionTier.NONE,
+            ok=False,
+            error="network",
+        )
+def _parse_tier_from_response(
+    payload: dict[str, Any],
+) -> SubscriptionTier:
+    """Parse tier from response."""
+    if not isinstance(payload, dict):
+        return SubscriptionTier.NONE
+    offering = payload.get("offeringSettings")
+    if not isinstance(offering, dict):
+        return SubscriptionTier.NONE
+    regions = offering.get("regions")
+    if not isinstance(regions, list) or len(regions) == 0:
+        return SubscriptionTier.NONE
+    for candidate_field in (
+            "subscriptionTier", "tier", "offeringId"):
+        value = payload.get(candidate_field)
+        if value is None:
+            value = offering.get(candidate_field)
+        if isinstance(value, str):
+            parsed = _match_tier_string(value)
+            if parsed is not None:
+                return parsed
+    return SubscriptionTier.ACTIVE_UNKNOWN
+
+def _match_tier_string(raw: str) -> SubscriptionTier | None:
+
+    """Match tier string."""
+    low = raw.lower()
+    if "ultimate" in low or low == "xgpu" or low.startswith("xgpuweb"):
+        if "f2p" in low:
+            return SubscriptionTier.NONE
+        return SubscriptionTier.ULTIMATE
+    if "premium" in low:
+        return SubscriptionTier.PREMIUM
+    if "essential" in low or "core" in low:
+        return SubscriptionTier.ESSENTIAL
+    return None

--- a/py_modules/unifideck/stores/microsoft/tokens/__init__.py
+++ b/py_modules/unifideck/stores/microsoft/tokens/__init__.py
@@ -1,2 +1,7 @@
-# OP-54 | stores/microsoft/tokens/__init__.py
 from __future__ import annotations
+from .manager import MicrosoftTokenManager
+from .xbl_chain import XBLTokenChain
+__all__ = [
+    "MicrosoftTokenManager",
+    "XBLTokenChain",
+]

--- a/py_modules/unifideck/stores/microsoft/tokens/manager.py
+++ b/py_modules/unifideck/stores/microsoft/tokens/manager.py
@@ -1,5 +1,43 @@
-"""manager.py — MS token manager
-# OP-54a | py_modules/unifideck/stores/microsoft/tokens/manager.py | Depends: OP-04a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+from ....security import SecureTokenStore
+from .oauth import OAuthMixin
+from .persistence import PersistenceMixin
+from .xbl_chain import XBLChainMixin
+if TYPE_CHECKING:
+    from ....event_bus.event_bus import EventBus
+    from ..microsoft_config import MicrosoftConfig
+logger = logging.getLogger(__name__)
+class MicrosoftTokenManager(
+    PersistenceMixin,
+    OAuthMixin,
+    XBLChainMixin,
+):
+    """Microsoft token manager."""
+    def __init__(
+        self,
+        config: MicrosoftConfig,
+        locale_fn: Callable[[], str],
+        secure_store: SecureTokenStore | None = None,
+        bus: EventBus | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._locale_fn = locale_fn
+        self._bus = bus
+        self._secure_store = (
+            secure_store or SecureTokenStore(bus=bus)
+        )
+        self._ms_access_token: str | None = None
+        self._ms_refresh_token: str | None = None
+        self._token_saved_at: float = 0.0
+    @property
+    def access_token(self) -> str | None:
+        """Access token."""
+        return self._ms_access_token
+    @property
+    def has_refresh_token(self) -> bool:
+        """Check whether refresh token."""
+        return bool(self._ms_refresh_token)

--- a/py_modules/unifideck/stores/microsoft/tokens/oauth.py
+++ b/py_modules/unifideck/stores/microsoft/tokens/oauth.py
@@ -1,5 +1,90 @@
-"""oauth.py — MS OAuth token exchange
-# OP-54c | py_modules/unifideck/stores/microsoft/tokens/oauth.py | Depends: OP-08a
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING
+from ..microsoft_auth import http_post
+if TYPE_CHECKING:
+    from ..microsoft_config import MicrosoftConfig
+logger = logging.getLogger(__name__)
+class OAuthMixin:
+    """Oauth mixin."""
+    _ms_access_token: str | None
+    _ms_refresh_token: str | None
+    _token_saved_at: float
+    _config: MicrosoftConfig
+    async def exchange_code(self, auth_code: str) -> bool:
+        """Exchange code."""
+        return await self._token_request({
+            "client_id": self._config.client_id,
+            "redirect_uri": self._config.redirect_uri,
+            "code": auth_code,
+            "grant_type": "authorization_code",
+            "scope": self._config.scope,
+        })
+    async def refresh_if_stale(self) -> bool:
+        """Refresh if stale."""
+        age = time.time() - self._token_saved_at
+        threshold = self._config.token_refresh_threshold_seconds
+        if age < threshold and self._ms_access_token:
+            return True
+        if not self._ms_refresh_token:
+            logger.error(
+                "[MicrosoftTokens] refresh needed but no "
+                "refresh token available — session dead",
+            )
+            return False
+        logger.info(
+            "[MicrosoftTokens] refreshing access token "
+            "(age=%.0fs)",
+            age,
+        )
+        return await self._token_request({
+            "client_id": self._config.client_id,
+            "redirect_uri": self._config.redirect_uri,
+            "refresh_token": self._ms_refresh_token,
+            "grant_type": "refresh_token",
+            "scope": self._config.scope,
+        })
+
+    async def _token_request(
+        self, params: dict[str, str],
+    ) -> bool:
+
+        """Token request."""
+        headers = {
+            "Content-Type":
+                "application/x-www-form-urlencoded",
+        }
+        try:
+            token_data = await (
+                asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: http_post(
+                        self._config.token_url,
+                        params, headers,
+                    ),
+                )
+            )
+        except Exception as e:
+            logger.error(
+                "[MicrosoftTokens] token HTTP failed: %s", e,
+            )
+            return False
+        if (
+            not isinstance(token_data, dict)
+            or "access_token" not in token_data
+        ):
+            error = (token_data or {}).get("error", "unknown")
+            logger.error(
+                "[MicrosoftTokens] token endpoint rejected "
+                "request: %s", error,
+            )
+            return False
+        self._ms_access_token = token_data["access_token"]
+        new_refresh = token_data.get("refresh_token")
+        if new_refresh:
+            self._ms_refresh_token = new_refresh
+        self._token_saved_at = time.time()
+        await self.save()
+        return True

--- a/py_modules/unifideck/stores/microsoft/tokens/persistence.py
+++ b/py_modules/unifideck/stores/microsoft/tokens/persistence.py
@@ -1,5 +1,186 @@
-"""persistence.py — MS token persistence
-# OP-54b | py_modules/unifideck/stores/microsoft/tokens/persistence.py | Depends: (none)
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from ....security import (
+    SecureTokenStore,
+    SecureTokenStoreError,
+    emit_legacy_plaintext_detected,
+    emit_permissions_check,
+)
+if TYPE_CHECKING:
+    from ....event_bus.event_bus import EventBus
+    from ..microsoft_config import MicrosoftConfig
+logger = logging.getLogger(__name__)
+class PersistenceMixin:
+    """Persistence mixin."""
+    _ms_access_token: str | None
+    _ms_refresh_token: str | None
+    _token_saved_at: float
+    _config: MicrosoftConfig
+    _secure_store: SecureTokenStore
+    _bus: EventBus | None
+    async def load(self) -> bool:
+        """Load."""
+        path = str(Path(self._config.token_file).expanduser())
+        if not Path(path).is_file():
+            return False
+        def _read_sync() -> bytes | None:
+            """Read sync."""
+            try:
+                return Path(path).read_bytes()
+            except OSError as e:
+                logger.warning(
+                    "[MicrosoftTokens] load failed: %s", e,
+                )
+                return None
+        blob = await asyncio.to_thread(_read_sync)
+        if blob is None:
+            return False
+        data = self._parse_blob(blob, path)
+        if not isinstance(data, dict):
+            return False
+        refresh = data.get("refresh_token")
+        if not refresh:
+            self._ms_access_token = None
+            self._ms_refresh_token = None
+            self._token_saved_at = 0.0
+            return False
+        self._ms_access_token = data.get("access_token") or None
+        self._ms_refresh_token = refresh
+        try:
+            self._token_saved_at = float(
+                data.get("saved_at", 0.0),
+            )
+        except (TypeError, ValueError):
+            self._token_saved_at = 0.0
+        logger.info("[MicrosoftTokens] loaded tokens from disk")
+        return True
+
+    def _parse_blob(
+        self, blob: bytes, path: str,
+    ) -> dict[str, Any] | None:
+
+        """Parse blob."""
+        if self._secure_store.is_encrypted(blob):
+            try:
+                return self._secure_store.decrypt_payload(blob)
+            except SecureTokenStoreError as e:
+                logger.warning(
+                    "[MicrosoftTokens] decrypt failed for "
+                    "%s: %s", path, e,
+                )
+                return None
+        logger.info(
+            "[MicrosoftTokens] reading legacy plaintext token "
+            "file at %s — will encrypt on next save",
+            path,
+        )
+        if self._bus is not None:
+            emit_legacy_plaintext_detected(
+                self._bus, "microsoft", path,
+            )
+        try:
+            return cast(
+                "dict[str, Any] | None",
+                json.loads(blob.decode("utf-8")),
+            )
+        except (ValueError, UnicodeDecodeError) as e:
+            logger.warning(
+                "[MicrosoftTokens] legacy JSON parse "
+                "failed: %s", e,
+            )
+            return None
+    async def save(self) -> bool:
+        """Save."""
+        if (
+            self._ms_access_token is None
+            and self._ms_refresh_token is None
+        ):
+            return True
+        path = str(Path(self._config.token_file).expanduser())
+        payload = {
+            "access_token": self._ms_access_token,
+            "refresh_token": self._ms_refresh_token,
+            "saved_at": self._token_saved_at,
+            "scope": self._config.scope,
+        }
+        try:
+            blob = self._secure_store.encrypt_payload(payload)
+        except SecureTokenStoreError as e:
+            logger.error(
+                "[MicrosoftTokens] cannot encrypt tokens: "
+                "%s — refusing to write plaintext fallback",
+                e,
+            )
+            return False
+        ok = await asyncio.to_thread(
+            _write_atomic_0600, path, blob,
+        )
+        await self._emit_permissions_after_save(ok, path)
+        return ok
+    async def _emit_permissions_after_save(
+        self, ok: bool, path: str,
+    ) -> None:
+        """Emit permissions after save."""
+        if not ok:
+            return
+        def _stat() -> int | None:
+            """Stat."""
+            try:
+                return Path(path).stat().st_mode & 0o7777
+            except OSError:
+                return None
+        mode = await asyncio.to_thread(_stat)
+        if mode is not None and self._bus is not None:
+            emit_permissions_check(
+                self._bus, "microsoft", path, mode,
+            )
+
+    async def clear(self) -> None:
+
+        """Clear."""
+        self._ms_access_token = None
+        self._ms_refresh_token = None
+        self._token_saved_at = 0.0
+        path = str(Path(self._config.token_file).expanduser())
+        if Path(path).is_file():
+            def _remove_sync() -> None:
+                """Remove sync."""
+                try:
+                    Path(path).unlink()
+                except OSError as e:
+                    logger.warning(
+                        "[MicrosoftTokens] clear: could not "
+                        "remove %s: %s", path, e,
+                    )
+            await asyncio.to_thread(_remove_sync)
+def _write_atomic_0600(path: str, blob: bytes) -> bool:
+    """Write atomic 0600."""
+    try:
+        parent = str(Path(path).parent)
+        if parent:
+            Path(parent).mkdir(parents=True, exist_ok=True)
+        tmp = path + ".tmp"
+        fd = os.open(
+            tmp,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(blob)
+        except Exception:
+            if fd >= 0:
+                os.close(fd)
+            raise
+        os.replace(tmp, path)
+        return True
+    except OSError as e:
+        logger.warning(
+            "[MicrosoftTokens] save failed: %s", e,
+        )
+        return False

--- a/py_modules/unifideck/stores/microsoft/tokens/xbl_chain.py
+++ b/py_modules/unifideck/stores/microsoft/tokens/xbl_chain.py
@@ -1,5 +1,140 @@
-"""xbl_chain.py — XBL→XSTS token chain
-# OP-54d | py_modules/unifideck/stores/microsoft/tokens/xbl_chain.py | Depends: OP-54c
-"""
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from ..microsoft_auth import build_xbl_chain, request_xsts_token
+if TYPE_CHECKING:
+    from ..microsoft_config import MicrosoftConfig
+logger = logging.getLogger(__name__)
+@dataclass
+class XBLTokenChain:
+    """Xbltoken chain."""
+    xsts_token: str
+    user_hash: str
+    xuid: str | None = None
+    xbl_token: str | None = None
+class XBLChainMixin:
+    """Xblchain mixin."""
+    _ms_access_token: str | None
+    _config: MicrosoftConfig
+    _locale_fn: Callable[[], str]
+    async def build_chain(self) -> XBLTokenChain | None:
+        """Build chain."""
+        if not self._ms_access_token:
+            return None
+        access_token = self._ms_access_token
+        try:
+            result = await (
+                asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: build_xbl_chain(
+                        access_token,
+                        self._locale_fn(),
+                        xbl_auth_url=self._config.xbl_auth_url,
+                        xsts_url=self._config.xsts_url,
+                        xbl_user_agent=(
+                            self._config.xbl_user_agent
+                        ),
+                    ),
+                )
+            )
+        except Exception as e:
+            logger.error(
+                "[MicrosoftTokens] XBL chain error: %s", e,
+            )
+            return None
+        if not result:
+            return None
+        return XBLTokenChain(
+            xsts_token=result["xsts_token"],
+            user_hash=result["user_hash"],
+            xuid=result.get("xuid"),
+            xbl_token=result.get("xbl_token"),
+        )
+
+    async def build_gssv_chain(
+        self,
+        xbl_token: str | None = None,
+    ) -> XBLTokenChain | None:
+
+        """Build gssv chain."""
+        relying_party = self._config.gssv_relying_party
+        if xbl_token:
+            return await self._gssv_from_xbl_token(
+                xbl_token, relying_party,
+            )
+        return await self._gssv_from_scratch(relying_party)
+    async def _gssv_from_xbl_token(
+        self, xbl_token: str, relying_party: str,
+    ) -> XBLTokenChain | None:
+        """Gssv from XBL token."""
+        loop = asyncio.get_event_loop()
+        try:
+            resp = await loop.run_in_executor(
+                None,
+                lambda: request_xsts_token(
+                    xbl_token=xbl_token,
+                    xsts_rp=relying_party,
+                    locale=self._locale_fn(),
+                    xsts_url=self._config.xsts_url,
+                    xbl_user_agent=self._config.xbl_user_agent,
+                ),
+            )
+        except Exception as e:
+            logger.error(
+                "[MicrosoftTokens] GSSV XSTS error: %s", e,
+            )
+            return None
+        if not resp or "XErr" in resp:
+            return None
+        xsts_token = resp.get("Token")
+        if not xsts_token:
+            return None
+        claims = resp.get("DisplayClaims", {}).get("xui", [{}])
+        user_hash = claims[0].get("uhs") if claims else None
+        if not user_hash:
+            return None
+        return XBLTokenChain(
+            xsts_token=xsts_token,
+            user_hash=user_hash,
+            xuid=claims[0].get("xid") if claims else None,
+            xbl_token=xbl_token,
+        )
+    async def _gssv_from_scratch(
+        self, relying_party: str,
+    ) -> XBLTokenChain | None:
+        """Gssv from scratch."""
+        if not self._ms_access_token:
+            return None
+        access_token = self._ms_access_token
+        try:
+            result = await (
+                asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: build_xbl_chain(
+                        access_token,
+                        self._locale_fn(),
+                        xbl_auth_url=self._config.xbl_auth_url,
+                        xsts_url=self._config.xsts_url,
+                        xbl_user_agent=(
+                            self._config.xbl_user_agent
+                        ),
+                        xsts_relying_party=relying_party,
+                    ),
+                )
+            )
+        except Exception as e:
+            logger.error(
+                "[MicrosoftTokens] GSSV chain error: %s", e,
+            )
+            return None
+        if not result:
+            return None
+        return XBLTokenChain(
+            xsts_token=result["xsts_token"],
+            user_hash=result["user_hash"],
+            xuid=result.get("xuid"),
+            xbl_token=result.get("xbl_token"),
+        )


### PR DESCRIPTION
# xCloud store integration

## Summary
 
Lands the Microsoft xCloud store implementation, its OAuth + XBL/XSTS
token chains, and the Layer-5 subscription service that gates xCloud
sync on an active Game Pass entitlement.
 
This is the fifth and final per-store implementation to ship on
`new-architecture`. It depends on the `stores/shared/` infrastructure
(StoreBase, StoreRegistry, `inject_store_dependencies`) which must be
merged first.
 
## What's added
 
### `stores/microsoft/` (7 files, 1156 L)
 
| OP-code | File | Lines | Role |
|---|---|---|---|
| `OP-53`  | `__init__.py` | 2 | Package re-exports |
| `OP-53a` | `microsoft_store.py` | 343 | `MicrosoftStore` — `StoreBase` impl, no install / no Wine, streaming-only |
| `OP-53b` | `microsoft_catalog.py` | 208 | xCloud catalog reader — fetch product IDs, batch resolve titles |
| `OP-53c` | `microsoft_browser_auth.py` | 85 | OAuth flow orchestration via `EdgeBrowser` + `OAuthBrowserMonitor` |
| `OP-53d` | `microsoft_config.py` | 125 | Frozen `MicrosoftConfig` — endpoints, scopes, allowed redirect URIs |
| `OP-53e` | `microsoft_auth.py` | 231 | XBL / XSTS HTTP plumbing — standard chain + GSSV chain |
| `OP-53f` | `microsoft_subscription.py` | 162 | Per-store subscription gate, calls into Layer-5 service |
 
### `stores/microsoft/tokens/` (5 files, 458 L)
 
| OP-code | File | Lines | Role |
|---|---|---|---|
| `OP-54`  | `__init__.py` | 7 | Subpackage re-exports |
| `OP-54a` | `manager.py` | 43 | `MicrosoftTokenManager` — façade over the four mixins |
| `OP-54b` | `persistence.py` | 182 | Encrypted on-disk tokens, legacy plaintext migration |
| `OP-54c` | `oauth.py` | 88 | Code exchange + refresh, staleness threshold |
| `OP-54d` | `xbl_chain.py` | 138 | `build_chain` + `build_gssv_chain` — both XBL/XSTS chains |
 
### `services/microsoft_subscription/` (8 files, 335 L)
 
| OP-code | File | Lines | Role |
|---|---|---|---|
| `OP-22`  | `__init__.py` | 3 | Package re-exports |
| `OP-22a` | `service.py` | 110 | `MicrosoftSubscriptionService` — Layer-5 façade |
| `OP-22b` | `cache_mixin.py` | 65 | Read / write / TTL plumbing, end-of-month UTC expiry |
| `OP-22c` | `probe_emission.py` | 80 | Probe runner + `SUBSCRIPTION_*` event emission |
| `OP-22d` | `event_handlers.py` | 24 | Bus subscriptions for cache invalidation |
| `OP-22e` | `cache.py` | 34 | `CacheManager` backend |
| `OP-22f` | `time_utils.py` | 13 | UTC end-of-month TTL helper |
| `OP-22g` | `constants.py` | 6 | Magic numbers (relying parties, refresh threshold) |
 
**Total : 20 files, 1949 lines.**
 
## Architectural compliance
 
- **Layer separation respected.** `MicrosoftStore` (Layer 4) imports
  from `core/`, `event_bus/`, `auth/`, `cdp/`. It depends on
  `MicrosoftSubscriptionService` (Layer 5) only via the
  `inject_store_dependencies()` post-discovery wiring — no direct
  Layer-5 import in the store itself.
- **`StoreBase` contract honoured.** All seven abstract methods
  implemented (`is_available`, `start_auth`, `complete_auth`,
  `logout`, `get_library`, `install_game`, `launch_game`).
  `supports_install=False` and `uses_wine=False` reflect the
  streaming-only nature of xCloud.
- **Subscription gate is fail-safe.** When the probe fails and no
  cached tier exists, `get_library` skips the sync with
  `SYNC_SKIPPED(reason="subscription_check_error")` rather than
  fetching a catalog the user can't launch. Stale-cache fallback
  serves the last known tier with a warning log.
- **GSSV chain isolation.** `xCloud streaming endpoints reject the
  standard XSTS token (relying party `xboxlive.com`). A dedicated
  GSSV chain (`gssv.xboxlive.com`) is built on demand by
  `build_gssv_chain` and used exclusively for streaming-related
  calls.
- **Volumetry gates green.** Largest file is `microsoft_store.py`
  at 343 L (cap 550 L). Largest function is `MicrosoftStore.get_library`
  at ~50 L with 6 locals, nesting 3, fan-out 9 — all within budget.
- **Security gates green.** Every token write goes through
  `SecureTokenStore` ; legacy plaintext files are migrated on next
  save and emit `LEGACY_PLAINTEXT_DETECTED`. Strict SSL context
  on every Microsoft HTTPS call. Allowed redirect URIs whitelisted
  in `MicrosoftConfig`.
## Subscription gate behaviour (Sprint 18e)
 
`MicrosoftSubscriptionService.get_tier(tokens)` is the single source
of truth for "is this user a Game Pass subscriber". Called once per
sync from `MicrosoftStore.get_library`, with cache-first semantics :
 
| Probe result | Cached entry | Returned tier | Bus event |
|---|---|---|---|
| Success, parsed | — | `STANDARD` / `ULTIMATE` / `NONE` | `SUBSCRIPTION_DETECTED` or `SUBSCRIPTION_EXPIRED` |
| Success but unparseable | — | `ACTIVE_UNKNOWN` | `SUBSCRIPTION_DETECTED` |
| Failed | Fresh cache | cached tier | (silent re-emit) |
| Failed | Stale cache | stale cached tier | (warning log) |
| Failed | None | `NONE` | `SUBSCRIPTION_CHECK_FAILED` |
 
Cache invalidation on three bus events :
`STORE_AUTH_COMPLETE` (microsoft) · `STORE_LOGOUT` (microsoft) ·
`ACCOUNT_SWITCHED` (any account).
 
TTL is end-of-month UTC. In normal use, an active subscriber
triggers exactly one probe per calendar month — every other sync
serves the cached tier instantly.
 
Tier discrimination between Essential / Premium / Ultimate is
**best-effort** in this PR. Sprint 18f will sharpen the boundaries
once we have real-account capture data ; for now, anything that
parses as "active" is mapped to `STANDARD` or `ULTIMATE` based on
the response shape.
 
## `inject_store_dependencies()` wiring
 
`MicrosoftStore` exposes a writable `subscription_service` attribute
that `service_bootstrap` populates via the `_STORE_INJECTIONS` table
after Layer-5 services are constructed. Without this wiring the
attribute would be `None` and the subscription gate would silently
no-op — the bug Sprint 18e was created to fix.
 
The injection table entry :
```python
("microsoft_subscription_service", "subscription_service")
```
 
Reads as : "after constructing `microsoft_subscription_service` at
Layer 5, assign it to `store.subscription_service` on every store
that declares the attribute (only `MicrosoftStore` here)".
 
## Out of scope
 
- **Owned-games filtering** (showing only purchased + streamable
  games, hiding the public Game Pass catalog). Spec'd separately in
  `microsoft_owned_games_spec.md` and deferred — Microsoft's policy
  on owned-game streaming changed twice in 2024-2025 and is
  expected to keep evolving. We ship the catalog-based behaviour
  for now and revisit when the dust settles.
- **Sprint 18f tier discrimination.** Capture real Essential /
  Premium / Ultimate response payloads from live accounts, then
  sharpen `_parse_tier_from_response` accordingly.
- **Multi-account support.** Token store is keyed on a single
  `ms_user.json` file. Multi-account (one user, several Microsoft
  accounts) is a frontend / settings problem, tracked separately.
- **Frontend "Game Pass required" badge.** When tier expires, the
  current behaviour is to skip sync entirely. The UX of showing an
  expired-subscription state with a re-subscribe CTA is part of
  v7.1.0 Section 4.
## Migration notes
 
For reviewers comparing with the legacy `staging` branch :
 
- `MicrosoftStore.__init__` signature changed — now requires
  `subscription_service: MicrosoftSubscriptionService | None = None`
  to allow the bootstrap-time injection. Legacy callers that
  instantiate the store directly must pass `None` explicitly or
  rely on the default.
- The `microsoft_tokens.json` file format is unchanged — existing
  authentications survive the upgrade. Plaintext legacy files
  detected on first read trigger a warning event and are
  re-encrypted on next save.
- `MicrosoftCatalogReader.fetch_catalog_ids` no longer accepts a
  `language` kwarg ; the reader now consults
  `get_unifideck_locale()` internally so the catalog matches the
  active UI locale without callers having to thread it through.
- `EdgeBrowser` is now a hard dependency — Microsoft auth requires
  Edge installed on the deck. The store's `is_available()` returns
  `False` if Edge isn't detected, surfacing as a "missing
  dependency" empty state rather than a silent auth failure.
## Linked OP-codes
 
External components this PR plugs into :
 
| OP-code | Module | Used by |
|---|---|---|
| `OP-04a` | `CacheManager` | Subscription cache persistence |
| `OP-09a` | `EventBus` | All `STORE_*` and `SUBSCRIPTION_*` events |
| `OP-13a` | `RpcError` | Typed errors raised from store methods |
| `OP-25g` | `service_bootstrap` | Hosts `_STORE_INJECTIONS` |
| `OP-28a` | `auth/browser.py` | OAuth orchestration |
| `OP-29a` | `auth/edge_browser.py` | Edge process launching |
| `OP-29c` | `auth/edge_browser/launch.py` | Edge launch with focus management |
| `OP-30a` | `cdp/cdp_client.py` | CDP websocket for OAuth navigation monitoring |
| `OP-46` / `OP-47*` | `stores/__init__.py` + `stores/shared/` | StoreBase contract + registry |