### PR TITLE
feat: Implement Ubisoft

### DIFF
--- a/py_modules/unifideck/services/bootstrap/store_injector.py
+++ b/py_modules/unifideck/services/bootstrap/store_injector.py
@@ -31,7 +31,9 @@ _STORE_INJECTIONS: dict[str, tuple[tuple[str, str], ...]] = {
     "microsoft": (
         ("_subscription_service", "microsoft_subscription"),
     ),
-    # Future: "ubisoft": (("_shortcut_service", "shortcut"), ...)
+    "ubisoft": (
+        ("_shortcut_service", "shortcut"),
+    ),
     # Future: "gog": (("_cloud_save", "cloudsave"), ...)
 }
 

--- a/py_modules/unifideck/stores/shared/store_base.py
+++ b/py_modules/unifideck/stores/shared/store_base.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Optional
-from ...core.bin import binary_resolver
+from ...core.binaries import binary_resolver
 from ...core.exe_finder import exe_finder
 from ...core.types import (
     AuthResult,

--- a/py_modules/unifideck/stores/shared/store_registry.py
+++ b/py_modules/unifideck/stores/shared/store_registry.py
@@ -3,7 +3,9 @@ import logging
 from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
 from ...core.types import Events, Result, StoreError
+
 if TYPE_CHECKING:
     from ...core.cache_manager import CacheManager
     from ...event_bus import EventBus
@@ -11,6 +13,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 class StoreRegistry:
     """Store registry."""
+
     def __init__(self, bus: "EventBus") -> None:
         """Initialize the instance."""
         self._stores: dict[str, StoreBase] = {}
@@ -47,9 +50,9 @@ class StoreRegistry:
         plugin_dir: str = "",
         config=None,
     ) -> int:
-
         """Auto discover."""
         import importlib
+
         from .store_base import StoreBase as _StoreBase
         real_stores = self._validate_stores_dir(
             stores_dir, plugin_dir,
@@ -66,11 +69,11 @@ class StoreRegistry:
             )
             return 0
         registered = 0
-        for filename, full_path in self._iter_store_files(
+        for module_suffix, full_path in self._iter_store_files(
             real_stores,
         ):
             store_cls = self._load_store_class(
-                package_name, filename, full_path,
+                package_name, module_suffix, full_path,
                 _StoreBase,
             )
             if store_cls is None:
@@ -84,14 +87,14 @@ class StoreRegistry:
                 logger.info(
                     "[StoreRegistry] registered %s (%s) "
                     "from %s",
-                    store_id, store_cls.__name__, filename,
+                    store_id, store_cls.__name__, full_path,
                 )
                 registered += 1
             except Exception as e:
                 logger.error(
                     "[StoreRegistry] Failed to instantiate "
                     "%s from %s: %s",
-                    store_cls.__name__, filename, e,
+                    store_cls.__name__, full_path, e,
                 )
         logger.info(
             "[StoreRegistry] Auto-discovery: %d stores "
@@ -145,13 +148,25 @@ class StoreRegistry:
         return real_stores
     @staticmethod
     def _iter_store_files(real_stores: str):
-        """Iter store files."""
+        """Iter store files.
+
+        Yields (module_suffix, full_path) tuples where module_suffix
+        is the dotted module path relative to ``unifideck.stores``.
+
+        Two layouts are accepted:
+
+        * Flat: a top-level ``<name>_store.py`` file → yields
+          ("<name>_store", path).
+        * Subpackage: a top-level ``<name>/`` directory containing
+          a ``store.py`` → yields ("<name>.store", path).
+
+        Symlinks and ``_``-prefixed entries are skipped at every
+        level for the same reasons as the flat path: confinement.
+        """
         real_stores_p = Path(real_stores)
         for entry in sorted(real_stores_p.iterdir()):
-            filename = entry.name
-            if not filename.endswith("_store.py"):
-                continue
-            if filename.startswith("_"):
+            name = entry.name
+            if name.startswith("_"):
                 continue
             if entry.is_symlink():
                 logger.warning(
@@ -159,18 +174,31 @@ class StoreRegistry:
                     "symlink %s", str(entry),
                 )
                 continue
-            yield filename, str(entry)
+            if entry.is_file() and name.endswith("_store.py"):
+                yield name[:-3], str(entry)
+                continue
+            if entry.is_dir():
+                store_py = entry / "store.py"
+                if not store_py.is_file():
+                    continue
+                if store_py.is_symlink():
+                    logger.warning(
+                        "[StoreRegistry] SECURITY: skipping "
+                        "symlinked store.py in %s", str(entry),
+                    )
+                    continue
+                yield f"{name}.store", str(store_py)
 
     @staticmethod
     def _load_store_class(
         package_name: str,
-        filename: str,
+        module_suffix: str,
         full_path: str,
         store_base_cls: type,
     ) -> type | None:
         """Load store class."""
         import importlib
-        module_name = f"{package_name}.{filename[:-3]}"
+        module_name = f"{package_name}.{module_suffix}"
         logger.info(
             "[StoreRegistry] loading %s from %s",
             module_name, full_path,
@@ -179,7 +207,7 @@ class StoreRegistry:
             mod = importlib.import_module(module_name)
         except Exception as e:
             logger.debug(
-                "[StoreRegistry] Skip %s: %s", filename, e,
+                "[StoreRegistry] Skip %s: %s", module_suffix, e,
             )
             return None
         for attr_name in dir(mod):
@@ -232,7 +260,6 @@ class StoreRegistry:
     async def auth_action(
         self, store_id: str, action: str, **kwargs,
     ) -> Result:
-
         """Auth action."""
         try:
             store = self.get(store_id)

--- a/py_modules/unifideck/stores/ubisoft/__init__.py
+++ b/py_modules/unifideck/stores/ubisoft/__init__.py
@@ -1,2 +1,4 @@
 # OP-55 | stores/ubisoft/__init__.py | Depends: OP-55a
-from __future__ import annotations
+from .store import UbisoftStore
+
+__all__ = ['UbisoftStore']

--- a/py_modules/unifideck/stores/ubisoft/auth/__init__.py
+++ b/py_modules/unifideck/stores/ubisoft/auth/__init__.py
@@ -1,2 +1,4 @@
 # OP-58 | stores/ubisoft/auth/__init__.py
-from __future__ import annotations
+from .facade import UbisoftAuth, UbisoftAuthServices, UbisoftAuthState
+
+__all__ = ['UbisoftAuth', 'UbisoftAuthServices', 'UbisoftAuthState']

--- a/py_modules/unifideck/stores/ubisoft/auth/context.py
+++ b/py_modules/unifideck/stores/ubisoft/auth/context.py
@@ -1,5 +1,85 @@
-"""context.py — Auth context dataclass
+"""context.py — Build the auth-context dict the frontend renders.
+
 # OP-58b | py_modules/unifideck/stores/ubisoft/auth/context.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .facade import UbisoftAuth
+
+logger = logging.getLogger(__name__)
+_SGDB_UBISOFT_CONNECT_ID = 5270094
+_AUTH_SHORTCUT_NAME = 'Ubisoft Connect'
+
+
+class _AuthContext:
+    """Auth context."""
+
+    def __init__(self, parent: UbisoftAuth) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    async def fetch_auth_shortcut_artwork(
+        self, unsigned_id: int, force: bool = False,
+    ) -> None:
+        """Fetch auth shortcut artwork."""
+        services = self._parent._services
+        sgdb = services.steamgriddb
+        if sgdb is None:
+            return
+        try:
+            await sgdb.fetch_artwork_for_appid(
+                appid=unsigned_id,
+                game_id=_SGDB_UBISOFT_CONNECT_ID,
+                force=force,
+            )
+        except Exception as e:
+            logger.debug('[Ubisoft.auth] artwork fetch failed: %s', e)
+
+    def build_auth_context_success(
+        self, unsigned_appid: int, *, with_launch_wait: bool = True,
+    ) -> dict[str, Any]:
+        """Build auth context success."""
+        config = self._parent._state.config
+        ctx: dict[str, Any] = {
+            'success': True,
+            'shortcut_appid': unsigned_appid,
+            'store_id': config.auth_shortcut_store_id,
+            'name': _AUTH_SHORTCUT_NAME,
+        }
+        if with_launch_wait:
+            ctx['launch_wait_ms'] = config.auth_shortcut_launch_wait_ms
+        return ctx
+
+    async def get_auth_shortcut_context(self) -> dict[str, Any]:
+        """Get auth shortcut context."""
+        services = self._parent._services
+        sm = services.shortcut_service
+        if sm is None:
+            return {'success': False, 'error': 'shortcut_service_unavailable'}
+        existing = await self._try_existing_registry(sm)
+        if existing is not None:
+            return self.build_auth_context_success(existing)
+        unsigned = await self._parent.ensure_auth_shortcut()
+        if unsigned is None:
+            return {'success': False, 'error': 'auth_shortcut_unavailable'}
+        return self.build_auth_context_success(unsigned)
+
+    async def _try_existing_registry(self, sm: Any) -> dict[str, Any] | None:
+        """Try existing registry."""
+        try:
+            registry = await sm.get_registry()
+        except Exception:
+            return None
+        config = self._parent._state.config
+        entry = registry.get(config.auth_shortcut_store_id)
+        if not isinstance(entry, dict):
+            return None
+        appid = entry.get('appid_unsigned') or entry.get('appid')
+        try:
+            return int(appid) if appid is not None else None
+        except (TypeError, ValueError):
+            return None

--- a/py_modules/unifideck/stores/ubisoft/auth/direct_signin.py
+++ b/py_modules/unifideck/stores/ubisoft/auth/direct_signin.py
@@ -1,5 +1,133 @@
-"""direct_signin.py — Direct sign-in flow
+"""direct_signin.py — Headless UPC sign-in (no Steam shortcut required).
+
 # OP-58e | py_modules/unifideck/stores/ubisoft/auth/direct_signin.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+from typing import Any
+
+from ....security import emit_external_auth_check_failed
+from ..binaries import UbisoftBinaryResolver
+from ..paths import UbisoftPrefixPaths
+from ..session import UbisoftSession
+
+logger = logging.getLogger(__name__)
+
+
+class _DirectSignIn:
+    """Direct sign in."""
+
+    def __init__(
+        self,
+        *,
+        binaries: UbisoftBinaryResolver,
+        bus: Any,
+        config: Any,
+        paths: UbisoftPrefixPaths,
+        session: UbisoftSession,
+        ensure_auth_prefix: Any,
+        queue_auth_assets_ensure: Any,
+    ) -> None:
+        """Initialize the instance."""
+        self._binaries = binaries
+        self._bus = bus
+        self._config = config
+        self._paths = paths
+        self._session = session
+        self._ensure_auth_prefix = ensure_auth_prefix
+        self._queue = queue_auth_assets_ensure
+
+    async def connect(self) -> dict[str, Any]:
+        """Connect."""
+        targets = await self._resolve_launch_targets()
+        if isinstance(targets, dict):
+            return targets
+        prefix_path, upc_path, umu_run = targets
+        env_pair = self._build_launch_env(prefix_path)
+        if env_pair is None:
+            return {'success': False, 'error': 'launch_env_unavailable'}
+        python_bin, env = env_pair
+        env['STEAM_COMPAT_DATA_PATH'] = prefix_path
+        cmd = [umu_run, upc_path]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except OSError as e:
+            await emit_external_auth_check_failed(
+                self._bus, store='ubisoft', reason=str(e),
+            )
+            return {'success': False, 'error': f'spawn_failed:{e}'}
+        captured = await self._wait_for_capture(proc, prefix_path)
+        if not captured:
+            return {'success': False, 'error': 'capture_timeout'}
+        return self._finalize_success(prefix_path)
+
+    async def _resolve_launch_targets(
+        self,
+    ) -> tuple[str, str, str] | dict[str, Any]:
+        """Resolve launch targets."""
+        prefix_path = await self._ensure_auth_prefix()
+        if not prefix_path:
+            return {'success': False, 'error': 'auth_prefix_unavailable'}
+        upc_path = self._paths.find_upc_exe(prefix_path)
+        if not upc_path:
+            return {'success': False, 'error': 'upc_exe_not_found'}
+        umu_run = self._binaries.find_umu_run()
+        if not umu_run:
+            return {'success': False, 'error': 'umu_run_not_found'}
+        return prefix_path, upc_path, umu_run
+
+    def _build_launch_env(
+        self, prefix_path: str,
+    ) -> tuple[str, dict[str, str]] | None:
+        """Build launch env."""
+        python_bin = self._binaries.find_python()
+        if not python_bin:
+            return None
+        proton_path = self._binaries.find_proton_path()
+        env = self._binaries.build_umu_env(
+            wineprefix=prefix_path,
+            gameid='umu-ubisoft-auth',
+            proton_path=proton_path,
+        )
+        return python_bin, env
+
+    def _finalize_success(self, prefix_path: str) -> dict[str, Any]:
+        """Finalize success."""
+        captured = self._session.capture(prefix_path)
+        self._queue('direct_signin')
+        return {
+            'success': True,
+            'prefix_path': prefix_path,
+            'session_token_present': bool(captured),
+        }
+
+    async def _wait_for_capture(
+        self, proc: asyncio.subprocess.Process, prefix_path: str,
+    ) -> str | None:
+        """Wait for capture."""
+        deadline_s = 30 * 60
+        elapsed = 0.0
+        interval = 2.0
+        while elapsed < deadline_s:
+            if self._session.has_valid_credentials(prefix_path):
+                token = self._session.capture(prefix_path)
+                if proc.returncode is None:
+                    try:
+                        proc.terminate()
+                    except ProcessLookupError:
+                        pass
+                return token or 'captured'
+            if proc.returncode is not None:
+                logger.info(
+                    '[Ubisoft.auth] UPC exited rc=%s', proc.returncode,
+                )
+                return None
+            await asyncio.sleep(interval)
+            elapsed += interval
+        return None

--- a/py_modules/unifideck/stores/ubisoft/auth/facade.py
+++ b/py_modules/unifideck/stores/ubisoft/auth/facade.py
@@ -1,5 +1,190 @@
-"""facade.py — Auth facade
+"""facade.py — Public Ubisoft auth surface.
+
 # OP-58a | py_modules/unifideck/stores/ubisoft/auth/facade.py | Depends: OP-55a
+
+Glues the five internal auth helpers (context, shortcut, session-monitor,
+direct-signin, shortcut-ops) behind a single ``UbisoftAuth`` class. The
+state and services frozen-dataclasses keep the constructor wide-but-flat
+so the store layer can wire dependencies without star-args.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from ....core.types import AuthResult, Events, Result
+from ....security import audit_auth_flow
+from ..binaries import UbisoftBinaryResolver
+from ..config import UbisoftConfig
+from ..paths import UbisoftPrefixPaths
+from ..session import UbisoftSession
+from .context import _AuthContext
+from .direct_signin import _DirectSignIn
+from .session_monitor import _AuthSessionMonitor
+from .shortcut import _AuthShortcut
+from .shortcut_ops import _ShortcutRegistryOps
+
+if TYPE_CHECKING:
+    from ....event_bus.event_bus import EventBus
+    from ....services.shortcut import ShortcutService
+    from ....steam.steamgriddb import SteamGridDBClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UbisoftAuthState:
+    """Ubisoft auth state."""
+
+    config: UbisoftConfig
+    paths: UbisoftPrefixPaths
+    binaries: UbisoftBinaryResolver
+    session: UbisoftSession
+    ensure_auth_prefix: Callable[[], Any]
+    queue_auth_assets_ensure: Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class UbisoftAuthServices:
+    """Ubisoft auth services."""
+
+    plugin_dir: str | None
+    shortcut_service: ShortcutService | None
+    steamgriddb: SteamGridDBClient | None
+
+
+class UbisoftAuth:
+    """Ubisoft auth."""
+
+    def __init__(
+        self,
+        bus: EventBus,
+        state: UbisoftAuthState,
+        services: UbisoftAuthServices,
+    ) -> None:
+        """Initialize the instance."""
+        self._bus = bus
+        self._state = state
+        self._services = services
+        self._context = _AuthContext(self)
+        self._shortcut = _AuthShortcut(self)
+        self._monitor = _AuthSessionMonitor(
+            config=state.config,
+            session=state.session,
+            queue_auth_assets_ensure=state.queue_auth_assets_ensure,
+        )
+        self._direct = _DirectSignIn(
+            binaries=state.binaries,
+            bus=bus,
+            config=state.config,
+            paths=state.paths,
+            session=state.session,
+            ensure_auth_prefix=state.ensure_auth_prefix,
+            queue_auth_assets_ensure=state.queue_auth_assets_ensure,
+        )
+        self._registry_ops = _ShortcutRegistryOps(config=state.config)
+
+    async def ensure_auth_shortcut(self) -> int | None:
+        """Ensure auth shortcut."""
+        return await self._shortcut.ensure_auth_shortcut()
+
+    async def auth_shortcut_exists_in_vdf(self) -> bool:
+        """Auth shortcut exists in VDF."""
+        return await self._shortcut.auth_shortcut_exists_in_vdf()
+
+    async def fetch_auth_shortcut_artwork(
+        self, unsigned_id: int, force: bool = False,
+    ) -> None:
+        """Fetch auth shortcut artwork."""
+        await self._context.fetch_auth_shortcut_artwork(unsigned_id, force)
+
+    async def get_auth_shortcut_context(self) -> dict[str, Any]:
+        """Get auth shortcut context."""
+        return await self._context.get_auth_shortcut_context()
+
+    async def is_available(self) -> bool:
+        """Check whether available."""
+        try:
+            return any(
+                self._state.session.has_valid_credentials(p)
+                for p in self._state.config.iter_game_prefix_paths()
+            ) or self._state.session.has_valid_credentials(
+                self._state.config.auth_prefix_dir_expanded,
+            )
+        except Exception as e:
+            logger.debug('[Ubisoft.auth] is_available failed: %s', e)
+            return False
+
+    @audit_auth_flow(store='ubisoft', method='wine_installer')
+    async def start_auth(self) -> AuthResult:
+        """Start auth."""
+        ctx = await self.get_auth_shortcut_context()
+        if not ctx.get('success'):
+            return AuthResult(
+                success=False,
+                error=str(ctx.get('error', 'auth_unavailable')),
+                store='ubisoft',
+            )
+        return AuthResult(
+            success=True,
+            store='ubisoft',
+            redirect_url=None,
+            extra={'shortcut_context': ctx},
+        )
+
+    async def complete_auth(self, code: str = '', **kwargs: Any) -> AuthResult:
+        """Complete auth."""
+        if await self.is_available():
+            await self._bus.emit(Events.STORE_AUTH_SUCCESS, store='ubisoft')
+            return AuthResult(success=True, store='ubisoft')
+        return AuthResult(
+            success=False, store='ubisoft', error='credentials_not_captured',
+        )
+
+    async def logout(self) -> Result:
+        """Logout."""
+        try:
+            self._state.session.clear_session_file()
+        except Exception as e:
+            logger.warning('[Ubisoft.auth] logout failed: %s', e)
+            return Result(success=False, error=str(e))
+        await self._bus.emit(Events.STORE_LOGOUT, store='ubisoft')
+        return Result(success=True)
+
+    async def start_auth_session_monitor(self) -> Result:
+        """Start auth session monitor."""
+        return await self._monitor.start()
+
+    def check_auth_session_status(self) -> dict[str, Any]:
+        """Check auth session status."""
+        return self._monitor.status()
+
+    async def connect_ubisoft_account(self) -> dict[str, Any]:
+        """Connect UBISOFT account."""
+        return await self._direct.connect()
+
+    async def _load_registry(self, sm: ShortcutService) -> dict[str, Any]:
+        """Load registry."""
+        return await self._registry_ops.load(sm)
+
+    async def _register_shortcut(
+        self, sm: ShortcutService, appid: int, name: str,
+    ) -> None:
+        """Register shortcut."""
+        await self._registry_ops.register(sm, appid, name)
+
+    async def _clear_compat(self, sm: ShortcutService, appid: int) -> None:
+        """Clear compat."""
+        await self._registry_ops.clear_compat(sm, appid)
+
+    async def _cleanup_legacy_registry(self, sm: ShortcutService) -> None:
+        """Cleanup legacy registry."""
+        await self._registry_ops.cleanup_legacy(sm)
+
+    async def _fetch_auth_shortcut_artwork(
+        self, unsigned_id: int, force: bool = False,
+    ) -> None:
+        """Internal alias used by _AuthShortcut."""
+        await self._context.fetch_auth_shortcut_artwork(unsigned_id, force)

--- a/py_modules/unifideck/stores/ubisoft/auth/session_monitor.py
+++ b/py_modules/unifideck/stores/ubisoft/auth/session_monitor.py
@@ -1,5 +1,81 @@
-"""session_monitor.py — UPC session monitor
+"""session_monitor.py — Background poll that detects UPC auth captures.
+
 # OP-58d | py_modules/unifideck/stores/ubisoft/auth/session_monitor.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from ....core.types import Result
+
+_AUTH_MONITOR_TIMEOUT_S = 30 * 60
+_AUTH_MONITOR_POLL_INTERVAL_S = 2.0
+logger = logging.getLogger(__name__)
+
+
+class _AuthSessionMonitor:
+    """Auth session monitor."""
+
+    def __init__(
+        self,
+        *,
+        config: Any,
+        session: Any,
+        queue_auth_assets_ensure: Callable[[str], None],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._session = session
+        self._queue = queue_auth_assets_ensure
+        self._task: asyncio.Task[None] | None = None
+        self._started_at: float = 0.0
+        self._captured: bool = False
+        self._error: str | None = None
+
+    async def start(self) -> Result:
+        """Start."""
+        if self._task is not None and not self._task.done():
+            return Result(success=True)
+        self._started_at = time.monotonic()
+        self._captured = False
+        self._error = None
+        self._task = asyncio.create_task(
+            self._loop(), name='ubisoft_auth_session_monitor',
+        )
+        return Result(success=True)
+
+    async def _loop(self) -> None:
+        """Loop."""
+        deadline = self._started_at + _AUTH_MONITOR_TIMEOUT_S
+        while time.monotonic() < deadline:
+            try:
+                source = self._session.find_best_credential_source()
+                if source:
+                    self._captured = True
+                    self._queue('auth_session_monitor')
+                    logger.info(
+                        '[Ubisoft.auth] session captured at %s', source,
+                    )
+                    return
+            except Exception as e:
+                self._error = str(e)
+                logger.debug('[Ubisoft.auth] monitor poll error: %s', e)
+            await asyncio.sleep(_AUTH_MONITOR_POLL_INTERVAL_S)
+        self._error = self._error or 'timeout'
+
+    def status(self) -> dict[str, Any]:
+        """Status."""
+        running = self._task is not None and not self._task.done()
+        return {
+            'running': running,
+            'captured': self._captured,
+            'error': self._error,
+            'elapsed_s': (
+                round(time.monotonic() - self._started_at, 1)
+                if self._started_at else 0.0
+            ),
+        }

--- a/py_modules/unifideck/stores/ubisoft/auth/shortcut.py
+++ b/py_modules/unifideck/stores/ubisoft/auth/shortcut.py
@@ -1,5 +1,255 @@
-"""shortcut.py — Auth shortcut VDF entry
+"""shortcut.py — Manage the "Ubisoft Connect" Steam shortcut.
+
 # OP-58c | py_modules/unifideck/stores/ubisoft/auth/shortcut.py | Depends: (none)
+
+The auth flow leans on a Steam shortcut so UPC opens inside gamescope
+with the right Proton runtime. This module owns the shortcut's
+creation, validation, and pruning of stale variants left over from
+older plugin builds.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ....services.shortcut import ShortcutService
+    from .facade import UbisoftAuth
+
+logger = logging.getLogger(__name__)
+_AUTH_LAUNCH_OPTIONS_TEMPLATE = (
+    '{store_id} UNIFIDECK_UBISOFT_ACTION=auth '
+    'UNIFIDECK_UBISOFT_PREFIX_NAME={prefix_name}'
+)
+_AUTH_SHORTCUT_NAME = 'Ubisoft Connect'
+_LEGACY_AUTH_LAUNCH_OPTIONS = 'ubisoft:.template'
+_ORPHAN_SHORTCUT_NAMES = frozenset({'upc.exe', 'ubisoft connect'})
+
+
+def _prune_orphan_shortcuts(shortcuts: dict[str, Any]) -> int:
+    """Prune orphan shortcuts.
+
+    Removes entries whose AppName matches a known orphan and whose
+    LaunchOptions don't carry a current Unifideck launch token.
+    """
+    removed = 0
+    for key in list(shortcuts.keys()):
+        entry = shortcuts.get(key)
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get('AppName') or entry.get('appname') or '').strip().lower()
+        if name not in _ORPHAN_SHORTCUT_NAMES:
+            continue
+        opts = str(entry.get('LaunchOptions') or '')
+        if 'UNIFIDECK_UBISOFT_ACTION' in opts:
+            continue
+        del shortcuts[key]
+        removed += 1
+    return removed
+
+
+def _prune_legacy_template_shortcuts(shortcuts: dict[str, Any]) -> int:
+    """Prune legacy template shortcuts (ubisoft:.template store_id)."""
+    removed = 0
+    for key in list(shortcuts.keys()):
+        entry = shortcuts.get(key)
+        if not isinstance(entry, dict):
+            continue
+        opts = str(entry.get('LaunchOptions') or '')
+        if _LEGACY_AUTH_LAUNCH_OPTIONS in opts:
+            del shortcuts[key]
+            removed += 1
+    return removed
+
+
+class _AuthShortcut:
+    """Auth shortcut."""
+
+    def __init__(self, parent: UbisoftAuth) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    def get_launcher_path(self) -> str:
+        """Get launcher path."""
+        config = self._parent._state.config
+        return str(
+            Path(config.auth_prefix_dir_expanded)
+            / config.upc_connect_relative_path
+        )
+
+    def build_auth_launch_options(self) -> str:
+        """Build auth launch options."""
+        config = self._parent._state.config
+        return _AUTH_LAUNCH_OPTIONS_TEMPLATE.format(
+            store_id=config.auth_shortcut_store_id,
+            prefix_name=config.auth_prefix_name,
+        )
+
+    async def ensure_auth_shortcut(self) -> int | None:
+        """Ensure auth shortcut."""
+        sm = self._parent._services.shortcut_service
+        if sm is None:
+            return None
+        config = self._parent._state.config
+        existing = await self.try_existing_shortcut(
+            sm, config.auth_shortcut_store_id,
+        )
+        if existing is not None:
+            return existing
+        return await self.create_new_auth_shortcut(
+            sm, config.auth_shortcut_store_id,
+        )
+
+    async def try_existing_shortcut(
+        self, sm: ShortcutService, store_id: str,
+    ) -> int | None:
+        """Try existing shortcut."""
+        try:
+            registry = await sm.get_registry()
+        except Exception:
+            return None
+        entry = registry.get(store_id)
+        if not isinstance(entry, dict):
+            return None
+        appid = entry.get('appid_unsigned') or entry.get('appid')
+        try:
+            return int(appid) if appid is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    async def create_new_auth_shortcut(
+        self, sm: ShortcutService, store_id: str,
+    ) -> int | None:
+        """Create new auth shortcut."""
+        try:
+            appid = await sm.create_shortcut(
+                name=_AUTH_SHORTCUT_NAME,
+                exe=self.get_launcher_path(),
+                start_dir=str(Path(self.get_launcher_path()).parent),
+                launch_options=self.build_auth_launch_options(),
+                store_id=store_id,
+            )
+        except Exception as e:
+            logger.warning(
+                '[Ubisoft.auth] create_shortcut failed: %s', e,
+            )
+            return None
+        unsigned = self._coerce_int(appid)
+        if unsigned is None:
+            return None
+        await self._finalize_new_shortcut(sm, appid=unsigned, unsigned_id=unsigned)
+        return unsigned
+
+    async def _finalize_new_shortcut(
+        self, sm: ShortcutService, appid: int, unsigned_id: int,
+    ) -> None:
+        """Finalize new shortcut."""
+        try:
+            await self._parent._fetch_auth_shortcut_artwork(unsigned_id, force=True)
+        except Exception as e:
+            logger.debug('[Ubisoft.auth] artwork fetch failed: %s', e)
+        await self._parent._register_shortcut(sm, appid, _AUTH_SHORTCUT_NAME)
+
+    def _add_canonical_if_missing(
+        self,
+        shortcuts: dict[str, Any],
+        launcher_path: str,
+        appid: int,
+        unsigned_id: int,
+    ) -> bool:
+        """Add canonical if missing."""
+        for entry in shortcuts.values():
+            if not isinstance(entry, dict):
+                continue
+            if entry.get('appid') == appid or entry.get('appid_unsigned') == unsigned_id:
+                return False
+        new_key = str(len(shortcuts))
+        shortcuts[new_key] = {
+            'appid': appid,
+            'appid_unsigned': unsigned_id,
+            'AppName': _AUTH_SHORTCUT_NAME,
+            'Exe': launcher_path,
+            'StartDir': str(Path(launcher_path).parent),
+            'LaunchOptions': self.build_auth_launch_options(),
+        }
+        return True
+
+    async def validate_auth_shortcut(self, sm: ShortcutService) -> bool:
+        """Validate auth shortcut."""
+        try:
+            shortcuts = await sm.get_vdf_shortcuts()
+        except Exception:
+            return False
+        config = self._parent._state.config
+        expected_opts = self.build_auth_launch_options()
+        for entry in shortcuts.values() if isinstance(shortcuts, dict) else []:
+            if not isinstance(entry, dict):
+                continue
+            if config.auth_shortcut_store_id in str(entry.get('LaunchOptions') or ''):
+                return self._fix_shortcut_fields(
+                    entry, self.get_launcher_path(),
+                    expected_opts,
+                    self._coerce_int(entry.get('appid')) or 0,
+                )
+        return False
+
+    def _fix_shortcut_fields(
+        self, entry: dict[str, Any], launcher_path: str,
+        expected_launch_options: str, expected_appid: int,
+    ) -> bool:
+        """Fix shortcut fields."""
+        changed = False
+        if entry.get('Exe') != launcher_path:
+            entry['Exe'] = launcher_path
+            changed = True
+        if entry.get('LaunchOptions') != expected_launch_options:
+            entry['LaunchOptions'] = expected_launch_options
+            changed = True
+        return not changed  # True when nothing needed fixing
+
+    async def auth_shortcut_exists_in_vdf(self) -> bool:
+        """Auth shortcut exists in VDF."""
+        sm = self._parent._services.shortcut_service
+        if sm is None:
+            return False
+        try:
+            shortcuts = await sm.get_vdf_shortcuts()
+        except Exception:
+            return False
+        return self.shortcut_in_vdf(shortcuts if isinstance(shortcuts, dict) else {})
+
+    async def add_shortcut_to_vdf(
+        self, sm: ShortcutService, appid: int,
+    ) -> None:
+        """Add shortcut to VDF."""
+        try:
+            await sm.persist_shortcut(appid=appid)
+        except Exception as e:
+            logger.debug('[Ubisoft.auth] persist_shortcut failed: %s', e)
+
+    def shortcut_in_vdf(self, shortcuts: dict[str, Any]) -> bool:
+        """Shortcut in VDF."""
+        config = self._parent._state.config
+        for entry in shortcuts.values():
+            if not isinstance(entry, dict):
+                continue
+            if config.auth_shortcut_store_id in str(entry.get('LaunchOptions') or ''):
+                return True
+        return False
+
+    @staticmethod
+    def extract_store_id(launch_options: str) -> str:
+        """Extract store ID from a LaunchOptions string."""
+        if not launch_options:
+            return ''
+        head = launch_options.split(' ', 1)[0]
+        return head.strip()
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        """Coerce int."""
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None

--- a/py_modules/unifideck/stores/ubisoft/auth/shortcut_ops.py
+++ b/py_modules/unifideck/stores/ubisoft/auth/shortcut_ops.py
@@ -1,5 +1,59 @@
-"""shortcut_ops.py — Shortcut auth operations
+"""shortcut_ops.py — ShortcutService wrappers shared by the auth flow.
+
 # OP-58f | py_modules/unifideck/stores/ubisoft/auth/shortcut_ops.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ....services.shortcut import ShortcutService
+    from ..config import UbisoftConfig
+
+_LEGACY_AUTH_SHORTCUT_STORE_ID = 'ubisoft:.template'
+logger = logging.getLogger(__name__)
+
+
+class _ShortcutRegistryOps:
+    """Shortcut registry ops."""
+
+    def __init__(self, *, config: UbisoftConfig) -> None:
+        """Initialize the instance."""
+        self._config = config
+
+    async def load(self, sm: ShortcutService) -> dict[str, Any]:
+        """Load."""
+        try:
+            return await sm.get_registry()
+        except Exception as e:
+            logger.warning('[Ubisoft.auth] registry load failed: %s', e)
+            return {}
+
+    async def register(
+        self, sm: ShortcutService, appid: int, name: str,
+    ) -> None:
+        """Register."""
+        try:
+            await sm.register_appid(
+                store_id=self._config.auth_shortcut_store_id,
+                appid=appid, name=name,
+            )
+        except Exception as e:
+            logger.warning('[Ubisoft.auth] registry register failed: %s', e)
+
+    async def clear_compat(
+        self, sm: ShortcutService, appid: int,
+    ) -> None:
+        """Clear compat."""
+        try:
+            await sm.clear_compat_tool(appid)
+        except Exception as e:
+            logger.debug('[Ubisoft.auth] clear_compat failed: %s', e)
+
+    async def cleanup_legacy(self, sm: ShortcutService) -> None:
+        """Cleanup legacy."""
+        try:
+            await sm.unregister_store_id(_LEGACY_AUTH_SHORTCUT_STORE_ID)
+        except Exception as e:
+            logger.debug('[Ubisoft.auth] legacy cleanup failed: %s', e)

--- a/py_modules/unifideck/stores/ubisoft/binaries.py
+++ b/py_modules/unifideck/stores/ubisoft/binaries.py
@@ -1,5 +1,262 @@
-"""binaries.py — Ubisoft binary detection
+"""binaries.py — Resolve umu-run / Proton / Python plus build env dicts.
+
 # OP-55d | py_modules/unifideck/stores/ubisoft/binaries.py | Depends: OP-07a
+
+UPC needs to run inside a Proton-managed Wine prefix wrapped by umu-run.
+Decky's plugin process is launched by systemd without the user's
+graphical session env, so DISPLAY / WAYLAND_DISPLAY / DBUS / XAUTHORITY
+also get scraped from the live Steam / gamescope-session process.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from .config import UbisoftConfig
+
+logger = logging.getLogger(__name__)
+_DISPLAY_ENV_VARS = (
+    'DISPLAY', 'WAYLAND_DISPLAY', 'DBUS_SESSION_BUS_ADDRESS', 'XAUTHORITY',
+)
+_PROTON_OFFICIAL_NAMES = (
+    'Proton - Experimental', 'Proton 10.0', 'Proton 9.0 (Beta)',
+)
+_STEAM_COMMON_CANDIDATES = (
+    str(Path('~') / '.steam' / 'steam' / 'steamapps' / 'common'),
+    str(Path('~') / '.local' / 'share' / 'Steam' / 'steamapps' / 'common'),
+    str(Path('~') / '.steam' / 'root' / 'steamapps' / 'common'),
+)
+_COMPAT_TOOLS_DIR = '~/.local/share/Steam/compatibilitytools.d'
+
+
+class UbisoftBinaryResolver:
+    """Ubisoft binary resolver."""
+
+    def __init__(
+        self, config: UbisoftConfig, plugin_dir: str | None,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._plugin_dir = plugin_dir
+
+    def find_umu_run(self) -> str | None:
+        """Find UMU run."""
+        if self._plugin_dir:
+            bundled = os.path.join(
+                self._plugin_dir, 'bin', 'umu', 'umu', 'umu-run',
+            )
+            if os.path.exists(bundled):
+                return bundled
+        for path in (
+            os.path.expanduser(
+                '~/.local/share/unifideck/bin/umu/umu/umu-run',
+            ),
+            '/usr/bin/umu-run',
+        ):
+            if os.path.exists(path):
+                return path
+        logger.warning('[Ubisoft] umu-run not found')
+        return None
+
+    def find_proton_path(self) -> str | None:
+        """Find PROTON path."""
+        official = self._find_official_proton()
+        if official:
+            return official
+        return self._find_custom_proton()
+
+    @staticmethod
+    def _find_official_proton() -> str | None:
+        """Find official PROTON."""
+        for steam_common in _STEAM_COMMON_CANDIDATES:
+            base = os.path.expanduser(steam_common)
+            for name in _PROTON_OFFICIAL_NAMES:
+                candidate = os.path.join(base, name)
+                if os.path.isdir(candidate):
+                    logger.info('[Ubisoft] Using Proton: %s', name)
+                    return candidate
+        return None
+
+    @staticmethod
+    def _find_custom_proton() -> str | None:
+        """Find custom PROTON."""
+        compat_dir = os.path.expanduser(_COMPAT_TOOLS_DIR)
+        if not os.path.isdir(compat_dir):
+            logger.warning('[Ubisoft] No Proton in compatibilitytools.d')
+            return None
+        umu: list[str] = []
+        ge: list[str] = []
+        try:
+            entries = sorted(os.listdir(compat_dir), reverse=True)
+        except OSError:
+            return None
+        for entry in entries:
+            full = os.path.join(compat_dir, entry)
+            if not os.path.isdir(full):
+                continue
+            if entry.startswith('UMU-Proton'):
+                umu.append(full)
+            elif entry.startswith('GE-Proton'):
+                ge.append(full)
+        candidates = umu + ge
+        if candidates:
+            logger.info(
+                '[Ubisoft] Using Proton: %s', os.path.basename(candidates[0]),
+            )
+            return candidates[0]
+        logger.warning('[Ubisoft] No Proton found')
+        return None
+
+    @staticmethod
+    def find_python() -> str:
+        """Find python."""
+        for name in ('python3', 'python'):
+            path = shutil.which(name)
+            if path:
+                return path
+        return 'python3'
+
+    @staticmethod
+    def proton_family(version_str: str) -> str:
+        """Proton family — coarse classification used by callers when
+        deciding which compatibility tweaks to apply.
+        """
+        if not version_str:
+            return 'unknown'
+        v = version_str.strip()
+        if v.startswith('UMU-Proton'):
+            return 'umu'
+        if v.startswith('GE-Proton'):
+            return 'ge'
+        if 'Experimental' in v:
+            return 'experimental'
+        if v.startswith('Proton '):
+            return 'official'
+        return 'unknown'
+
+    def build_umu_env(
+        self,
+        wineprefix: str,
+        gameid: str,
+        *,
+        proton_path: str | None = None,
+        store_game_id: str | None = None,
+        steam_window_env: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        """Build UMU env."""
+        home = os.environ.get('HOME', os.path.expanduser('~'))
+        uid = os.getuid()
+        env: dict[str, str] = {
+            'HOME': home,
+            'USER': os.environ.get('USER', 'deck'),
+            'PATH': os.environ.get(
+                'PATH', '/usr/local/bin:/usr/bin:/bin',
+            ),
+            'LANG': os.environ.get('LANG', 'en_US.UTF-8'),
+            'XDG_RUNTIME_DIR': os.environ.get(
+                'XDG_RUNTIME_DIR', f'/run/user/{uid}',
+            ),
+            'XDG_DATA_HOME': os.environ.get(
+                'XDG_DATA_HOME', os.path.join(home, '.local', 'share'),
+            ),
+            'WINEPREFIX': wineprefix,
+            'GAMEID': gameid,
+            'STORE': 'ubisoft',
+            'PROTON_VERB': 'waitforexitandrun',
+        }
+        if proton_path:
+            env['PROTONPATH'] = proton_path
+        if steam_window_env:
+            env.update(steam_window_env)
+        env.update(self.detect_display_env())
+        return env
+
+    def detect_display_env(self) -> dict[str, str]:
+        """Detect display env."""
+        result = self._collect_display_env_from_self()
+        if result.get('DISPLAY') or result.get('WAYLAND_DISPLAY'):
+            return result
+        if self._fill_display_env_from_steam(result):
+            return result
+        self._apply_steam_deck_defaults(result)
+        return result
+
+    @staticmethod
+    def _collect_display_env_from_self() -> dict[str, str]:
+        """Collect display env from self (the current process)."""
+        result: dict[str, str] = {}
+        for var in _DISPLAY_ENV_VARS:
+            value = os.environ.get(var)
+            if value:
+                result[var] = value
+        return result
+
+    def _fill_display_env_from_steam(self, result: dict[str, str]) -> bool:
+        """Fill display env from steam — returns True when DISPLAY found."""
+        for proc_name in ('steam', 'gamescope-session'):
+            for pid in self._pgrep(proc_name):
+                if self._scan_pid_for_display(pid, result):
+                    return True
+        return False
+
+    def _scan_pid_for_display(
+        self, pid: str, result: dict[str, str],
+    ) -> bool:
+        """Scan pid for display env."""
+        env = self._read_proc_environ(pid, _DISPLAY_ENV_VARS)
+        for k, v in env.items():
+            if k not in result and v:
+                result[k] = v
+        if result.get('DISPLAY') or result.get('WAYLAND_DISPLAY'):
+            logger.info(
+                '[Ubisoft] display env from PID %s: DISPLAY=%s',
+                pid, result.get('DISPLAY'),
+            )
+            return True
+        return False
+
+    @staticmethod
+    def _apply_steam_deck_defaults(result: dict[str, str]) -> None:
+        """Apply steam DECK defaults."""
+        if not result.get('DISPLAY'):
+            result['DISPLAY'] = ':0'
+        xauth = os.path.join(os.path.expanduser('~'), '.Xauthority')
+        if not result.get('XAUTHORITY') and os.path.isfile(xauth):
+            result['XAUTHORITY'] = xauth
+
+    @staticmethod
+    def _pgrep(process_name: str) -> list[str]:
+        """Pgrep."""
+        try:
+            res = subprocess.run(
+                ['pgrep', '-u', str(os.getuid()), '-x', process_name],
+                capture_output=True, text=True, timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return []
+        return [
+            line.strip() for line in res.stdout.splitlines() if line.strip()
+        ]
+
+    @staticmethod
+    def _read_proc_environ(
+        pid: str, targets: tuple[str, ...],
+    ) -> dict[str, str]:
+        """Read proc environ."""
+        out: dict[str, str] = {}
+        try:
+            with open(f'/proc/{pid}/environ', 'rb') as f:
+                blob = f.read()
+        except (OSError, PermissionError):
+            return out
+        for entry in blob.split(b'\x00'):
+            decoded = entry.decode('utf-8', errors='replace')
+            if '=' not in decoded:
+                continue
+            key, _, value = decoded.partition('=')
+            if key in targets and value:
+                out[key] = value
+        return out

--- a/py_modules/unifideck/stores/ubisoft/config.py
+++ b/py_modules/unifideck/stores/ubisoft/config.py
@@ -1,5 +1,296 @@
-"""config.py — Ubisoft config dataclass
+"""config.py — Ubisoft store configuration dataclass.
+
 # OP-55b | py_modules/unifideck/stores/ubisoft/config.py | Depends: (none)
+
+Holds every path, URL, and tunable the Ubisoft modules need. Built
+once at startup from ``ConfigManager`` via :meth:`from_config_manager`
+and threaded immutably through the rest of the store.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from unifideck.utils.config_helpers import get_cfg
+
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DATA_DIR = '~/.local/share/unifideck'
+_DEFAULT_ID_MAP_FILE = '~/.local/share/unifideck/ubisoft_id_map.json'
+_DEFAULT_VISIBLE_GAMES_FILE = (
+    '~/.local/share/unifideck/ubisoft_visible_games.json'
+)
+_DEFAULT_PREFIXES_DIR = '~/.local/share/unifideck/prefixes/ubisoft'
+_DEFAULT_INSTALLER_CACHE_DIR = (
+    '~/.local/share/unifideck/ubisoft_installer_cache'
+)
+_DEFAULT_UPC_SESSION_FILE = (
+    '~/.local/share/unifideck/ubisoft_upc_session.txt'
+)
+_DEFAULT_GAME_ID_DB_FILE = (
+    '~/.local/share/unifideck/ubisoft_game_db.txt'
+)
+_DEFAULT_DEFAULT_INSTALL_BASE = '~/Games/Ubisoft'
+_DEFAULT_SDCARD_INSTALL_BASE = '/run/media/mmcblk0p1/Games/Ubisoft'
+_DEFAULT_INSTALLER_URL = (
+    'https://static3.cdn.ubi.com/orbit/launcher_installer/'
+    'UbisoftConnectInstaller.exe'
+)
+_DEFAULT_INSTALLER_FILENAME = 'UbisoftConnectInstaller.exe'
+_DEFAULT_GAME_ID_DB_URL = (
+    'https://raw.githubusercontent.com/iArtorias/ubisoft_game_ids/main/'
+    'UBI_GAMES.txt'
+)
+_DEFAULT_UPC_RELATIVE_PATH = (
+    'drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/upc.exe'
+)
+_DEFAULT_UPC_CONNECT_RELATIVE_PATH = (
+    'drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/'
+    'UbisoftConnect.exe'
+)
+_DEFAULT_CONFIGURATIONS_RELATIVE_PATH = (
+    'drive_c/users/steamuser/AppData/Local/Ubisoft Game Launcher/'
+    'cache/configuration/configurations'
+)
+_DEFAULT_OWNERSHIP_RELATIVE_PATH = (
+    'drive_c/users/steamuser/AppData/Local/Ubisoft Game Launcher/'
+    'cache/ownership'
+)
+_UBI_CONFIG_PREFIX = 'stores.ubisoft'
+
+
+@dataclass(frozen=True)
+class UbisoftConfig:
+    """Ubisoft config."""
+
+    _FIELD_SPECS: ClassVar[tuple]
+    data_dir: str = _DEFAULT_DATA_DIR
+    id_map_file: str = _DEFAULT_ID_MAP_FILE
+    visible_games_file: str = _DEFAULT_VISIBLE_GAMES_FILE
+    prefixes_dir: str = _DEFAULT_PREFIXES_DIR
+    installer_cache_dir: str = _DEFAULT_INSTALLER_CACHE_DIR
+    upc_session_file: str = _DEFAULT_UPC_SESSION_FILE
+    game_id_db_file: str = _DEFAULT_GAME_ID_DB_FILE
+    default_install_base: str = _DEFAULT_DEFAULT_INSTALL_BASE
+    sdcard_install_base: str = _DEFAULT_SDCARD_INSTALL_BASE
+    template_prefix_name: str = '.template'
+    auth_prefix_name: str = '.upc-auth'
+    auth_shortcut_store_id: str = 'ubisoft:upc-auth'
+    auth_shortcut_launch_wait_ms: int = 1500
+    installer_url: str = _DEFAULT_INSTALLER_URL
+    installer_filename: str = _DEFAULT_INSTALLER_FILENAME
+    bootstrap_marker: str = 'unifideck_ubisoft_bootstrap.marker'
+    game_id_db_url: str = _DEFAULT_GAME_ID_DB_URL
+    game_id_db_max_age_seconds: int = 7 * 24 * 3600
+    upc_relative_path: str = _DEFAULT_UPC_RELATIVE_PATH
+    upc_connect_relative_path: str = _DEFAULT_UPC_CONNECT_RELATIVE_PATH
+    configurations_relative_path: str = _DEFAULT_CONFIGURATIONS_RELATIVE_PATH
+    ownership_relative_path: str = _DEFAULT_OWNERSHIP_RELATIVE_PATH
+    upc_credential_files: tuple[str, ...] = (
+        'ConnectSecureStorage.dat', 'user.dat',
+    )
+    upc_local_subdir: str = os.path.join(
+        'AppData', 'Local', 'Ubisoft Game Launcher',
+    )
+    upc_auth_cache_artifacts: tuple[str, ...] = (
+        'settings.yaml',
+        os.path.join('cache', 'configuration'),
+        os.path.join('cache', 'settings'),
+        os.path.join('cache', 'ulcf'),
+        os.path.join('cache', 'http2', 'Default', 'Network'),
+        os.path.join('cache', 'http2', 'Default', 'Local Storage'),
+        os.path.join('cache', 'http2', 'Default', 'IndexedDB'),
+        os.path.join('cache', 'http2', 'Default', 'Preferences'),
+        os.path.join('cache', 'http2', 'Default', 'Session Storage'),
+        os.path.join('cache', 'ownership'),
+    )
+    wine_system_users: tuple[str, ...] = (
+        'Public', 'All Users', 'Default', 'Default User',
+    )
+    filter_steam_linked: bool = True
+    steam_library_cross_ref: bool = False
+
+    @property
+    def data_dir_expanded(self) -> str:
+        """Data dir expanded."""
+        return os.path.expanduser(self.data_dir)
+
+    @property
+    def id_map_file_expanded(self) -> str:
+        """Id map file expanded."""
+        return os.path.expanduser(self.id_map_file)
+
+    @property
+    def visible_games_file_expanded(self) -> str:
+        """Visible games file expanded."""
+        return os.path.expanduser(self.visible_games_file)
+
+    @property
+    def prefixes_dir_expanded(self) -> str:
+        """Prefixes dir expanded."""
+        return os.path.expanduser(self.prefixes_dir)
+
+    @property
+    def template_dir_expanded(self) -> str:
+        """Template dir expanded."""
+        return os.path.join(self.prefixes_dir_expanded, self.template_prefix_name)
+
+    @property
+    def auth_prefix_dir_expanded(self) -> str:
+        """Auth prefix dir expanded."""
+        return os.path.join(self.prefixes_dir_expanded, self.auth_prefix_name)
+
+    @property
+    def installer_cache_dir_expanded(self) -> str:
+        """Installer cache dir expanded."""
+        return os.path.expanduser(self.installer_cache_dir)
+
+    @property
+    def upc_session_file_expanded(self) -> str:
+        """Upc session file expanded."""
+        return os.path.expanduser(self.upc_session_file)
+
+    @property
+    def game_id_db_file_expanded(self) -> str:
+        """Game ID db file expanded."""
+        return os.path.expanduser(self.game_id_db_file)
+
+    @property
+    def default_install_base_expanded(self) -> str:
+        """Default install base expanded."""
+        return os.path.expanduser(self.default_install_base)
+
+    def iter_game_prefix_paths(self) -> list[str]:
+        """List of existing per-game prefixes (directories under prefixes_dir
+        that aren't the template or auth prefix).
+        """
+        root = self.prefixes_dir_expanded
+        if not os.path.isdir(root):
+            return []
+        skip = {self.template_prefix_name, self.auth_prefix_name}
+        out: list[str] = []
+        for entry in sorted(os.listdir(root)):
+            if entry in skip or entry.startswith('.'):
+                continue
+            full = os.path.join(root, entry)
+            if os.path.isdir(full):
+                out.append(full)
+        return out
+
+    @staticmethod
+    def _parse_str(
+        config: ConfigManager | None, key: str, default: str,
+    ) -> str:
+        """Parse str."""
+        value = get_cfg(config, key, default)
+        return str(value) if value is not None else default
+
+    @staticmethod
+    def _parse_int(
+        config: ConfigManager | None, key: str, default: int,
+    ) -> int:
+        """Parse int."""
+        value = get_cfg(config, key, default)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _parse_tuple(
+        config: ConfigManager | None,
+        key: str,
+        default: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        """Parse tuple."""
+        value = get_cfg(config, key, list(default))
+        if isinstance(value, (list, tuple)):
+            return tuple(str(v) for v in value)
+        return default
+
+    @staticmethod
+    def _parse_bool(
+        config: ConfigManager | None, key: str, default: bool,
+    ) -> bool:
+        """Parse bool."""
+        value = get_cfg(config, key, default)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in ('1', 'true', 'yes', 'on')
+        return default
+
+    @classmethod
+    def from_config_manager(
+        cls, config: ConfigManager | None,
+    ) -> UbisoftConfig:
+        """From config manager."""
+        kwargs: dict[str, Any] = {}
+        for field_name, key_suffix, parser, default in cls._FIELD_SPECS:
+            full_key = f'{_UBI_CONFIG_PREFIX}.{key_suffix}'
+            kwargs[field_name] = parser(config, full_key, default)
+        return cls(**kwargs)
+
+    def describe(self) -> str:
+        """Describe."""
+        return (
+            f'UbisoftConfig(prefixes_dir={self.prefixes_dir_expanded}, '
+            f'filter_steam_linked={self.filter_steam_linked}, '
+            f'steam_library_cross_ref={self.steam_library_cross_ref})'
+        )
+
+
+UbisoftConfig._FIELD_SPECS = (
+    ('data_dir', 'data_dir', UbisoftConfig._parse_str, _DEFAULT_DATA_DIR),
+    ('id_map_file', 'id_map_file', UbisoftConfig._parse_str, _DEFAULT_ID_MAP_FILE),
+    ('visible_games_file', 'visible_games_file', UbisoftConfig._parse_str,
+     _DEFAULT_VISIBLE_GAMES_FILE),
+    ('prefixes_dir', 'prefixes_dir', UbisoftConfig._parse_str, _DEFAULT_PREFIXES_DIR),
+    ('installer_cache_dir', 'installer_cache_dir', UbisoftConfig._parse_str,
+     _DEFAULT_INSTALLER_CACHE_DIR),
+    ('upc_session_file', 'upc_session_file', UbisoftConfig._parse_str,
+     _DEFAULT_UPC_SESSION_FILE),
+    ('game_id_db_file', 'game_id_db_file', UbisoftConfig._parse_str,
+     _DEFAULT_GAME_ID_DB_FILE),
+    ('default_install_base', 'default_install_base', UbisoftConfig._parse_str,
+     _DEFAULT_DEFAULT_INSTALL_BASE),
+    ('sdcard_install_base', 'sdcard_install_base', UbisoftConfig._parse_str,
+     _DEFAULT_SDCARD_INSTALL_BASE),
+    ('template_prefix_name', 'template_prefix_name', UbisoftConfig._parse_str,
+     '.template'),
+    ('auth_prefix_name', 'auth_prefix_name', UbisoftConfig._parse_str, '.upc-auth'),
+    ('auth_shortcut_store_id', 'auth_shortcut_store_id', UbisoftConfig._parse_str,
+     'ubisoft:upc-auth'),
+    ('auth_shortcut_launch_wait_ms', 'auth_shortcut_launch_wait_ms',
+     UbisoftConfig._parse_int, 1500),
+    ('installer_url', 'installer_url', UbisoftConfig._parse_str,
+     _DEFAULT_INSTALLER_URL),
+    ('installer_filename', 'installer_filename', UbisoftConfig._parse_str,
+     _DEFAULT_INSTALLER_FILENAME),
+    ('bootstrap_marker', 'bootstrap_marker', UbisoftConfig._parse_str,
+     'unifideck_ubisoft_bootstrap.marker'),
+    ('game_id_db_url', 'game_id_db_url', UbisoftConfig._parse_str,
+     _DEFAULT_GAME_ID_DB_URL),
+    ('game_id_db_max_age_seconds', 'game_id_db_max_age_seconds',
+     UbisoftConfig._parse_int, 7 * 24 * 3600),
+    ('upc_relative_path', 'upc_relative_path', UbisoftConfig._parse_str,
+     _DEFAULT_UPC_RELATIVE_PATH),
+    ('upc_connect_relative_path', 'upc_connect_relative_path',
+     UbisoftConfig._parse_str, _DEFAULT_UPC_CONNECT_RELATIVE_PATH),
+    ('configurations_relative_path', 'configurations_relative_path',
+     UbisoftConfig._parse_str, _DEFAULT_CONFIGURATIONS_RELATIVE_PATH),
+    ('ownership_relative_path', 'ownership_relative_path',
+     UbisoftConfig._parse_str, _DEFAULT_OWNERSHIP_RELATIVE_PATH),
+    ('upc_credential_files', 'upc_credential_files', UbisoftConfig._parse_tuple,
+     ('ConnectSecureStorage.dat', 'user.dat')),
+    ('wine_system_users', 'wine_system_users', UbisoftConfig._parse_tuple,
+     ('Public', 'All Users', 'Default', 'Default User')),
+    ('filter_steam_linked', 'filter_steam_linked', UbisoftConfig._parse_bool, True),
+    ('steam_library_cross_ref', 'steam_library_cross_ref',
+     UbisoftConfig._parse_bool, False),
+)

--- a/py_modules/unifideck/stores/ubisoft/id_map.py
+++ b/py_modules/unifideck/stores/ubisoft/id_map.py
@@ -1,5 +1,210 @@
-"""id_map.py — Ubisoft game ID map
+"""id_map.py — space_id ↔ install_id / launch_id cache.
+
 # OP-55g | py_modules/unifideck/stores/ubisoft/id_map.py | Depends: OP-04a
+
+Persistent JSON cache mapping UPC ``space_id`` UUIDs to the numeric
+``install_id`` / ``launch_id`` plus optional metadata (game name,
+ubisoftConnectGameId). Sources of truth for this map (registry, config
+binary, community DB) live in :mod:`.id_map_sources`.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+from .config import UbisoftConfig
+from .id_map_sources import (
+    _IdMapSources,
+    extract_game_id_from_registry as _extract_game_id_from_registry,
+)
+from .paths import UbisoftPrefixPaths
+
+logger = logging.getLogger(__name__)
+_STEAM_TITLE_PREFIXES_TO_SKIP = (
+    'Proton', 'Steam Linux Runtime', 'Steamworks',
+)
+
+
+class UbisoftIdMap:
+    """Ubisoft ID map."""
+
+    def __init__(
+        self, config: UbisoftConfig, paths: UbisoftPrefixPaths,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._cache: dict[str, dict[str, Any]] = {}
+        self._sources = _IdMapSources(self)
+        self._load()
+
+    def _load(self) -> None:
+        """Load."""
+        path = self._config.id_map_file_expanded
+        if not os.path.isfile(path):
+            return
+        try:
+            with open(path, encoding='utf-8') as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                self._cache = data
+                logger.info(
+                    '[Ubisoft] loaded id_map (%d entries)', len(data),
+                )
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning('[Ubisoft] failed to load id_map: %s', e)
+            self._cache = {}
+
+    def _save(self) -> None:
+        """Save."""
+        path = self._config.id_map_file_expanded
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = path + '.tmp'
+            with open(tmp, 'w', encoding='utf-8') as f:
+                json.dump(self._cache, f, indent=2)
+            os.replace(tmp, path)
+        except OSError as e:
+            logger.warning('[Ubisoft] failed to save id_map: %s', e)
+
+    def resolve_install_id(self, space_id: str) -> str | None:
+        """Resolve install ID."""
+        entry = self._cache.get(space_id, {})
+        if 'ubisoftconnect_game_id' in entry:
+            return entry.get('ubisoftconnect_game_id')
+        return entry.get('install_id')
+
+    def resolve_launch_id(self, space_id: str) -> str | None:
+        """Resolve launch ID."""
+        entry = self._cache.get(space_id, {})
+        if 'ubisoftconnect_game_id' in entry:
+            return entry.get('ubisoftconnect_game_id')
+        return entry.get('launch_id')
+
+    def update(
+        self, space_id: str, install_id: str, launch_id: str,
+    ) -> None:
+        """Update."""
+        existing = self._cache.get(space_id, {})
+        existing.update({
+            'install_id': install_id,
+            'launch_id': launch_id,
+        })
+        self._cache[space_id] = existing
+        self._save()
+
+    def update_bulk(self, mapping: dict[str, dict[str, Any]]) -> None:
+        """Update bulk."""
+        if not mapping:
+            return
+        for space_id, fields in mapping.items():
+            existing = self._cache.get(space_id, {})
+            existing.update(fields)
+            self._cache[space_id] = existing
+        self._save()
+
+    def merge_entry(
+        self, space_id: str, fields: dict[str, Any],
+    ) -> bool:
+        """Merge entry. Returns True when something changed."""
+        if not space_id or not fields:
+            return False
+        existing = self._cache.get(space_id, {})
+        changed = False
+        for key, value in fields.items():
+            if value in (None, ''):
+                continue
+            if existing.get(key) != value:
+                existing[key] = value
+                changed = True
+        if changed:
+            self._cache[space_id] = existing
+            self._save()
+        return changed
+
+    def get_entry(self, space_id: str) -> dict[str, Any]:
+        """Get entry."""
+        return dict(self._cache.get(space_id, {}))
+
+    def in_cache(self, space_id: str) -> bool:
+        """In cache."""
+        return space_id in self._cache
+
+    async def refresh_from_configurations(
+        self, space_id: str | None = None,
+    ) -> bool:
+        """Refresh from configurations."""
+        return await self._sources.refresh_from_configurations(space_id)
+
+    async def fetch_game_id_database(self) -> list[tuple[str, str]]:
+        """Fetch game ID database."""
+        return await self._sources.fetch_game_id_database()
+
+    async def lookup_game_id_by_name(self, game_name: str) -> str | None:
+        """Lookup game ID by name."""
+        return await self._sources.lookup_game_id_by_name(game_name)
+
+    @staticmethod
+    def extract_game_id_from_registry(prefix_path: str) -> str | None:
+        """Extract game ID from registry."""
+        return _extract_game_id_from_registry(prefix_path)
+
+    @staticmethod
+    def get_steam_library_titles() -> set[str]:
+        """Best-effort scrape of Steam's libraryfolders.vdf to give the
+        steam-filter cross-ref a list of installed Steam titles. Returns
+        an empty set when Steam isn't installed or the VDF can't be
+        parsed.
+        """
+        result: set[str] = set()
+        for steamapps in (
+            os.path.expanduser('~/.steam/steam/steamapps'),
+            os.path.expanduser('~/.local/share/Steam/steamapps'),
+        ):
+            if not os.path.isdir(steamapps):
+                continue
+            try:
+                manifests = [
+                    f for f in os.listdir(steamapps)
+                    if f.startswith('appmanifest_') and f.endswith('.acf')
+                ]
+            except OSError:
+                continue
+            for manifest in manifests:
+                try:
+                    with open(
+                        os.path.join(steamapps, manifest), encoding='utf-8', errors='replace',
+                    ) as f:
+                        for line in f:
+                            m = re.search(r'"name"\s+"([^"]+)"', line)
+                            if not m:
+                                continue
+                            name = m.group(1).strip()
+                            if not name:
+                                continue
+                            if any(
+                                name.startswith(prefix)
+                                for prefix in _STEAM_TITLE_PREFIXES_TO_SKIP
+                            ):
+                                break
+                            result.add(name)
+                            break
+                except OSError:
+                    continue
+        return result
+
+    @staticmethod
+    def _normalize_for_matching(name: str) -> str:
+        """Normalize for matching."""
+        if not name:
+            return ''
+        normalised = name.lower().replace('_', ' ')
+        normalised = re.sub(r"[®™©''\-:.,!?()\"']", '', normalised)
+        return ' '.join(normalised.split())
+
+    def normalize_for_matching(self, name: str) -> str:
+        """Normalize for matching."""
+        return self._normalize_for_matching(name)

--- a/py_modules/unifideck/stores/ubisoft/id_map_sources.py
+++ b/py_modules/unifideck/stores/ubisoft/id_map_sources.py
@@ -1,5 +1,207 @@
-"""id_map_sources.py — Ubisoft ID map sources
+"""id_map_sources.py — Sources that feed UbisoftIdMap.
+
 # OP-55h | py_modules/unifideck/stores/ubisoft/id_map_sources.py | Depends: (none)
+
+The id-map can be filled from three sources, in order of authority:
+
+1. The per-prefix Wine ``system.reg`` (and ``user.reg``) — produced by
+   UPC at install time, contains the canonical numeric InstallId.
+2. The UPC ``configurations`` cache (parsed by :mod:`.parser`).
+3. A community-maintained text database of (numeric_id, name) pairs.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import os
+import re
+import time
+import urllib.request
+from typing import TYPE_CHECKING, Any
+
+from ...core.net import ssl_ctx_permissive
+
+if TYPE_CHECKING:
+    from .id_map import UbisoftIdMap
+
+logger = logging.getLogger(__name__)
+
+_REGISTRY_INSTALLS_PATTERN = re.compile(
+    r'\[Software\\\\Wow6432Node\\\\Ubisoft\\\\Launcher\\\\Installs\\\\(\d+)\][^\[]*?'
+    r'"InstallDir"\s*=\s*"([^"]*)"',
+    re.DOTALL,
+)
+_USER_REG_INSTALLS_PATTERN = re.compile(
+    r'\[Software\\\\Ubisoft\\\\Launcher\\\\Installs\\\\(\d+)\]',
+)
+_STANDARD_INSTALL_PATH_MARKERS = (
+    'Ubisoft Game Launcher/games/',
+    'Ubisoft Game Launcher\\games\\',
+)
+
+
+def extract_game_id_from_registry(prefix_path: str) -> str | None:
+    """Extract game ID from registry."""
+    for reg_name in ('system.reg', os.path.join('pfx', 'system.reg')):
+        reg_path = os.path.join(prefix_path, reg_name)
+        content = read_reg_file(reg_path)
+        if not content:
+            continue
+        game_id = scan_system_reg_installs(content)
+        if game_id:
+            logger.info('[Ubisoft] game ID %s from %s', game_id, reg_name)
+            return game_id
+        sibling = extract_id_from_user_reg_sibling(reg_path)
+        if sibling:
+            return sibling
+    return None
+
+
+def read_reg_file(reg_path: str) -> str | None:
+    """Read reg file."""
+    if not os.path.isfile(reg_path):
+        return None
+    try:
+        with open(reg_path, encoding='utf-8', errors='replace') as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def scan_system_reg_installs(content: str) -> str | None:
+    """Scan system reg installs."""
+    for match in _REGISTRY_INSTALLS_PATTERN.finditer(content):
+        game_id = match.group(1)
+        install_dir = match.group(2).replace('\\\\', '/')
+        if any(m in install_dir for m in _STANDARD_INSTALL_PATH_MARKERS):
+            return game_id
+    return None
+
+
+def extract_id_from_user_reg_sibling(reg_path: str) -> str | None:
+    """Extract ID from user reg sibling."""
+    user_reg = reg_path.replace('system.reg', 'user.reg')
+    content = read_reg_file(user_reg)
+    if not content:
+        return None
+    match = _USER_REG_INSTALLS_PATTERN.search(content)
+    return match.group(1) if match else None
+
+
+class _IdMapSources:
+    """Id map sources."""
+
+    def __init__(self, idmap: UbisoftIdMap) -> None:
+        """Initialize the instance."""
+        self._idmap = idmap
+
+    async def refresh_from_configurations(
+        self, space_id: str | None = None,
+    ) -> bool:
+        """Refresh from configurations.
+
+        Walks every per-game prefix, parses the UPC ``configurations``
+        binary, and merges the discovered (install_id, launch_id)
+        pairs into the id-map. Returns True when at least one entry
+        was added or updated.
+        """
+        from .parser import build_id_map_from_configurations
+        config = self._idmap._config
+        paths = self._idmap._paths
+        updated = False
+        for prefix_dir in (
+            [paths.get_prefix_path(space_id)] if space_id
+            else config.iter_game_prefix_paths()
+        ):
+            cfg_path = paths.find_configurations(prefix_dir)
+            if not cfg_path:
+                continue
+            if await self._refresh_from_path(
+                cfg_path, build_id_map_from_configurations,
+                f'configurations:{prefix_dir}',
+            ):
+                updated = True
+        return updated
+
+    async def _refresh_from_path(
+        self, config_path: str, parser_fn: Any, label: str,
+    ) -> bool:
+        """Refresh from path."""
+        try:
+            mapping = await asyncio.to_thread(parser_fn, config_path)
+        except Exception as e:
+            logger.warning('[Ubisoft] parse %s failed: %s', label, e)
+            return False
+        if not mapping:
+            return False
+        self._idmap.update_bulk(mapping)
+        logger.info(
+            '[Ubisoft] merged %d entries from %s', len(mapping), label,
+        )
+        return True
+
+    async def fetch_game_id_database(self) -> list[tuple[str, str]]:
+        """Fetch game ID database."""
+        config = self._idmap._config
+        db_path = config.game_id_db_file_expanded
+        if os.path.isfile(db_path):
+            age = time.time() - os.path.getmtime(db_path)
+            if age < config.game_id_db_max_age_seconds:
+                return await asyncio.to_thread(
+                    self._parse_game_id_database, db_path,
+                )
+        try:
+            await asyncio.to_thread(
+                self._download_game_id_database,
+                config.game_id_db_url, db_path,
+            )
+        except Exception as e:
+            logger.warning('[Ubisoft] game ID DB download failed: %s', e)
+            if not os.path.isfile(db_path):
+                return []
+        return await asyncio.to_thread(
+            self._parse_game_id_database, db_path,
+        )
+
+    async def lookup_game_id_by_name(self, game_name: str) -> str | None:
+        """Lookup game ID by name."""
+        if not game_name:
+            return None
+        target = self._idmap.normalize_for_matching(game_name)
+        for game_id, candidate in await self.fetch_game_id_database():
+            if self._idmap.normalize_for_matching(candidate) == target:
+                return game_id
+        return None
+
+    @staticmethod
+    def _download_game_id_database(url: str, dest_path: str) -> None:
+        """Download game ID database."""
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        tmp = dest_path + '.tmp'
+        ctx = ssl_ctx_permissive('ubisoft community game-id db')
+        with urllib.request.urlopen(url, context=ctx, timeout=60) as resp:
+            with open(tmp, 'wb') as f:
+                while True:
+                    chunk = resp.read(64 * 1024)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+        os.replace(tmp, dest_path)
+        logger.info('[Ubisoft] game ID database downloaded to %s', dest_path)
+
+    @staticmethod
+    def _parse_game_id_database(filepath: str) -> list[tuple[str, str]]:
+        """Parse game ID database."""
+        entries: list[tuple[str, str]] = []
+        try:
+            with open(filepath, encoding='utf-8', errors='replace') as f:
+                for raw in f:
+                    line = raw.strip()
+                    if not line or line.startswith('#'):
+                        continue
+                    parts = line.split(', ', 1)
+                    if len(parts) == 2 and parts[0].isdigit():
+                        entries.append((parts[0], parts[1]))
+        except OSError as e:
+            logger.warning('[Ubisoft] game ID DB parse failed: %s', e)
+        return entries

--- a/py_modules/unifideck/stores/ubisoft/installer/__init__.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/__init__.py
@@ -1,2 +1,5 @@
 # OP-56 | stores/ubisoft/installer/__init__.py
-from __future__ import annotations
+from .cache import UbisoftInstallerCache
+from .installer import UbisoftInstaller
+
+__all__ = ['UbisoftInstaller', 'UbisoftInstallerCache']

--- a/py_modules/unifideck/stores/ubisoft/installer/cache.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/cache.py
@@ -1,5 +1,98 @@
-"""cache.py — Ubisoft install cache
+"""cache.py — Cache the Ubisoft Connect installer ``.exe``.
+
 # OP-56b | py_modules/unifideck/stores/ubisoft/installer/cache.py | Depends: OP-04a
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import os
+import urllib.request
+from typing import Any
+
+from ....core.net import ssl_ctx_strict
+from ..config import UbisoftConfig
+
+logger = logging.getLogger(__name__)
+_INSTALLER_MIN_SIZE_BYTES = 1000
+_PE_MAGIC = b'MZ'
+_INSTALLER_DOWNLOAD_TIMEOUT_S = 600.0
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+class UbisoftInstallerCache:
+    """Ubisoft installer cache."""
+
+    def __init__(self, config: UbisoftConfig) -> None:
+        """Initialize the instance."""
+        self._config = config
+
+    async def ensure_cached(self) -> str | None:
+        """Ensure cached."""
+        cache_dir = self._config.installer_cache_dir_expanded
+        os.makedirs(cache_dir, exist_ok=True)
+        cached_path = os.path.join(cache_dir, self._config.installer_filename)
+        if self._is_cached_valid(cached_path):
+            return cached_path
+        ok = await asyncio.to_thread(
+            self._download_sync, self._config.installer_url, cached_path,
+        )
+        return cached_path if ok else None
+
+    @staticmethod
+    def _is_cached_valid(cached_path: str) -> bool:
+        """Is cached valid."""
+        if not os.path.isfile(cached_path):
+            return False
+        try:
+            size = os.path.getsize(cached_path)
+        except OSError:
+            return False
+        if size < _INSTALLER_MIN_SIZE_BYTES:
+            return False
+        try:
+            with open(cached_path, 'rb') as f:
+                magic = f.read(2)
+        except OSError:
+            return False
+        return magic == _PE_MAGIC
+
+    @staticmethod
+    def _download_sync(url: str, dest_path: str) -> bool:
+        """Download sync."""
+        tmp = dest_path + '.tmp'
+        try:
+            ctx = ssl_ctx_strict()
+            with urllib.request.urlopen(
+                url, context=ctx, timeout=_INSTALLER_DOWNLOAD_TIMEOUT_S,
+            ) as resp:
+                _stream_to_file(resp, tmp)
+        except Exception as e:
+            logger.warning('[Ubisoft.cache] download failed: %s', e)
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            return False
+        try:
+            if os.path.getsize(tmp) < _INSTALLER_MIN_SIZE_BYTES:
+                os.unlink(tmp)
+                return False
+            os.replace(tmp, dest_path)
+        except OSError as e:
+            logger.warning('[Ubisoft.cache] rename failed: %s', e)
+            return False
+        return True
+
+
+def _stream_to_file(response: Any, path: str) -> int:
+    """Stream to file."""
+    written = 0
+    with open(path, 'wb') as f:
+        while True:
+            chunk = response.read(_DOWNLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            f.write(chunk)
+            written += len(chunk)
+    return written

--- a/py_modules/unifideck/stores/ubisoft/installer/installer.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/installer.py
@@ -1,5 +1,220 @@
-"""installer.py — Ubisoft installer
+"""installer.py — Public ``UbisoftInstaller`` surface.
+
 # OP-56a | py_modules/unifideck/stores/ubisoft/installer/installer.py | Depends: OP-55a
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+import subprocess
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from ....core.types import InstallResult, Result
+from ..binaries import UbisoftBinaryResolver
+from ..config import UbisoftConfig
+from ..id_map import UbisoftIdMap
+from ..library import UbisoftLibrary
+from ..paths import UbisoftPrefixPaths
+from ..session import UbisoftSession
+from . import registry as _reg
+from .launch_env import UpcLaunchEnvBuildError, _UpcLaunchEnv
+from .launcher import _LauncherInstall
+from .manual_ui import _ManualUiInstaller
+from .registry import _ShortcutRegistry
+from .uninstall import _UninstallPipeline
+from .update_op import _UpdateOperation
+
+logger = logging.getLogger(__name__)
+_UPDATE_TIMEOUT_S = 4 * 60 * 60
+
+
+class UbisoftInstaller:
+    """Ubisoft installer."""
+
+    def __init__(
+        self,
+        config: UbisoftConfig,
+        paths: UbisoftPrefixPaths,
+        binaries: UbisoftBinaryResolver,
+        id_map: UbisoftIdMap,
+        session: UbisoftSession,
+        library: UbisoftLibrary,
+        bootstrap_game_prefix: Callable[[str], Awaitable[bool]],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._binaries = binaries
+        self._id_map = id_map
+        self._session = session
+        self._library = library
+        self._bootstrap_game_prefix = bootstrap_game_prefix
+        self._active_install_pids: dict[str, int] = {}
+        self._shortcut_registry = _ShortcutRegistry(config)
+        self._launcher = _LauncherInstall(self)
+        self._manual_ui = _ManualUiInstaller(
+            config, library, id_map, session, self._active_install_pids,
+        )
+        self._uninstall = _UninstallPipeline(self)
+        self._update_op = _UpdateOperation(
+            id_map=id_map, paths=paths, session=session,
+            build_launch_env=self._build_upc_launch_env,
+        )
+
+    async def uninstall_game(
+        self, game_id: str, *, delete_prefix: bool = False,
+    ) -> Result:
+        """Uninstall game."""
+        return await self._uninstall.uninstall_game(
+            game_id, delete_prefix=delete_prefix,
+        )
+
+    async def open_launcher_for_install(self, game_id: str) -> Result:
+        """Open launcher for install."""
+        return await self._launcher.open_launcher_for_install(game_id)
+
+    def _build_upc_launch_env(
+        self,
+        game_id: str,
+        prefix_path: str,
+        *,
+        prefer_connect_exe: bool = False,
+        upc_missing_error: str = 'upc_exe_not_found',
+    ) -> _UpcLaunchEnv:
+        """Build UPC launch env."""
+        finder = (
+            self._paths.find_connect_exe if prefer_connect_exe
+            else self._paths.find_upc_exe
+        )
+        upc_path = finder(prefix_path)
+        if not upc_path:
+            upc_path = (
+                self._paths.find_upc_exe(prefix_path)
+                if prefer_connect_exe else None
+            )
+        if not upc_path:
+            raise UpcLaunchEnvBuildError(upc_missing_error)
+        umu_run = self._binaries.find_umu_run()
+        if not umu_run:
+            raise UpcLaunchEnvBuildError('umu_run_not_found')
+        python_bin = self._binaries.find_python()
+        proton_path = self._binaries.find_proton_path()
+        steam_window_env = self._build_steam_window_env(
+            f'ubisoft:{game_id}',
+        )
+        env = self._binaries.build_umu_env(
+            wineprefix=prefix_path,
+            gameid=f'umu-ubisoft-{game_id}',
+            proton_path=proton_path,
+            store_game_id=f'ubisoft:{game_id}',
+            steam_window_env=steam_window_env,
+        )
+        return _UpcLaunchEnv(
+            upc_path=upc_path, umu_run=umu_run,
+            python_bin=python_bin, env=env,
+        )
+
+    async def install_game(
+        self,
+        game_id: str,
+        *,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        install_path: str | None = None,
+    ) -> InstallResult:
+        """Install game."""
+        prefix_path = self._paths.get_prefix_path(game_id)
+        ok = await self._bootstrap_game_prefix(game_id)
+        if not ok:
+            return InstallResult(
+                success=False, store='ubisoft', game_id=game_id,
+                error='prefix_bootstrap_failed',
+            )
+        try:
+            launch = self._build_upc_launch_env(
+                game_id, prefix_path, prefer_connect_exe=True,
+            )
+        except UpcLaunchEnvBuildError as e:
+            return InstallResult(
+                success=False, store='ubisoft', game_id=game_id,
+                error=e.error_code,
+            )
+        info = self._library._detector._id_map.get_entry(game_id)
+        return await self._manual_ui.install_via_upc_ui(
+            game_id=game_id,
+            game_name=info.get('name'),
+            prefix_path=prefix_path,
+            upc_path=launch.upc_path,
+            umu_run=launch.umu_run,
+            python_bin=launch.python_bin,
+            env=launch.env,
+            progress_cb=progress_cb,
+            install_path=install_path,
+        )
+
+    def is_install_session_active(self, game_id: str) -> bool:
+        """Is install session active."""
+        return game_id in self._active_install_pids
+
+    async def cancel_install_session(self, game_id: str) -> Result:
+        """Cancel install session."""
+        pid = self._active_install_pids.pop(game_id, None)
+        if pid is None:
+            return Result(success=False, error='no_active_session')
+        try:
+            os.kill(pid, 15)
+        except ProcessLookupError:
+            return Result(success=True)
+        except OSError as e:
+            return Result(success=False, error=f'kill_failed:{e}')
+        return Result(success=True)
+
+    async def check_for_updates(self) -> list[str]:
+        """Check for updates."""
+        # UPC drives updates internally; we surface no proactive list.
+        return []
+
+    async def update_game(self, game_id: str) -> InstallResult:
+        """Update game."""
+        return await self._update_op.update(game_id)
+
+    def inject_install_registry(
+        self, prefix_path: str, install_id: str, install_dir: str,
+    ) -> None:
+        """Inject install registry."""
+        _reg.inject_install_registry(prefix_path, install_id, install_dir)
+
+    def kill_upc_processes(self) -> None:
+        """Kill UPC processes."""
+        try:
+            subprocess.run(
+                ['pkill', '-f', 'UbisoftConnect.exe'],
+                check=False, timeout=5,
+            )
+            subprocess.run(
+                ['pkill', '-f', 'upc.exe'],
+                check=False, timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            logger.debug('[Ubisoft.installer] kill_upc_processes: %s', e)
+
+    def _build_steam_window_env(
+        self, store_game_id: str | None,
+    ) -> dict[str, str]:
+        """Build steam window env."""
+        appid = self._shortcut_registry.resolve_shortcut_appid(store_game_id)
+        if not appid:
+            return {
+                'SteamGameId': '0',
+                'STEAM_COMPAT_APP_ID': '0',
+                'SteamAppId': '0',
+                'UMU_STEAM_GAME_ID': '0',
+            }
+        encoded = str((appid << 32) | 0x02000000)
+        appid_str = str(appid)
+        return {
+            'SteamGameId': appid_str,
+            'STEAM_COMPAT_APP_ID': appid_str,
+            'SteamAppId': appid_str,
+            'UMU_STEAM_GAME_ID': encoded,
+        }

--- a/py_modules/unifideck/stores/ubisoft/installer/launch_env.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/launch_env.py
@@ -1,5 +1,25 @@
-"""launch_env.py — Ubisoft launch environment
+"""launch_env.py — UPC launch environment dataclass + error type.
+
 # OP-56c | py_modules/unifideck/stores/ubisoft/installer/launch_env.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+from dataclasses import dataclass
+
+
+@dataclass
+class _UpcLaunchEnv:
+    """UPC launch env."""
+
+    upc_path: str
+    umu_run: str
+    python_bin: str
+    env: dict[str, str]
+
+
+class UpcLaunchEnvBuildError(Exception):
+    """Raised when the runtime can't be assembled to launch UPC."""
+
+    def __init__(self, error_code: str) -> None:
+        super().__init__(error_code)
+        self.error_code = error_code

--- a/py_modules/unifideck/stores/ubisoft/installer/launcher.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/launcher.py
@@ -1,5 +1,93 @@
-"""launcher.py — Ubisoft UPC launcher
+"""launcher.py — Spawn UPC for "open launcher to install" flow.
+
 # OP-56d | py_modules/unifideck/stores/ubisoft/installer/launcher.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from ....core.types import Result
+from .launch_env import UpcLaunchEnvBuildError
+
+if TYPE_CHECKING:
+    from .installer import UbisoftInstaller
+
+logger = logging.getLogger(__name__)
+
+
+class _LauncherInstall:
+    """Launcher install."""
+
+    def __init__(self, parent: UbisoftInstaller) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    async def open_launcher_for_install(self, game_id: str) -> Result:
+        """Open launcher for install."""
+        prefix_path = self._parent._paths.get_prefix_path(game_id)
+        try:
+            launch = self._parent._build_upc_launch_env(
+                game_id, prefix_path, prefer_connect_exe=True,
+            )
+        except UpcLaunchEnvBuildError as e:
+            return Result(success=False, error=e.error_code)
+        install_id = (
+            self._parent._id_map.resolve_install_id(game_id) or game_id
+        )
+        cmd = [
+            launch.umu_run, launch.upc_path,
+            f'uplay://install/{install_id}',
+        ]
+        return await self._spawn_and_monitor_upc(
+            cmd, launch.env, game_id, prefix_path,
+        )
+
+    async def _spawn_and_monitor_upc(
+        self,
+        cmd: list[str],
+        env: dict[str, str],
+        game_id: str,
+        prefix_path: str,
+    ) -> Result:
+        """Spawn and monitor UPC."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, env=env,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except OSError as e:
+            return Result(success=False, error=f'spawn_failed:{e}')
+        spawned_pid = proc.pid
+        loop = asyncio.get_running_loop()
+        loop.create_task(
+            self.monitor_after_exit(
+                game_id, spawned_pid, proc, prefix_path,
+            ),
+            name=f'ubisoft_upc_monitor:{game_id}',
+        )
+        return Result(success=True, data={'pid': spawned_pid})
+
+    async def monitor_after_exit(
+        self, game_id: str, spawned_pid: int,
+        proc: asyncio.subprocess.Process, prefix_path: str,
+    ) -> None:
+        """Monitor after exit."""
+        try:
+            await proc.wait()
+        except (OSError, asyncio.CancelledError):
+            return
+        try:
+            self._parent._library._detector.get_installed_game_info(game_id)
+        except Exception as e:
+            logger.debug(
+                '[Ubisoft.launcher] post-exit detection: %s', e,
+            )
+        try:
+            self._parent._session.capture(prefix_path)
+        except Exception as e:
+            logger.debug(
+                '[Ubisoft.launcher] post-exit session capture: %s', e,
+            )

--- a/py_modules/unifideck/stores/ubisoft/installer/manual_ui.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/manual_ui.py
@@ -1,5 +1,287 @@
-"""manual_ui.py — Ubisoft manual install UI
+"""manual_ui.py — Drive UPC's GUI installer and detect completion.
+
 # OP-56e | py_modules/unifideck/stores/ubisoft/installer/manual_ui.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from ....core.types import InstallResult
+from ..config import UbisoftConfig
+from ..id_map import UbisoftIdMap
+from ..library import UbisoftLibrary
+from ..library.detection_helpers import looks_like_game_install
+from ..session import UbisoftSession
+from . import registry as _reg
+
+logger = logging.getLogger(__name__)
+_MANUAL_INSTALL_TIMEOUT_S = 2 * 60 * 60
+_MANUAL_INSTALL_POLL_INTERVAL_S = 10.0
+_STABILITY_WAIT_MAX_POLLS = 360
+_STABILITY_POLL_INTERVAL_S = 10.0
+_STABILITY_STABLE_THRESHOLD = 3
+
+
+class _ManualUiInstaller:
+    """Manual UI installer."""
+
+    def __init__(
+        self,
+        config: UbisoftConfig,
+        library: UbisoftLibrary,
+        id_map: UbisoftIdMap,
+        session: UbisoftSession,
+        active_install_pids: dict[str, int],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._library = library
+        self._id_map = id_map
+        self._session = session
+        self._active_install_pids = active_install_pids
+
+    async def install_via_upc_ui(
+        self,
+        *,
+        game_id: str,
+        game_name: str | None,
+        prefix_path: str,
+        upc_path: str,
+        umu_run: str,
+        python_bin: str,
+        env: dict[str, str],
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        install_path: str | None = None,
+    ) -> InstallResult:
+        """Install via UPC UI."""
+        if install_path is None:
+            install_path = self._config.default_install_base_expanded
+        os.makedirs(install_path, exist_ok=True)
+        install_base, dirs_before, upc_dirs_before = self._snapshot_pre_install(
+            install_path, prefix_path,
+        )
+        self._capture_and_propagate_session(prefix_path)
+        proc = await self._notify_and_spawn_upc(
+            game_id=game_id, upc_path=upc_path, umu_run=umu_run,
+            python_bin=python_bin, env=env, progress_cb=progress_cb,
+        )
+        self._active_install_pids[game_id] = proc.pid
+        try:
+            install_dir = await self._poll_for_new_install(
+                proc=proc,
+                install_base=install_base,
+                dirs_before=dirs_before,
+                upc_dirs_before=upc_dirs_before,
+                progress_cb=progress_cb,
+            )
+            if install_dir is None:
+                return InstallResult(
+                    success=False, store='ubisoft', game_id=game_id,
+                    error='install_dir_not_detected',
+                )
+            return await self._finalize_manual_install(
+                game_id=game_id, game_name=game_name, install_dir=install_dir,
+            )
+        finally:
+            self._active_install_pids.pop(game_id, None)
+            await self._terminate_upc_gracefully(proc)
+
+    async def _notify_and_spawn_upc(
+        self,
+        *,
+        game_id: str,
+        upc_path: str,
+        umu_run: str,
+        python_bin: str,
+        env: dict[str, str],
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> asyncio.subprocess.Process:
+        """Notify and spawn UPC."""
+        if progress_cb is not None:
+            await progress_cb({
+                'phase': 'spawn', 'game_id': game_id,
+                'message': 'Launching Ubisoft Connect installer',
+            })
+        install_id = self._id_map.resolve_install_id(game_id) or game_id
+        cmd = [
+            umu_run, upc_path, f'uplay://install/{install_id}',
+        ]
+        return await asyncio.create_subprocess_exec(
+            *cmd, env=env,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+    def _snapshot_pre_install(
+        self, install_path: str | None, prefix_path: str,
+    ) -> tuple[str, set[str], dict[str, set[str]]]:
+        """Snapshot pre install."""
+        base, dirs = self._snapshot_install_base(install_path)
+        upc_dirs = self._snapshot_upc_game_dirs(prefix_path)
+        return base, dirs, upc_dirs
+
+    def _capture_and_propagate_session(self, prefix_path: str) -> None:
+        """Capture and propagate session."""
+        try:
+            self._session.capture(prefix_path)
+            self._session.propagate_all_to_all()
+        except Exception as e:
+            logger.debug('[Ubisoft.manual] session propagate: %s', e)
+
+    def _snapshot_install_base(
+        self, install_path: str | None,
+    ) -> tuple[str, set]:
+        """Snapshot install base."""
+        if not install_path or not os.path.isdir(install_path):
+            return install_path or '', set()
+        try:
+            return install_path, set(os.listdir(install_path))
+        except OSError:
+            return install_path, set()
+
+    @staticmethod
+    async def _terminate_upc_gracefully(
+        proc: asyncio.subprocess.Process, timeout: float = 15.0,
+    ) -> None:
+        """Terminate UPC gracefully."""
+        if proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=timeout)
+        except TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+
+    async def _finalize_manual_install(
+        self, *, game_id: str, game_name: str | None, install_dir: str,
+    ) -> InstallResult:
+        """Finalize manual install."""
+        executable = self._library.find_game_executable(install_dir) or ''
+        await self._library.write_install_marker(
+            game_id, install_dir, executable, game_name or '',
+        )
+        install_id = self._id_map.resolve_install_id(game_id)
+        if install_id:
+            try:
+                _reg.inject_install_registry(
+                    prefix_path=self._config.prefixes_dir_expanded,
+                    install_id=install_id, install_dir=install_dir,
+                )
+            except Exception as e:
+                logger.debug('[Ubisoft.manual] reg inject: %s', e)
+        return InstallResult(
+            success=True, store='ubisoft', game_id=game_id,
+            install_path=install_dir,
+        )
+
+    @staticmethod
+    def _snapshot_upc_game_dirs(prefix_path: str) -> dict[str, set]:
+        """Snapshot UPC game dirs."""
+        roots = (
+            os.path.join(
+                prefix_path, 'drive_c', 'Program Files (x86)',
+                'Ubisoft', 'Ubisoft Game Launcher', 'games',
+            ),
+            os.path.join(
+                prefix_path, 'pfx', 'drive_c', 'Program Files (x86)',
+                'Ubisoft', 'Ubisoft Game Launcher', 'games',
+            ),
+        )
+        out: dict[str, set] = {}
+        for root in roots:
+            if os.path.isdir(root):
+                try:
+                    out[root] = set(os.listdir(root))
+                except OSError:
+                    out[root] = set()
+        return out
+
+    async def _poll_for_new_install(
+        self,
+        *,
+        proc: asyncio.subprocess.Process,
+        install_base: str,
+        dirs_before: set,
+        upc_dirs_before: dict[str, set],
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> str | None:
+        """Poll for new install."""
+        deadline = _MANUAL_INSTALL_TIMEOUT_S
+        elapsed = 0.0
+        while elapsed < deadline:
+            for base, before in (
+                (install_base, dirs_before),
+                *upc_dirs_before.items(),
+            ):
+                new_dir = self._check_new_dirs(base, before)
+                if new_dir and looks_like_game_install(new_dir):
+                    await self._notify_install_detected(new_dir, progress_cb)
+                    await self._wait_for_install_completion(new_dir, progress_cb)
+                    return new_dir
+            if proc.returncode is not None:
+                return None
+            await asyncio.sleep(_MANUAL_INSTALL_POLL_INTERVAL_S)
+            elapsed += _MANUAL_INSTALL_POLL_INTERVAL_S
+        return None
+
+    @staticmethod
+    async def _notify_install_detected(
+        install_dir: str,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> None:
+        """Notify install detected."""
+        if progress_cb is None:
+            return
+        await progress_cb({
+            'phase': 'detected', 'install_dir': install_dir,
+            'message': 'Install detected; waiting for completion',
+        })
+
+    def _check_new_dirs(self, base: str, before: set) -> str | None:
+        """Check new dirs."""
+        if not base or not os.path.isdir(base):
+            return None
+        try:
+            current = set(os.listdir(base))
+        except OSError:
+            return None
+        new = current - before
+        for entry in sorted(new):
+            full = os.path.join(base, entry)
+            if os.path.isdir(full):
+                return full
+        return None
+
+    async def _wait_for_install_completion(
+        self,
+        install_dir: str,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> None:
+        """Wait for install completion."""
+        last_size = -1
+        stable_count = 0
+        for _ in range(_STABILITY_WAIT_MAX_POLLS):
+            size = _reg.get_directory_size(install_dir)
+            if size == last_size:
+                stable_count += 1
+                if stable_count >= _STABILITY_STABLE_THRESHOLD:
+                    return
+            else:
+                stable_count = 0
+                last_size = size
+                if progress_cb is not None:
+                    await progress_cb({
+                        'phase': 'progress', 'install_dir': install_dir,
+                        'bytes_written': size,
+                    })
+            await asyncio.sleep(_STABILITY_POLL_INTERVAL_S)

--- a/py_modules/unifideck/stores/ubisoft/installer/registry.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/registry.py
@@ -1,5 +1,188 @@
-"""registry.py — Ubisoft Wine registry ops
+"""registry.py — Wine registry surgery for installs / shortcuts.
+
 # OP-56f | py_modules/unifideck/stores/ubisoft/installer/registry.py | Depends: (none)
+
+Two unrelated concerns share this module per the OP-56f spec:
+
+1. Module-level functions that read & rewrite the per-prefix
+   ``system.reg`` to inject or remove install entries.
+2. ``_ShortcutRegistry`` — a thin reader of unifideck's shortcut
+   registry json used by the launcher's gamescope-window glue.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import json
+import logging
+import os
+from typing import Any
+
+from ..config import UbisoftConfig
+
+logger = logging.getLogger(__name__)
+_INSTALLS_REG_SECTION_FMT = (
+    '[Software\\\\WOW6432Node\\\\Ubisoft\\\\Launcher\\\\Installs\\\\{install_id}]'
+)
+_STEAM_COMPAT_ENV_VARS = ('SteamAppId', 'SteamGameId', 'STEAM_COMPAT_APP_ID')
+
+
+def resolve_active_prefix_dir(prefix_path: str) -> str | None:
+    """Resolve active prefix dir."""
+    for candidate in (
+        os.path.join(prefix_path, 'pfx'),
+        prefix_path,
+    ):
+        if os.path.isfile(os.path.join(candidate, 'system.reg')):
+            return candidate
+    return None
+
+
+def read_system_reg(active_prefix: str) -> tuple[str, str] | None:
+    """Read system reg."""
+    reg_path = os.path.join(active_prefix, 'system.reg')
+    try:
+        with open(reg_path, encoding='utf-8', errors='replace') as f:
+            return f.read(), reg_path
+    except OSError as e:
+        logger.debug('[Ubisoft.registry] reg read: %s', e)
+        return None
+
+
+def find_install_registry_section_bounds(
+    content: str, section: str,
+) -> tuple[int, int] | None:
+    """Find install registry section bounds."""
+    start = content.find(section)
+    if start < 0:
+        return None
+    nxt = content.find('\n[', start + len(section))
+    end = nxt if nxt >= 0 else len(content)
+    return start, end
+
+
+def _update_or_append_install_section(
+    content: str, section: str, values: list[str],
+) -> str:
+    """Update or append install section."""
+    bounds = find_install_registry_section_bounds(content, section)
+    body = section + '\n' + '\n'.join(values) + '\n'
+    if bounds is None:
+        sep = '\n' if content and not content.endswith('\n') else ''
+        return content + sep + body
+    start, end = bounds
+    return content[:start] + body + content[end:]
+
+
+def inject_install_registry(
+    prefix_path: str, install_id: str, install_dir: str,
+) -> None:
+    """Inject install registry."""
+    active = resolve_active_prefix_dir(prefix_path)
+    if active is None:
+        return
+    pair = read_system_reg(active)
+    if pair is None:
+        return
+    content, reg_path = pair
+    section = _INSTALLS_REG_SECTION_FMT.format(install_id=install_id)
+    install_dir_wine = 'Z:' + install_dir.replace('/', '\\\\')
+    values = [f'"InstallDir"="{install_dir_wine}"']
+    new_content = _update_or_append_install_section(content, section, values)
+    if new_content == content:
+        return
+    try:
+        with open(reg_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+    except OSError as e:
+        logger.warning('[Ubisoft.registry] reg write: %s', e)
+
+
+def clean_install_registry(prefix_path: str, install_id: str) -> None:
+    """Clean install registry."""
+    active = resolve_active_prefix_dir(prefix_path)
+    if active is None:
+        return
+    pair = read_system_reg(active)
+    if pair is None:
+        return
+    content, reg_path = pair
+    section = _INSTALLS_REG_SECTION_FMT.format(install_id=install_id)
+    bounds = find_install_registry_section_bounds(content, section)
+    if bounds is None:
+        return
+    start, end = bounds
+    new_content = content[:start] + content[end:]
+    try:
+        with open(reg_path, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+    except OSError as e:
+        logger.warning('[Ubisoft.registry] reg write: %s', e)
+
+
+def get_directory_size(path: str) -> int:
+    """Get directory size."""
+    if not os.path.isdir(path):
+        return 0
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for f in files:
+            try:
+                total += os.path.getsize(os.path.join(root, f))
+            except OSError:
+                continue
+    return total
+
+
+def parse_positive_int(value: Any) -> int | None:
+    """Parse positive int."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+class _ShortcutRegistry:
+    """Shortcut registry."""
+
+    def __init__(self, config: UbisoftConfig) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._registry_path = os.path.join(
+            config.data_dir_expanded, 'shortcuts_registry.json',
+        )
+
+    def load(self) -> dict[str, Any]:
+        """Load."""
+        if not os.path.isfile(self._registry_path):
+            return {}
+        try:
+            with open(self._registry_path, encoding='utf-8') as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def scan_for_ubisoft_appid(self, registry: dict[str, Any]) -> int | None:
+        """Scan for UBISOFT appid."""
+        for key, entry in registry.items():
+            if not isinstance(key, str) or not key.startswith('ubisoft:'):
+                continue
+            if not isinstance(entry, dict):
+                continue
+            appid = parse_positive_int(entry.get('appid_unsigned'))
+            if appid:
+                return appid
+        return None
+
+    def resolve_shortcut_appid(
+        self, store_game_id: str | None,
+    ) -> int | None:
+        """Resolve shortcut appid."""
+        registry = self.load()
+        if store_game_id:
+            entry = registry.get(store_game_id)
+            if isinstance(entry, dict):
+                appid = parse_positive_int(entry.get('appid_unsigned'))
+                if appid:
+                    return appid
+        return self.scan_for_ubisoft_appid(registry)

--- a/py_modules/unifideck/stores/ubisoft/installer/uninstall.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/uninstall.py
@@ -1,5 +1,217 @@
-"""uninstall.py — Ubisoft uninstaller
+"""uninstall.py — Multi-step uninstall pipeline.
+
 # OP-56g | py_modules/unifideck/stores/ubisoft/installer/uninstall.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ....core.types import Result
+from . import registry as _reg
+from .launch_env import UpcLaunchEnvBuildError
+
+if TYPE_CHECKING:
+    from .installer import UbisoftInstaller
+
+logger = logging.getLogger(__name__)
+_PROTOCOL_UNINSTALL_TIMEOUT_S = 60.0
+_DELETE_MIN_PATH_DEPTH = 4
+
+
+class _UninstallPipeline:
+    """Uninstall pipeline."""
+
+    def __init__(self, parent: UbisoftInstaller) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    async def uninstall_game(
+        self, game_id: str, *, delete_prefix: bool = False,
+    ) -> Result:
+        """Uninstall game."""
+        prefix_path, install_path, install_id = (
+            self.resolve_uninstall_targets(game_id)
+        )
+        protocol_done = False
+        if install_id:
+            protocol_done = await self.attempt_protocol_uninstall(
+                game_id, prefix_path, install_id, delete_prefix,
+            )
+        install_path = self.refresh_install_path(
+            game_id, prefix_path, install_path,
+        )
+        deleted_dir = await self.delete_game_directory(
+            install_path, prefix_path, delete_prefix,
+        )
+        prefix_deleted, _err = await self.delete_prefix_if_requested(
+            prefix_path, delete_prefix,
+        )
+        self.post_uninstall_cleanup(
+            game_id, prefix_path, install_id, prefix_deleted,
+        )
+        return Result(
+            success=True,
+            data={
+                'protocol_uninstall': protocol_done,
+                'deleted_directory': deleted_dir,
+                'prefix_deleted': prefix_deleted,
+            },
+        )
+
+    def resolve_uninstall_targets(
+        self, game_id: str,
+    ) -> tuple[str, str | None, str | None]:
+        """Resolve uninstall targets."""
+        prefix_path = self._parent._paths.get_prefix_path(game_id)
+        info = self._parent._library.get_installed_game_info(game_id) or {}
+        install_path = info.get('install_path')
+        install_id = (
+            self._parent._id_map.get_entry(game_id).get('install_id')
+            or info.get('install_id')
+        )
+        return prefix_path, install_path, install_id
+
+    async def attempt_protocol_uninstall(
+        self, game_id: str, prefix_path: str,
+        install_id: str | None, delete_prefix: bool,
+    ) -> bool:
+        """Attempt protocol uninstall."""
+        if not install_id:
+            return False
+        try:
+            return await self.try_protocol_uninstall(
+                game_id, prefix_path, install_id,
+            )
+        except UpcLaunchEnvBuildError as e:
+            logger.warning(
+                '[Ubisoft.uninstall] protocol uninstall env error: %s',
+                e.error_code,
+            )
+            return False
+        except Exception as e:
+            logger.warning(
+                '[Ubisoft.uninstall] protocol uninstall failed: %s', e,
+            )
+            return False
+
+    def refresh_install_path(
+        self, game_id: str, prefix_path: str, install_path: str | None,
+    ) -> str | None:
+        """Refresh install path."""
+        if install_path and Path(install_path).is_dir():
+            return install_path
+        info = self._parent._library.get_installed_game_info(game_id)
+        return (info or {}).get('install_path') or install_path
+
+    async def delete_game_directory(
+        self, install_path: str | None, prefix_path: str, delete_prefix: bool,
+    ) -> str | None:
+        """Delete game directory."""
+        if not install_path:
+            return None
+        if not Path(install_path).is_dir():
+            return None
+        if not self._is_path_safe_to_delete(install_path, 'install_path'):
+            return None
+        if not delete_prefix:
+            inside_prefix = Path(install_path).is_relative_to(prefix_path)
+            if not inside_prefix:
+                logger.info(
+                    '[Ubisoft.uninstall] skip external dir %s', install_path,
+                )
+                return None
+        ok = await self.delete_tree_with_retries(install_path, 'install_dir')
+        return install_path if ok else None
+
+    async def delete_prefix_if_requested(
+        self, prefix_path: str, delete_prefix: bool,
+    ) -> tuple[bool, str | None]:
+        """Delete prefix if requested."""
+        if not delete_prefix:
+            return False, None
+        if not Path(prefix_path).is_dir():
+            return False, None
+        if not self._is_path_safe_to_delete(prefix_path, 'prefix'):
+            return False, 'unsafe'
+        ok = await self.delete_tree_with_retries(prefix_path, 'prefix')
+        return ok, None if ok else 'failed'
+
+    def post_uninstall_cleanup(
+        self, game_id: str, prefix_path: str,
+        install_id: str | None, prefix_deleted: bool,
+    ) -> None:
+        """Post uninstall cleanup."""
+        if not prefix_deleted and install_id:
+            try:
+                _reg.clean_install_registry(prefix_path, install_id)
+            except Exception as e:
+                logger.debug('[Ubisoft.uninstall] reg clean: %s', e)
+
+    async def try_protocol_uninstall(
+        self, game_id: str, prefix_path: str, install_id: str,
+    ) -> bool:
+        """Try protocol uninstall."""
+        env_b = self._parent._build_upc_launch_env(
+            game_id, prefix_path, prefer_connect_exe=True,
+        )
+        cmd = [
+            env_b.umu_run, env_b.upc_path,
+            f'uplay://uninstall/{install_id}',
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, env=env_b.env,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(
+                proc.wait(), timeout=_PROTOCOL_UNINSTALL_TIMEOUT_S,
+            )
+        except (TimeoutError, OSError):
+            return False
+        return True
+
+    @staticmethod
+    def _is_path_safe_to_delete(target_path: str, label: str) -> bool:
+        """Is path safe to delete."""
+        try:
+            real = Path(target_path).resolve()
+        except OSError:
+            return False
+        depth = len(real.parts)
+        if depth < _DELETE_MIN_PATH_DEPTH:
+            logger.warning(
+                '[Ubisoft.uninstall] refusing %s with depth %d: %s',
+                label, depth, real,
+            )
+            return False
+        return True
+
+    @staticmethod
+    async def delete_tree_with_retries(
+        target_path: str, label: str, *, retries: int = 3,
+    ) -> bool:
+        """Delete tree with retries."""
+        for attempt in range(1, retries + 1):
+            try:
+                await asyncio.to_thread(
+                    shutil.rmtree, target_path, ignore_errors=False,
+                )
+                return True
+            except OSError as e:
+                logger.warning(
+                    '[Ubisoft.uninstall] delete %s attempt %d: %s',
+                    label, attempt, e,
+                )
+                await asyncio.sleep(1.0)
+        try:
+            await asyncio.to_thread(
+                shutil.rmtree, target_path, ignore_errors=True,
+            )
+            return not Path(target_path).exists()
+        except OSError:
+            return False

--- a/py_modules/unifideck/stores/ubisoft/installer/update_op.py
+++ b/py_modules/unifideck/stores/ubisoft/installer/update_op.py
@@ -1,5 +1,98 @@
-"""update_op.py — Ubisoft update operation
+"""update_op.py — Run UPC's per-game update.
+
 # OP-56h | py_modules/unifideck/stores/ubisoft/installer/update_op.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from ....core.types import InstallResult
+from .launch_env import UpcLaunchEnvBuildError, _UpcLaunchEnv
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..id_map import UbisoftIdMap
+    from ..paths import UbisoftPrefixPaths
+    from ..session import UbisoftSession
+
+_UPDATE_TIMEOUT_S = 4 * 60 * 60
+logger = logging.getLogger(__name__)
+
+
+class _UpdateOperation:
+    """Update operation."""
+
+    def __init__(
+        self, *,
+        id_map: UbisoftIdMap,
+        paths: UbisoftPrefixPaths,
+        session: UbisoftSession,
+        build_launch_env: Callable[..., _UpcLaunchEnv],
+    ) -> None:
+        """Initialize the instance."""
+        self._id_map = id_map
+        self._paths = paths
+        self._session = session
+        self._build_launch_env = build_launch_env
+
+    async def update(self, game_id: str) -> InstallResult:
+        """Update."""
+        prepared = self._prepare_launch(game_id)
+        if isinstance(prepared, InstallResult):
+            return prepared
+        return await self._run_update_process(game_id, prepared)
+
+    def _prepare_launch(
+        self, game_id: str,
+    ) -> _UpcLaunchEnv | InstallResult:
+        """Prepare launch."""
+        prefix_path = self._paths.get_prefix_path(game_id)
+        try:
+            return self._build_launch_env(
+                game_id, prefix_path, prefer_connect_exe=True,
+            )
+        except UpcLaunchEnvBuildError as e:
+            return InstallResult(
+                success=False, store='ubisoft', game_id=game_id,
+                error=e.error_code,
+            )
+
+    async def _run_update_process(
+        self, game_id: str, launch_env: _UpcLaunchEnv,
+    ) -> InstallResult:
+        """Run update process."""
+        install_id = self._id_map.resolve_install_id(game_id) or game_id
+        cmd = [
+            launch_env.umu_run, launch_env.upc_path,
+            f'uplay://launch/{install_id}',
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, env=launch_env.env,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(proc.wait(), timeout=_UPDATE_TIMEOUT_S)
+        except TimeoutError:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+            return InstallResult(
+                success=False, store='ubisoft', game_id=game_id,
+                error='update_timeout',
+            )
+        except OSError as e:
+            return InstallResult(
+                success=False, store='ubisoft', game_id=game_id,
+                error=f'spawn_failed:{e}',
+            )
+        if proc.returncode != 0:
+            return InstallResult(
+                success=False, store='ubisoft', game_id=game_id,
+                error=f'rc:{proc.returncode}',
+            )
+        return InstallResult(success=True, store='ubisoft', game_id=game_id)

--- a/py_modules/unifideck/stores/ubisoft/library/__init__.py
+++ b/py_modules/unifideck/stores/ubisoft/library/__init__.py
@@ -1,2 +1,4 @@
 # OP-57 | stores/ubisoft/library/__init__.py
-from __future__ import annotations
+from .facade import UbisoftLibrary
+
+__all__ = ['UbisoftLibrary']

--- a/py_modules/unifideck/stores/ubisoft/library/data_loader.py
+++ b/py_modules/unifideck/stores/ubisoft/library/data_loader.py
@@ -1,5 +1,93 @@
-"""data_loader.py — Library data loader
+"""data_loader.py — Resolve and load the configurations / ownership files.
+
 # OP-57c | py_modules/unifideck/stores/ubisoft/library/data_loader.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..config import UbisoftConfig
+    from ..parser import GameConfig
+    from ..paths import UbisoftPrefixPaths
+    ParseConfigurationsFn = Callable[[str], list[GameConfig]]
+    ParseOwnershipFn = Callable[[str], list[int]]
+
+logger = logging.getLogger(__name__)
+
+
+class _DataLoader:
+    """Data loader."""
+
+    def __init__(
+        self, *, config: UbisoftConfig, paths: UbisoftPrefixPaths,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+
+    async def load_configurations(
+        self, parse_configurations: ParseConfigurationsFn,
+    ) -> list[GameConfig] | None:
+        """Load configurations."""
+        cfg_path = self._find_library_configurations_path()
+        if cfg_path is None:
+            return None
+        try:
+            return await asyncio.to_thread(parse_configurations, cfg_path)
+        except Exception as e:
+            logger.warning(
+                '[Ubisoft.library] configurations parse failed: %s', e,
+            )
+            return None
+
+    async def load_ownership_set(
+        self, parse_ownership: ParseOwnershipFn,
+    ) -> set[int] | None:
+        """Load ownership set."""
+        ownership_path, _label = self._discover_ownership_file()
+        if not ownership_path:
+            return None
+        try:
+            owned = await asyncio.to_thread(parse_ownership, ownership_path)
+        except Exception as e:
+            logger.warning('[Ubisoft.library] ownership parse failed: %s', e)
+            return None
+        return set(owned) if owned else set()
+
+    def _find_library_configurations_path(self) -> str | None:
+        """Find library configurations path."""
+        for prefix in self._config.iter_game_prefix_paths():
+            cfg = self._paths.find_configurations(prefix)
+            if cfg:
+                return cfg
+        auth = self._config.auth_prefix_dir_expanded
+        if auth and os.path.isdir(auth):
+            cfg = self._paths.find_configurations(auth)
+            if cfg:
+                return cfg
+        return None
+
+    def _discover_ownership_file(self) -> tuple[str | None, str]:
+        """Discover ownership file."""
+        relative = self._config.ownership_relative_path
+        for prefix in self._config.iter_game_prefix_paths():
+            cache_dir = Path(prefix) / relative
+            cache_dir_pfx = Path(prefix) / 'pfx' / relative
+            for candidate_dir in (cache_dir, cache_dir_pfx):
+                if not candidate_dir.is_dir():
+                    continue
+                files = sorted(
+                    candidate_dir.iterdir(), key=lambda p: p.stat().st_mtime,
+                    reverse=True,
+                )
+                for entry in files:
+                    if entry.is_file() and entry.stat().st_size > 0:
+                        return str(entry), str(prefix)
+        return None, ''

--- a/py_modules/unifideck/stores/ubisoft/library/detection.py
+++ b/py_modules/unifideck/stores/ubisoft/library/detection.py
@@ -1,5 +1,133 @@
-"""detection.py — Install detection
+"""detection.py — Public ``_InstallDetector`` surface for the library.
+
 # OP-57f | py_modules/unifideck/stores/ubisoft/library/detection.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from typing import Any
+
+from ..config import UbisoftConfig
+from ..id_map import UbisoftIdMap
+from .detection_cascade import _DetectionCascade
+from .detection_helpers import (
+    find_game_executable as _find_game_executable_impl,
+    in_prefix_game_roots,
+    load_json_file_safe as _load_json_file_safe_impl,
+    write_install_marker as _write_install_marker_impl,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _InstallDetector:
+    """Install detector."""
+
+    def __init__(
+        self, config: UbisoftConfig, id_map: UbisoftIdMap,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._id_map = id_map
+        self._cascade = _DetectionCascade(self)
+
+    @staticmethod
+    def find_game_executable(install_path: str) -> str | None:
+        """Find game executable."""
+        return _find_game_executable_impl(install_path)
+
+    async def write_install_marker(
+        self, space_id: str, install_path: str, executable: str,
+        game_title: str = '',
+    ) -> None:
+        """Write install marker."""
+        await _write_install_marker_impl(
+            space_id=space_id, install_path=install_path,
+            executable=executable, game_title=game_title,
+        )
+
+    @staticmethod
+    def load_json_file_safe(path: str) -> Any | None:
+        """Load JSON file safe."""
+        return _load_json_file_safe_impl(path)
+
+    @staticmethod
+    def get_game_official_url(game_id: str) -> str:
+        """Get game official URL."""
+        return f'https://store.ubi.com/us/game?pid={game_id}'
+
+    async def get_installed(self) -> dict[str, Any]:
+        """Get installed."""
+        installed: dict[str, Any] = {}
+        for space_id in list(self._id_map._cache.keys()):
+            info = self.get_installed_game_info(space_id)
+            if info:
+                installed[space_id] = info
+        return installed
+
+    def get_installed_game_info(self, game_id: str) -> dict[str, Any] | None:
+        """Get installed game info."""
+        space_id = game_id
+        for prefix_path in self._config.iter_game_prefix_paths():
+            info = self._detect_installed_game(space_id, prefix_path)
+            if info:
+                self._auto_resolve_id_from_registry(space_id, prefix_path, info)
+                return info
+        return None
+
+    def _auto_resolve_id_from_registry(
+        self, space_id: str, prefix_path: str, game_info: dict[str, Any],
+    ) -> None:
+        """Auto resolve ID from registry."""
+        if game_info.get('install_id'):
+            return
+        try:
+            game_id = self._id_map.extract_game_id_from_registry(prefix_path)
+        except Exception:
+            game_id = None
+        if game_id:
+            game_info['install_id'] = game_id
+            self._id_map.merge_entry(space_id, {'install_id': game_id})
+
+    async def _auto_resolve_missing_id(
+        self, space_id: str, prefix_path: str, game_info: dict[str, Any],
+    ) -> None:
+        """Auto resolve missing ID."""
+        if game_info.get('install_id'):
+            return
+        try:
+            await self._id_map.refresh_from_configurations(space_id)
+        except Exception as e:
+            logger.debug('[Ubisoft.detection] refresh failed: %s', e)
+        entry = self._id_map.get_entry(space_id)
+        if entry.get('install_id'):
+            game_info['install_id'] = entry['install_id']
+
+    def _detect_installed_game(
+        self, space_id: str, prefix_path: str,
+    ) -> dict[str, Any] | None:
+        """Detect installed game."""
+        known_name = self._get_game_name(space_id) or ''
+        normalised = self._id_map.normalize_for_matching(known_name)
+        return self._cascade.detect_via_marker(
+            space_id, known_name,
+            in_prefix_game_roots(prefix_path),
+        ) or self._cascade.detect_via_prefix_install_state(
+            space_id,
+            in_prefix_game_roots(prefix_path),
+            normalised, known_name,
+            self._cascade._default_check_install_state,
+        ) or self._cascade.detect_via_external_roots(
+            space_id, self._cascade._helpers.get_external_game_roots(),
+            normalised, known_name,
+            self._cascade._default_check_install_state,
+        ) or self._cascade.detect_via_registry_install_id(
+            space_id, prefix_path, known_name,
+            self._cascade._default_check_install_state,
+        )
+
+    def _get_game_name(self, space_id: str) -> str | None:
+        """Get game name."""
+        entry = self._id_map.get_entry(space_id)
+        name = entry.get('name')
+        return name if isinstance(name, str) else None

--- a/py_modules/unifideck/stores/ubisoft/library/detection_cascade.py
+++ b/py_modules/unifideck/stores/ubisoft/library/detection_cascade.py
@@ -1,5 +1,252 @@
-"""detection_cascade.py — Detection cascade
+"""detection_cascade.py — Cascade of fallback strategies for install detection.
+
 # OP-57g | py_modules/unifideck/stores/ubisoft/library/detection_cascade.py | Depends: (none)
+
+Tries (in order): the install-marker file, in-prefix UPC games dir,
+configured external game roots (default + sd-card + mounted media),
+and finally the per-prefix Wine registry.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+import re
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from .detection_helpers import (
+    _DetectionHelpers,
+    load_json_file_safe,
+    looks_like_game_install,
+    walk_install_candidates,
+    write_marker_sync,
+)
+from .wine_path import wine_path_to_linux
+
+if TYPE_CHECKING:
+    from .detection import _InstallDetector
+
+logger = logging.getLogger(__name__)
+_INSTALL_MARKER_FILENAME = '.unifideck_ubisoft'
+
+
+class _DetectionCascade:
+    """Detection cascade."""
+
+    def __init__(self, parent: _InstallDetector) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+        self._helpers = _DetectionHelpers(parent)
+
+    def detect_via_marker(
+        self, space_id: str, known_name: str, search_roots: list[str],
+    ) -> dict[str, Any] | None:
+        """Detect via marker."""
+        for _entry, game_dir in walk_install_candidates(search_roots):
+            marker_data = self._load_marker_for_space(game_dir, space_id)
+            if marker_data is None:
+                continue
+            return self._build_marker_result(
+                space_id, known_name, game_dir,
+                os.path.basename(game_dir), marker_data,
+            )
+        return None
+
+    @staticmethod
+    def _load_marker_for_space(
+        game_dir: str, space_id: str,
+    ) -> dict | None:
+        """Load marker for space."""
+        path = os.path.join(game_dir, _INSTALL_MARKER_FILENAME)
+        marker = load_json_file_safe(path)
+        if not isinstance(marker, dict):
+            return None
+        if marker.get('space_id') == space_id:
+            return marker
+        return None
+
+    def _build_marker_result(
+        self, space_id: str, known_name: str, game_dir: str,
+        folder: str, marker_data: dict,
+    ) -> dict[str, Any]:
+        """Build marker result."""
+        executable = self._resolve_marker_executable(marker_data, game_dir)
+        return {
+            'space_id': space_id,
+            'install_path': game_dir,
+            'install_dir': folder,
+            'executable': executable,
+            'name': marker_data.get('title') or known_name,
+            'install_id': '',
+        }
+
+    def _resolve_marker_executable(
+        self, marker_data: dict, install_path: str,
+    ) -> str:
+        """Resolve marker executable."""
+        rel = marker_data.get('executable')
+        if isinstance(rel, str) and rel:
+            full = os.path.join(install_path, rel)
+            if os.path.isfile(full):
+                return full
+        return self._parent.find_game_executable(install_path) or ''
+
+    def detect_via_prefix_install_state(
+        self,
+        space_id: str,
+        prefix_game_roots: list[str],
+        normalized_known_name: str,
+        known_name: str,
+        check_install_state: Callable[[str], bool],
+    ) -> dict[str, Any] | None:
+        """Detect via prefix install state."""
+        for _entry, game_dir in walk_install_candidates(prefix_game_roots):
+            folder = os.path.basename(game_dir)
+            if not self.fuzzy_folder_match(folder, normalized_known_name):
+                continue
+            state = os.path.join(game_dir, 'uplay_install.state')
+            if os.path.isfile(state) and not check_install_state(state):
+                continue
+            if not looks_like_game_install(game_dir):
+                continue
+            self._write_unifideck_marker(game_dir, space_id, known_name)
+            return self.build_install_info(space_id, game_dir, known_name)
+        return None
+
+    def detect_via_external_roots(
+        self,
+        space_id: str,
+        external_game_roots: list[str],
+        normalized_known_name: str,
+        known_name: str,
+        check_install_state: Callable[[str], bool],
+    ) -> dict[str, Any] | None:
+        """Detect via external roots."""
+        for _entry, game_dir in walk_install_candidates(external_game_roots):
+            folder = os.path.basename(game_dir)
+            if not self.fuzzy_folder_match(folder, normalized_known_name):
+                continue
+            if not looks_like_game_install(game_dir):
+                continue
+            self._write_unifideck_marker(game_dir, space_id, known_name)
+            return self.build_install_info(space_id, game_dir, known_name)
+        return None
+
+    def detect_via_registry_install_id(
+        self,
+        space_id: str,
+        prefix_path: str,
+        known_name: str,
+        check_install_state: Callable[[str], bool],
+    ) -> dict[str, Any] | None:
+        """Detect via registry install ID."""
+        for reg_name in ('system.reg', os.path.join('pfx', 'system.reg')):
+            reg_path = os.path.join(prefix_path, reg_name)
+            if not os.path.isfile(reg_path):
+                continue
+            install_id = self._parent._id_map.get_entry(space_id).get(
+                'install_id',
+            )
+            if not install_id:
+                continue
+            pattern = self._build_registry_pattern(install_id)
+            result = self._try_registry_file(
+                reg_path, pattern, space_id, install_id, prefix_path,
+                known_name, check_install_state,
+            )
+            if result is not None:
+                return result
+        return None
+
+    @staticmethod
+    def _build_registry_pattern(install_id: str) -> re.Pattern:
+        """Build registry pattern."""
+        return re.compile(
+            (
+                r'\[Software\\\\Wow6432Node\\\\Ubisoft\\\\Launcher\\\\'
+                r'Installs\\\\' + re.escape(install_id) + r'\][^\[]*?'
+                r'"InstallDir"\s*=\s*"([^"]*)"'
+            ),
+            re.DOTALL,
+        )
+
+    def _try_registry_file(
+        self,
+        reg_path: str,
+        pattern: re.Pattern,
+        space_id: str,
+        install_id: str,
+        prefix_path: str,
+        known_name: str,
+        check_install_state: Callable[[str], bool],
+    ) -> dict[str, Any] | None:
+        """Try registry file."""
+        try:
+            with open(reg_path, encoding='utf-8', errors='replace') as f:
+                content = f.read()
+        except OSError:
+            return None
+        match = pattern.search(content)
+        if not match:
+            return None
+        wine_path = match.group(1).replace('\\\\', '\\')
+        linux_path = wine_path_to_linux(wine_path, prefix_path)
+        if not linux_path:
+            return None
+        if not self._validate_registry_install(linux_path, check_install_state):
+            return None
+        self._write_unifideck_marker(linux_path, space_id, known_name)
+        return self.build_install_info(space_id, linux_path, known_name)
+
+    @staticmethod
+    def _validate_registry_install(
+        linux_path: str | None, check_install_state: Callable[[str], bool],
+    ) -> bool:
+        """Validate registry install."""
+        if not linux_path or not os.path.isdir(linux_path):
+            return False
+        state = os.path.join(linux_path, 'uplay_install.state')
+        if os.path.isfile(state) and not check_install_state(state):
+            return False
+        return looks_like_game_install(linux_path)
+
+    def build_install_info(
+        self, space_id: str, game_dir: str, title_hint: str,
+    ) -> dict[str, Any]:
+        """Build install info."""
+        executable = self._parent.find_game_executable(game_dir) or ''
+        return {
+            'space_id': space_id,
+            'install_path': game_dir,
+            'install_dir': os.path.basename(game_dir),
+            'executable': executable,
+            'name': title_hint,
+            'install_id': self._parent._id_map.get_entry(space_id).get(
+                'install_id', '',
+            ),
+        }
+
+    def fuzzy_folder_match(
+        self, folder_name: str, normalized_known_name: str,
+    ) -> bool:
+        """Fuzzy folder match."""
+        if not normalized_known_name:
+            return False
+        norm = self._parent._id_map.normalize_for_matching(folder_name)
+        return (
+            norm == normalized_known_name
+            or normalized_known_name in norm
+            or norm in normalized_known_name
+        )
+
+    def _write_unifideck_marker(
+        self, install_path: str, space_id: str, title: str,
+    ) -> None:
+        """Write unifideck marker."""
+        write_marker_sync(install_path, space_id, title)
+
+    @staticmethod
+    def _default_check_install_state(state_file: str) -> bool:
+        """Default check install state."""
+        from ..parser import check_install_state as _impl
+        return _impl(state_file)

--- a/py_modules/unifideck/stores/ubisoft/library/detection_helpers.py
+++ b/py_modules/unifideck/stores/ubisoft/library/detection_helpers.py
@@ -1,5 +1,226 @@
-"""detection_helpers.py — Detection helpers
+"""detection_helpers.py — Filesystem helpers used by detection logic.
+
 # OP-57h | py_modules/unifideck/stores/ubisoft/library/detection_helpers.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import datetime
+import glob
+import json
+import logging
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .detection import _InstallDetector
+
+logger = logging.getLogger(__name__)
+_EXE_SKIP_PATTERNS = (
+    'unins', 'setup', 'install', 'crash', 'redist', 'vcredist',
+    'dxsetup', 'dotnet', 'upc', 'uplay',
+)
+_GAME_INSTALL_MIN_SIZE = 100 * 1024 * 1024
+_IN_PREFIX_GAMES_PATH = str(
+    Path('drive_c') / 'Program Files (x86)' / 'Ubisoft'
+    / 'Ubisoft Game Launcher' / 'games'
+)
+_INSTALL_MARKER_FILENAME = '.unifideck_ubisoft'
+
+
+def load_json_file_safe(path: str) -> Any | None:
+    """Load JSON file safe."""
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, encoding='utf-8', errors='replace') as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug('[Ubisoft.detection] json load %s: %s', path, e)
+        return None
+
+
+def walk_install_candidates(
+    roots: list[str],
+) -> Iterator[tuple[str, str]]:
+    """Walk install candidates."""
+    seen: set[str] = set()
+    for root in roots:
+        if not root or not os.path.isdir(root):
+            continue
+        try:
+            entries = sorted(os.listdir(root))
+        except OSError:
+            continue
+        for entry in entries:
+            full = os.path.join(root, entry)
+            if not os.path.isdir(full):
+                continue
+            real = os.path.realpath(full)
+            if real in seen:
+                continue
+            seen.add(real)
+            yield entry, full
+
+
+def in_prefix_game_roots(prefix_path: str) -> list[str]:
+    """In prefix game roots."""
+    return [
+        os.path.join(prefix_path, _IN_PREFIX_GAMES_PATH),
+        os.path.join(prefix_path, 'pfx', _IN_PREFIX_GAMES_PATH),
+    ]
+
+
+def find_game_executable(install_path: str) -> str | None:
+    """Find game executable."""
+    if not install_path or not os.path.isdir(install_path):
+        return None
+    candidates: list[tuple[int, str]] = []
+    try:
+        for root, _dirs, files in os.walk(install_path):
+            depth = root[len(install_path):].count(os.sep)
+            if depth >= 3:
+                continue
+            for f in files:
+                lower = f.lower()
+                if not lower.endswith('.exe'):
+                    continue
+                if any(p in lower for p in _EXE_SKIP_PATTERNS):
+                    continue
+                full = os.path.join(root, f)
+                try:
+                    size = os.path.getsize(full)
+                except OSError:
+                    continue
+                if size < 1024:
+                    continue
+                candidates.append((size, full))
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
+def looks_like_game_install(path: str) -> bool:
+    """Looks like game install."""
+    if not path or not os.path.isdir(path):
+        return False
+    try:
+        for root, _dirs, files in os.walk(path):
+            depth = root[len(path):].count(os.sep)
+            if depth >= 2:
+                break
+            for f in files:
+                if f.lower().endswith('.exe'):
+                    return True
+    except OSError:
+        return False
+    total = 0
+    try:
+        for root, _dirs, files in os.walk(path):
+            for f in files:
+                try:
+                    total += os.path.getsize(os.path.join(root, f))
+                except OSError:
+                    continue
+                if total > _GAME_INSTALL_MIN_SIZE:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+async def write_install_marker(
+    space_id: str,
+    install_path: str,
+    executable: str,
+    game_title: str = '',
+) -> None:
+    """Write install marker."""
+    write_marker_sync(install_path, space_id, game_title or '', executable=executable)
+
+
+def write_marker_sync(
+    install_path: str,
+    space_id: str,
+    title: str,
+    executable: str = '',
+) -> None:
+    """Write marker sync."""
+    if not install_path or not os.path.isdir(install_path):
+        return
+    marker = os.path.join(install_path, _INSTALL_MARKER_FILENAME)
+    payload = {
+        'space_id': space_id,
+        'title': title,
+        'executable': executable,
+        'created_at': datetime.datetime.utcnow().isoformat() + 'Z',
+    }
+    try:
+        with open(marker, 'w', encoding='utf-8') as f:
+            json.dump(payload, f, indent=2)
+    except OSError as e:
+        logger.debug('[Ubisoft.detection] marker write: %s', e)
+
+
+class _DetectionHelpers:
+    """Detection helpers."""
+
+    def __init__(self, parent: _InstallDetector) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    def get_external_game_roots(self) -> list[str]:
+        """Get external game roots."""
+        config = self._parent._config
+        roots: list[str] = []
+        self._append_custom_path_root(roots, config)
+        self._append_mounted_media_roots(roots)
+        return self._dedup_roots_by_realpath(roots)
+
+    @staticmethod
+    def _append_custom_path_root(roots: list[str], config: Any) -> None:
+        """Append custom path root."""
+        for path in (
+            config.default_install_base_expanded,
+            config.sdcard_install_base,
+        ):
+            if path and os.path.isdir(path):
+                roots.append(path)
+
+    @staticmethod
+    def _append_mounted_media_roots(roots: list[str]) -> None:
+        """Append mounted media roots."""
+        for media_parent in ('/run/media', '/media'):
+            if not os.path.isdir(media_parent):
+                continue
+            try:
+                for entry in sorted(os.listdir(media_parent)):
+                    parent = Path(media_parent) / entry
+                    if parent.is_dir():
+                        _DetectionHelpers._append_sub_mount_roots(parent, roots)
+            except OSError:
+                continue
+
+    @staticmethod
+    def _append_sub_mount_roots(parent: Path, roots: list[str]) -> None:
+        """Append sub mount roots."""
+        for pattern in ('Games/Ubisoft', '*/Games/Ubisoft'):
+            for hit in glob.glob(str(parent / pattern)):
+                if os.path.isdir(hit):
+                    roots.append(hit)
+
+    @staticmethod
+    def _dedup_roots_by_realpath(roots: list[str]) -> list[str]:
+        """Dedup roots by realpath."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for r in roots:
+            real = os.path.realpath(r)
+            if real not in seen:
+                seen.add(real)
+                out.append(r)
+        return out

--- a/py_modules/unifideck/stores/ubisoft/library/facade.py
+++ b/py_modules/unifideck/stores/ubisoft/library/facade.py
@@ -1,5 +1,82 @@
-"""facade.py — Library facade
+"""facade.py — Public ``UbisoftLibrary`` surface.
+
 # OP-57a | py_modules/unifideck/stores/ubisoft/library/facade.py | Depends: OP-55a
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from ....core.types import Game
+from ..config import UbisoftConfig
+from ..id_map import UbisoftIdMap
+from ..paths import UbisoftPrefixPaths
+from .detection import _InstallDetector
+from .fetch import _LibraryFetcher
+from .manifest import _VisibleManifestProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class UbisoftLibrary:
+    """Ubisoft library."""
+
+    def __init__(
+        self,
+        config: UbisoftConfig,
+        paths: UbisoftPrefixPaths,
+        id_map: UbisoftIdMap,
+        queue_template_creation: Callable[[], None],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._id_map = id_map
+        self._queue_template_creation = queue_template_creation
+        self._detector = _InstallDetector(config, id_map)
+        self._fetcher = _LibraryFetcher(config, paths, id_map)
+        self._manifest = _VisibleManifestProcessor(
+            config, id_map,
+            load_json_file_safe=_InstallDetector.load_json_file_safe,
+        )
+
+    async def get_library(self) -> list[Game]:
+        """Get library."""
+        installed = await self.get_installed()
+        games = await self._fetcher.fetch_local_binaries(installed)
+        if games is None:
+            self._queue_template_creation()
+            games = []
+        manifest = self._manifest.load_manifest()
+        if manifest:
+            games = self._manifest.apply_filter(
+                games, installed, manifest, source_label='visible_manifest',
+            )
+        return games
+
+    async def get_installed(self) -> dict[str, Any]:
+        """Get installed."""
+        return await self._detector.get_installed()
+
+    def get_installed_game_info(self, game_id: str) -> dict[str, Any] | None:
+        """Get installed game info."""
+        return self._detector.get_installed_game_info(game_id)
+
+    def find_game_executable(self, install_path: str) -> str | None:
+        """Find game executable."""
+        return self._detector.find_game_executable(install_path)
+
+    async def write_install_marker(
+        self, space_id: str, install_path: str, executable: str,
+        game_title: str = '',
+    ) -> None:
+        """Write install marker."""
+        await self._detector.write_install_marker(
+            space_id, install_path, executable, game_title,
+        )
+
+    @staticmethod
+    def get_game_official_url(game_id: str) -> str:
+        """Get game official URL."""
+        return _InstallDetector.get_game_official_url(game_id)

--- a/py_modules/unifideck/stores/ubisoft/library/fetch.py
+++ b/py_modules/unifideck/stores/ubisoft/library/fetch.py
@@ -1,5 +1,73 @@
-"""fetch.py — Library fetcher
+"""fetch.py — Drive the data-loader + game-builder pipeline.
+
 # OP-57b | py_modules/unifideck/stores/ubisoft/library/fetch.py | Depends: OP-55a
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from ....core.types import Game
+from .data_loader import _DataLoader
+from .game_builder import _GameBuilder
+
+if TYPE_CHECKING:
+    from ..config import UbisoftConfig
+    from ..id_map import UbisoftIdMap
+    from ..parser import GameConfig
+    from ..paths import UbisoftPrefixPaths
+    ParseConfigurationsFn = Callable[[str], list[GameConfig]]
+    ParseOwnershipFn = Callable[[str], list[int]]
+
+logger = logging.getLogger(__name__)
+
+
+class _LibraryFetcher:
+    """Library fetcher."""
+
+    def __init__(
+        self,
+        config: UbisoftConfig,
+        paths: UbisoftPrefixPaths,
+        id_map: UbisoftIdMap,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._id_map = id_map
+        self._data_loader = _DataLoader(config=config, paths=paths)
+        self._builder = _GameBuilder(config=config, id_map=id_map)
+
+    async def fetch_local_binaries(
+        self, installed: dict[str, Any],
+    ) -> list[Game] | None:
+        """Fetch local binaries."""
+        parser_pair = self._import_ubisoft_parser()
+        if parser_pair is None:
+            return None
+        parse_configurations, parse_ownership = parser_pair
+        configs = await self._data_loader.load_configurations(
+            parse_configurations,
+        )
+        if configs is None:
+            return None
+        owned_set = await self._data_loader.load_ownership_set(parse_ownership)
+        config_by_id = self._builder.build_config_lookup(configs)
+        matched = self._builder.cross_reference_ownership(
+            configs, config_by_id, owned_set,
+        )
+        matched = self._builder.apply_steam_filter(matched)
+        return self._builder.build_games_from_configs(matched, installed)
+
+    @staticmethod
+    def _import_ubisoft_parser() -> tuple[
+        ParseConfigurationsFn, ParseOwnershipFn,
+    ] | None:
+        """Import UBISOFT parser."""
+        try:
+            from ..parser import parse_configurations, parse_ownership
+        except Exception as e:
+            logger.warning('[Ubisoft.library] parser import failed: %s', e)
+            return None
+        return parse_configurations, parse_ownership

--- a/py_modules/unifideck/stores/ubisoft/library/game_builder.py
+++ b/py_modules/unifideck/stores/ubisoft/library/game_builder.py
@@ -1,5 +1,179 @@
-"""game_builder.py — Game object builder
+"""game_builder.py — Convert parsed configurations into ``Game`` objects.
+
 # OP-57d | py_modules/unifideck/stores/ubisoft/library/game_builder.py | Depends: OP-05
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from ....core.types import Game
+from ..steam_filter import filter_steam_linked_configs
+
+if TYPE_CHECKING:
+    from ..config import UbisoftConfig
+    from ..id_map import UbisoftIdMap
+    from ..parser import GameConfig
+
+logger = logging.getLogger(__name__)
+_MOJIBAKE_REPLACEMENTS = (
+    ('Â®', '®'), ('â\x80¢', '™'), ('â¢', '™'), ('â\x80\x99', "'"),
+    ('Â', ''),
+)
+_SKIP_TITLE_KEYWORDS = re.compile(
+    r'\b(test\b|beta|alpha|closed|preorder|pre-order|promotion|internal|'
+    r'dev|qc|pts|test server|demo|trial)\b',
+    re.IGNORECASE,
+)
+_SKIP_DLC_KEYWORDS = re.compile(
+    r'\b(dlc|season pass|expansion|pack|bonus|soundtrack|art ?book|skins?|'
+    r'outfit|costume|weapon|map|mission|episode|revolver|kukri|cane-sword|'
+    r'hammer|knife|dagger|conspiracy|runaway train|texture|language|'
+    r'starter edition|battle pass|car shipment|full stock|full unlock|master '
+    r'unlock|paint|perk|club|credit pack|currency pack|ownership|'
+    r'ubicollectibles|legion of the dead|calling all units)\b',
+    re.IGNORECASE,
+)
+_STORE_MARKER_PATTERN = re.compile(r'\[STEAM\]|\[Uplay', re.IGNORECASE)
+_CYRILLIC_PATTERN = re.compile(r'[Ѐ-ӿ]')
+_PLACEHOLDER_L_PATTERN = re.compile(r'(l\d+|[A-Z0-9_]+)')
+_PLACEHOLDER_LITERALS = frozenset({'a ubisoft game'})
+
+
+class _GameBuilder:
+    """Game builder."""
+
+    def __init__(
+        self, *, config: UbisoftConfig, id_map: UbisoftIdMap,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._id_map = id_map
+
+    @staticmethod
+    def build_config_lookup(
+        configs: list[GameConfig],
+    ) -> dict[int, GameConfig]:
+        """Build config lookup."""
+        return {cfg.launch_id: cfg for cfg in configs if cfg.launch_id}
+
+    @staticmethod
+    def cross_reference_ownership(
+        configs: list[GameConfig],
+        config_by_id: dict[int, GameConfig],
+        owned_set: set[int] | None,
+    ) -> list[GameConfig]:
+        """Cross reference ownership."""
+        if not owned_set:
+            return configs
+        owned: list[GameConfig] = []
+        for launch_id in owned_set:
+            cfg = config_by_id.get(launch_id)
+            if cfg is not None:
+                owned.append(cfg)
+        return owned
+
+    def apply_steam_filter(
+        self, configs: list[GameConfig],
+    ) -> list[GameConfig]:
+        """Apply steam filter."""
+        if not self._config.filter_steam_linked:
+            return configs
+        return self._filter_steam_linked_configs(configs)
+
+    def _filter_steam_linked_configs(
+        self, configs: list[GameConfig],
+    ) -> list[GameConfig]:
+        """Filter steam linked configs."""
+        return filter_steam_linked_configs(
+            configs,
+            self._config.steam_library_cross_ref,
+            self._id_map,
+        )
+
+    def build_games_from_configs(
+        self,
+        matched_configs: list[GameConfig],
+        installed: dict[str, Any],
+    ) -> list[Game]:
+        """Build games from configs."""
+        seen_norms: set[str] = set()
+        id_map_updates: dict[str, dict[str, Any]] = {}
+        out: list[Game] = []
+        for cfg in matched_configs:
+            game = self._build_one_game(
+                cfg, installed, seen_norms, id_map_updates,
+            )
+            if game is not None:
+                out.append(game)
+        if id_map_updates:
+            self._id_map.update_bulk(id_map_updates)
+        return out
+
+    def _build_one_game(
+        self,
+        cfg: GameConfig,
+        installed: dict[str, Any],
+        seen_norms: set[str],
+        id_map_updates: dict[str, dict[str, Any]],
+    ) -> Game | None:
+        """Build one game."""
+        title = self._clean_launcher_title(cfg.name)
+        if not title or self._should_skip_launcher_title(title):
+            return None
+        norm = self._id_map.normalize_for_matching(title)
+        if not norm or norm in seen_norms:
+            return None
+        seen_norms.add(norm)
+        space_id = cfg.space_id or str(cfg.launch_id)
+        installed_info = installed.get(space_id, {})
+        is_installed = bool(installed_info)
+        if cfg.space_id:
+            id_map_updates[cfg.space_id] = {
+                'install_id': str(cfg.install_id),
+                'launch_id': str(cfg.launch_id),
+                'name': title,
+            }
+        return Game(
+            store='ubisoft',
+            game_id=space_id,
+            title=title,
+            installed=is_installed,
+            install_path=str(installed_info.get('install_path', '')),
+        )
+
+    @staticmethod
+    def _clean_launcher_title(title: Any) -> str:
+        """Clean launcher title."""
+        if not isinstance(title, str):
+            return ''
+        cleaned = title
+        for src, dst in _MOJIBAKE_REPLACEMENTS:
+            cleaned = cleaned.replace(src, dst)
+        return cleaned.strip()
+
+    def _is_launcher_placeholder_title(self, title: str) -> bool:
+        """Is launcher placeholder title."""
+        if not title:
+            return True
+        lower = title.lower().strip()
+        if lower in _PLACEHOLDER_LITERALS:
+            return True
+        if _PLACEHOLDER_L_PATTERN.fullmatch(title):
+            return True
+        return False
+
+    def _should_skip_launcher_title(self, title: str) -> bool:
+        """Should skip launcher title."""
+        if self._is_launcher_placeholder_title(title):
+            return True
+        if _SKIP_TITLE_KEYWORDS.search(title):
+            return True
+        if _SKIP_DLC_KEYWORDS.search(title):
+            return True
+        if _STORE_MARKER_PATTERN.search(title):
+            return True
+        if _CYRILLIC_PATTERN.search(title):
+            return True
+        return False

--- a/py_modules/unifideck/stores/ubisoft/library/manifest.py
+++ b/py_modules/unifideck/stores/ubisoft/library/manifest.py
@@ -1,5 +1,282 @@
-"""manifest.py — Ubisoft manifest format
+"""manifest.py — Visible-games manifest filter & enrichment.
+
 # OP-57e | py_modules/unifideck/stores/ubisoft/library/manifest.py | Depends: (none)
+
+The "visible manifest" is an optional allow-list living under the
+unifideck data dir. When present, only entries from the manifest are
+shown — useful for free-to-claim Ubisoft titles that don't appear in
+the local UPC ownership cache.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from ....core.types import Game
+from ..config import UbisoftConfig
+from ..id_map import UbisoftIdMap
+
+logger = logging.getLogger(__name__)
+
+
+def _first_non_empty(raw: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """First non empty."""
+    for key in keys:
+        value = raw.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ''
+
+
+@dataclass
+class _VisibleManifestIndex:
+    """Visible manifest index."""
+
+    by_norm: dict[str, dict[str, Any]] = field(default_factory=dict)
+    by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
+    norms: set[str] = field(default_factory=set)
+    ids: set[str] = field(default_factory=set)
+
+    def lookup(
+        self, game_id: str, norm_title: str,
+    ) -> dict[str, Any] | None:
+        """Lookup."""
+        if game_id and game_id in self.by_id:
+            return self.by_id[game_id]
+        if norm_title and norm_title in self.by_norm:
+            return self.by_norm[norm_title]
+        return None
+
+    def matches(self, game_id: str, norm_title: str) -> bool:
+        """Matches."""
+        if game_id and game_id in self.ids:
+            return True
+        if norm_title and norm_title in self.norms:
+            return True
+        return False
+
+
+class _VisibleManifestProcessor:
+    """Visible manifest processor."""
+
+    def __init__(
+        self,
+        config: UbisoftConfig,
+        id_map: UbisoftIdMap,
+        load_json_file_safe: Callable[[str], Any | None],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._id_map = id_map
+        self._load_json = load_json_file_safe
+
+    def load_manifest(self) -> list[dict[str, Any]]:
+        """Load manifest."""
+        path = self._config.visible_games_file_expanded
+        payload = self._load_json(path)
+        if payload is None:
+            return []
+        raw_games = (
+            payload.get('games', []) if isinstance(payload, dict) else payload
+        )
+        manifest: list[dict[str, Any]] = []
+        for raw in raw_games or []:
+            normalised = self._normalize_entry(raw)
+            if normalised is not None:
+                manifest.append(normalised)
+        return manifest
+
+    @staticmethod
+    def _normalize_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
+        """Normalize entry."""
+        if not isinstance(raw, dict):
+            return None
+        title = _first_non_empty(raw, ('title', 'name'))
+        if not title:
+            return None
+        space_id = _first_non_empty(raw, ('space_id', 'spaceId'))
+        install_id = _first_non_empty(raw, ('install_id',))
+        launch_id = _first_non_empty(raw, ('launch_id',)) or install_id
+        ubic = _first_non_empty(
+            raw, ('ubisoftconnect_game_id', 'product_id'),
+        )
+        return {
+            'title': title,
+            'space_id': space_id,
+            'install_id': install_id,
+            'launch_id': launch_id,
+            'ubisoftconnect_game_id': ubic,
+        }
+
+    @staticmethod
+    def _game_id_for(entry: dict[str, Any]) -> str:
+        """Game ID for."""
+        return (
+            entry.get('space_id')
+            or entry.get('install_id')
+            or entry.get('ubisoftconnect_game_id')
+            or ''
+        )
+
+    def _merge_into_id_map(self, entry: dict[str, Any]) -> bool:
+        """Merge into ID map."""
+        space_id = entry.get('space_id')
+        if not space_id:
+            return False
+        return self._id_map.merge_entry(
+            space_id,
+            {
+                'install_id': entry.get('install_id') or '',
+                'launch_id': entry.get('launch_id') or '',
+                'name': entry.get('title') or '',
+                'ubisoftconnect_game_id': entry.get('ubisoftconnect_game_id') or '',
+            },
+        )
+
+    def _build_index(
+        self, manifest: list[dict[str, Any]],
+    ) -> _VisibleManifestIndex:
+        """Build index."""
+        index = _VisibleManifestIndex()
+        for entry in manifest:
+            game_id = self._game_id_for(entry)
+            norm_title = self._id_map.normalize_for_matching(
+                entry.get('title') or '',
+            )
+            if game_id:
+                index.by_id[game_id] = entry
+                index.ids.add(game_id)
+            if norm_title:
+                index.by_norm[norm_title] = entry
+                index.norms.add(norm_title)
+        return index
+
+    def apply_filter(
+        self,
+        games: list[Game],
+        installed: dict[str, Any],
+        manifest: list[dict[str, Any]] | None,
+        source_label: str,
+    ) -> list[Game]:
+        """Apply filter."""
+        if not manifest:
+            return games
+        self._merge_manifest_into_id_map(manifest)
+        index = self._build_index(manifest)
+        filtered, seen_ids, seen_norms = self._filter_and_enrich_games(
+            games, index, source_label,
+        )
+        injected = self._inject_unseen_manifest_entries(
+            manifest, installed, filtered, seen_ids, seen_norms,
+            source_label,
+        )
+        if injected:
+            logger.info(
+                '[Ubisoft.manifest] %s injected %d unseen entries',
+                source_label, injected,
+            )
+        return filtered
+
+    def _merge_manifest_into_id_map(
+        self, manifest: list[dict[str, Any]],
+    ) -> bool:
+        """Merge manifest into ID map."""
+        changed = False
+        for entry in manifest:
+            if self._merge_into_id_map(entry):
+                changed = True
+        return changed
+
+    def _enrich_game_from_entry(
+        self, game: Game, entry: dict[str, Any],
+    ) -> None:
+        """Enrich game from entry."""
+        if entry.get('title'):
+            game.title = entry['title']
+        if entry.get('install_id') and not getattr(game, 'install_id', None):
+            game.install_id = entry['install_id']
+
+    def _filter_and_enrich_games(
+        self,
+        games: list[Game],
+        index: _VisibleManifestIndex,
+        source_label: str,
+    ) -> tuple[list[Game], set[str], set[str]]:
+        """Filter and enrich games."""
+        out: list[Game] = []
+        seen_ids: set[str] = set()
+        seen_norms: set[str] = set()
+        for game in games:
+            game_id = getattr(game, 'game_id', '') or ''
+            norm_title = self._id_map.normalize_for_matching(
+                getattr(game, 'title', '') or '',
+            )
+            entry = index.lookup(game_id, norm_title)
+            if entry is None:
+                continue
+            self._enrich_game_from_entry(game, entry)
+            out.append(game)
+            if game_id:
+                seen_ids.add(game_id)
+            if norm_title:
+                seen_norms.add(norm_title)
+        logger.info(
+            '[Ubisoft.manifest] %s kept %d / %d',
+            source_label, len(out), len(games),
+        )
+        return out, seen_ids, seen_norms
+
+    def _inject_unseen_manifest_entries(
+        self,
+        manifest: list[dict[str, Any]],
+        installed: dict[str, Any],
+        filtered: list[Game],
+        seen_ids: set[str],
+        seen_norms: set[str],
+        source_label: str,
+    ) -> int:
+        """Inject unseen manifest entries."""
+        injected = 0
+        for entry in manifest:
+            game_id = self._game_id_for(entry)
+            norm_title = self._id_map.normalize_for_matching(
+                entry.get('title') or '',
+            )
+            if game_id and game_id in seen_ids:
+                continue
+            if norm_title and norm_title in seen_norms:
+                continue
+            game = self._build_synthetic_game(entry, installed)
+            if game is None:
+                continue
+            filtered.append(game)
+            injected += 1
+            if game_id:
+                seen_ids.add(game_id)
+            if norm_title:
+                seen_norms.add(norm_title)
+        return injected
+
+    @staticmethod
+    def _build_synthetic_game(
+        entry: dict[str, Any], installed: dict[str, Any],
+    ) -> Game | None:
+        """Build synthetic game."""
+        title = entry.get('title') or ''
+        space_id = entry.get('space_id') or ''
+        install_id = entry.get('install_id') or ''
+        if not title:
+            return None
+        game_id = space_id or install_id
+        if not game_id:
+            return None
+        is_installed = bool(installed.get(game_id))
+        return Game(
+            store='ubisoft',
+            game_id=game_id,
+            title=title,
+            installed=is_installed,
+            install_path=str((installed.get(game_id) or {}).get('install_path', '')),
+        )

--- a/py_modules/unifideck/stores/ubisoft/library/wine_path.py
+++ b/py_modules/unifideck/stores/ubisoft/library/wine_path.py
@@ -1,5 +1,68 @@
-"""wine_path.py — Wine path resolution
+"""wine_path.py — Convert Wine-style paths to Linux filesystem paths.
+
 # OP-57i | py_modules/unifideck/stores/ubisoft/library/wine_path.py | Depends: (none)
+
+UPC stores executable paths in the form ``C:\\Program Files (x86)\\…``
+or ``Z:\\home\\deck\\…``. To resolve those against the actual filesystem
+we need to know which Wine prefix they came from and then map drive
+letters to the prefix's drive_c / dosdevices conventions.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+from pathlib import Path
+
+
+def wine_path_to_linux(wine_path: str, prefix_path: str) -> str | None:
+    """Convert ``wine_path`` to a real Linux path within ``prefix_path``.
+
+    Returns ``None`` if the input doesn't look like a Wine path or if
+    the corresponding drive can't be located on disk.
+    """
+    if not wine_path:
+        return None
+    normalized = wine_path.replace("\\", "/")
+    if len(normalized) < 2 or normalized[1] != ":":
+        return None
+    drive_letter = normalized[0].upper()
+    relative = normalized[2:].lstrip("/")
+    if drive_letter == "Z":
+        return _resolve_z_drive(relative)
+    if drive_letter == "C":
+        return _resolve_c_drive(prefix_path, relative)
+    return _resolve_other_drive(prefix_path, drive_letter, relative)
+
+
+def _resolve_z_drive(relative: str) -> str:
+    """Z: maps to the Linux root."""
+    return "/" + relative
+
+
+def _resolve_c_drive(prefix_path: str, relative: str) -> str:
+    """C: maps to ``<prefix>/drive_c`` (or ``<prefix>/pfx/drive_c``)."""
+    candidates = (
+        Path(prefix_path) / "drive_c" / relative,
+        Path(prefix_path) / "pfx" / "drive_c" / relative,
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return str(candidates[0])
+
+
+def _resolve_other_drive(
+    prefix_path: str, drive_letter: str, relative: str,
+) -> str | None:
+    """Any other letter resolves through the prefix's ``dosdevices`` map."""
+    letter = drive_letter.lower()
+    candidates = (
+        Path(prefix_path) / "dosdevices" / f"{letter}:",
+        Path(prefix_path) / "pfx" / "dosdevices" / f"{letter}:",
+    )
+    for dev in candidates:
+        if dev.exists() or dev.is_symlink():
+            try:
+                target = dev.resolve()
+            except OSError:
+                continue
+            return str(target / relative)
+    return None

--- a/py_modules/unifideck/stores/ubisoft/parser.py
+++ b/py_modules/unifideck/stores/ubisoft/parser.py
@@ -1,5 +1,334 @@
-"""parser.py — Ubisoft ownership parser
+"""parser.py — High-level UPC binary cache parsing.
+
 # OP-55e | py_modules/unifideck/stores/ubisoft/parser.py | Depends: (none)
+
+Walks the ``configurations`` and ``ownership`` files UPC writes inside
+its game-launcher cache and turns them into structured records (see
+:class:`GameConfig`). YAML payloads embedded in each record are parsed
+with PyYAML where present and fall back to permissive regex extraction
+for truncated chunks.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+import re
+from typing import Any, cast
+
+try:
+    import yaml as _yaml  # noqa: F401  PyYAML is bundled by Decky.
+    _HAS_YAML = True
+except Exception:  # pragma: no cover - degraded mode
+    _HAS_YAML = False
+
+from .parser_binary import (
+    parse_install_id,
+    parse_launch_id,
+    parse_ownership_record,
+    parse_record_size,
+)
+
+logger = logging.getLogger(__name__)
+BLACKLISTED_NAMES = [
+    'gamename', 'l1', 'l2', 'thumbimage', '', 'ubisoft game', 'name',
+]
+
+
+def _parse_config_header(
+    header: bytes, second_eight: bool = False,
+) -> tuple:
+    """Parse the install_id / launch_id / object-size triple at the
+    start of a configuration record. Returns (install_id, launch_id,
+    obj_size, header_bytes_consumed).
+    """
+    offset = 0
+    install_id, c1 = parse_install_id(header, offset)
+    offset += c1
+    launch_id, c2 = parse_launch_id(header, offset)
+    offset += c2
+    obj_size, c3, _raw = parse_record_size(header, offset, second_eight)
+    offset += c3
+    return install_id, launch_id, obj_size, offset
+
+
+def _get_yaml_field(game_yaml: dict, field: str = 'name') -> str:
+    """Extract a top-level field from a parsed game YAML, with the
+    UPC-specific fallbacks the launcher applies at runtime.
+    """
+    if not isinstance(game_yaml, dict):
+        return ""
+    current = game_yaml.get(field, "") or ""
+    if isinstance(current, str):
+        current = current.strip()
+    else:
+        current = str(current)
+    if field == 'name':
+        current = _yaml_field_localization_fallback(game_yaml, current)
+        current = _yaml_field_installer_fallback(game_yaml, current)
+    return current
+
+
+def _yaml_field_installer_fallback(root: dict, current: str) -> str:
+    """Pull a name out of installer.game_identifier when the top-level
+    name is empty or a placeholder.
+    """
+    if current and current.lower() not in BLACKLISTED_NAMES:
+        return current
+    installer = root.get('installer') if isinstance(root, dict) else None
+    if isinstance(installer, dict):
+        candidate = installer.get('game_identifier') or installer.get('name')
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return current
+
+
+def _yaml_field_localization_fallback(game_yaml: dict, current: str) -> str:
+    """Some titles only set the human name in localizations.default.GAMENAME."""
+    if current and current.lower() not in BLACKLISTED_NAMES:
+        return current
+    loc = game_yaml.get('localizations') if isinstance(game_yaml, dict) else None
+    if isinstance(loc, dict):
+        default = loc.get('default')
+        if isinstance(default, dict):
+            for key in ('GAMENAME', 'gamename', 'NAME', 'name'):
+                value = default.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+    return current
+
+
+class GameConfig:
+    """Parsed game entry from the configurations binary."""
+
+    def __init__(self):
+        """Initialize the instance."""
+        self.install_id: int = 0
+        self.launch_id: int = 0
+        self.space_id: str = ""
+        self.name: str = ""
+        self.executable: str = ""
+        self.thumb_image: str = ""
+        self.game_identifier: str = ""
+        self.yaml_raw: str = ""
+        self.third_party_platform: str = ""
+
+    def __repr__(self) -> str:
+        """Repr."""
+        return (
+            f"GameConfig(name={self.name!r}, space_id={self.space_id!r}, "
+            f"install_id={self.install_id}, launch_id={self.launch_id})"
+        )
+
+
+def _read_binary_file(filepath: str) -> bytes | None:
+    """Read a binary file, returning ``None`` on any I/O error."""
+    if not os.path.isfile(filepath):
+        logger.warning("[UbiParser] file not found: %s", filepath)
+        return None
+    try:
+        with open(filepath, "rb") as f:
+            return f.read()
+    except OSError as e:
+        logger.error("[UbiParser] failed to read %s: %s", filepath, e)
+        return None
+
+
+def _extract_config_chunk(
+    data: bytes,
+    global_offset: int,
+    header_size: int,
+    obj_size: int,
+    install_id: int,
+    launch_id: int,
+) -> GameConfig | None:
+    """Extract one chunk's worth of YAML and convert it to a GameConfig."""
+    chunk_start = global_offset + header_size
+    chunk_end = chunk_start + obj_size
+    if chunk_end > len(data) or obj_size < 50:
+        return None
+    chunk = data[chunk_start:chunk_end]
+    yaml_start = chunk.find(b"\x1A")
+    if yaml_start < 0:
+        return None
+    yaml_bytes = chunk[yaml_start + 1:]
+    text = yaml_bytes.decode("utf-8", errors="replace")
+    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", text)
+    if "start_game" not in text:
+        return None
+    parsed: dict[str, Any] = {}
+    if _HAS_YAML:
+        try:
+            loaded = _yaml.safe_load(text)
+            if isinstance(loaded, dict):
+                # The YAML is shaped {<install_id>: {root: {…}}}.
+                for value in loaded.values():
+                    if isinstance(value, dict) and 'root' in value:
+                        parsed = cast(dict, value['root'])
+                        break
+                if not parsed:
+                    parsed = loaded
+        except Exception as e:
+            logger.debug("[UbiParser] yaml parse failed: %s", e)
+    return _build_game_config(parsed, text, install_id, launch_id)
+
+
+def parse_configurations(filepath: str) -> list[GameConfig]:
+    """Parse the UPC configurations binary into a list of GameConfig.
+
+    Walks each 0x0A-rooted record, decodes the install_id / launch_id /
+    object-size header, and extracts the embedded YAML chunk.
+    """
+    data = _read_binary_file(filepath)
+    if data is None:
+        return []
+    results: list[GameConfig] = []
+    offset = 0
+    while offset < len(data):
+        if data[offset] != 0x0A:
+            offset += 1
+            continue
+        record_start = offset
+        offset += 1
+        try:
+            install_id, launch_id, obj_size, header_consumed = (
+                _parse_config_header(data[offset:offset + 32])
+            )
+        except Exception as e:
+            logger.debug("[UbiParser] header parse @ %d: %s", record_start, e)
+            offset = record_start + 1
+            continue
+        if obj_size < 50:
+            offset = record_start + 1
+            continue
+        cfg = _extract_config_chunk(
+            data, record_start, 1 + header_consumed,
+            obj_size, install_id, launch_id,
+        )
+        if cfg is not None and cfg.name:
+            results.append(cfg)
+        offset = record_start + 1 + header_consumed + obj_size
+    logger.info("[UbiParser] parsed %d configs from %s", len(results), filepath)
+    return results
+
+
+def _build_game_config(
+    parsed: dict, yaml_text: str, install_id: int, launch_id: int,
+) -> GameConfig | None:
+    """Lift the chosen scalar fields off the parsed YAML."""
+    cfg = GameConfig()
+    cfg.install_id = install_id
+    cfg.launch_id = launch_id
+    cfg.yaml_raw = yaml_text
+    cfg.name = _get_yaml_field(parsed, 'name')
+    cfg.space_id = _get_yaml_field(parsed, 'space_id')
+    cfg.thumb_image = _get_yaml_field(parsed, 'thumb_image')
+    installer = parsed.get('installer') if isinstance(parsed, dict) else None
+    if isinstance(installer, dict):
+        identifier = installer.get('game_identifier')
+        if isinstance(identifier, str):
+            cfg.game_identifier = identifier.strip()
+    start_game = parsed.get('start_game') if isinstance(parsed, dict) else None
+    if isinstance(start_game, dict):
+        cfg.executable = _resolve_executable(start_game)
+    if not cfg.executable:
+        match = re.search(r"relative:\s*(.+?\.exe)", yaml_text, re.IGNORECASE)
+        if match:
+            cfg.executable = match.group(1).strip().strip("'\"")
+    cfg.third_party_platform = _extract_third_party_platform(parsed, installer)
+    if not cfg.space_id:
+        match = re.search(r"space_id:\s*([a-f0-9\-]+)", yaml_text)
+        if match:
+            cfg.space_id = match.group(1)
+    return cfg if cfg.name else None
+
+
+def _resolve_executable(start_game: dict) -> str:
+    """Walk start_game.online.executables[].path.relative for an .exe."""
+    for branch_key in ('online', 'offline', 'steam'):
+        branch = start_game.get(branch_key)
+        if not isinstance(branch, dict):
+            continue
+        executables = branch.get('executables')
+        if not isinstance(executables, list):
+            continue
+        for entry in executables:
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get('path')
+            if isinstance(path, dict):
+                rel = path.get('relative')
+                if isinstance(rel, str) and rel.lower().endswith('.exe'):
+                    return rel.strip().strip("'\"")
+    return ""
+
+
+def _extract_third_party_platform(root: dict, installer: Any) -> str:
+    """Tag known third-party platform configurations (Steam, EGS, etc.)."""
+    if isinstance(installer, dict):
+        platform = installer.get('third_party_platform')
+        if isinstance(platform, str):
+            return platform.strip()
+    if isinstance(root, dict):
+        third = root.get('third_party_platform')
+        if isinstance(third, str):
+            return third.strip()
+    return ""
+
+
+def parse_ownership(filepath: str) -> list[int]:
+    """Parse the UPC ownership binary into a list of owned launch_ids."""
+    data = _read_ownership_file(filepath)
+    if data is None:
+        return []
+    owned: list[int] = []
+    offset = 0x108
+    while offset < len(data):
+        if data[offset] != 0x0A:
+            offset += 1
+            continue
+        offset += 1
+        rec_size, consumed, _raw = parse_record_size(data, offset, False)
+        offset += consumed
+        chunk_end = min(offset + rec_size, len(data))
+        chunk = data[offset:chunk_end]
+        record = parse_ownership_record(chunk)
+        if record is not None:
+            owned.append(record[0])
+        offset = chunk_end
+    logger.info("[UbiParser] %d owned IDs in %s", len(owned), filepath)
+    return owned
+
+
+def _read_ownership_file(filepath: str) -> bytes | None:
+    """Read the ownership cache, tolerating absence."""
+    return _read_binary_file(filepath)
+
+
+def check_install_state(state_file: str) -> bool:
+    """Return True when ``uplay_install.state`` indicates a complete install."""
+    if not os.path.isfile(state_file):
+        return False
+    try:
+        with open(state_file, "rb") as f:
+            return f.read(1) == b"\x0A"
+    except OSError:
+        return False
+
+
+def build_id_map_from_configurations(filepath: str) -> dict[str, dict[str, Any]]:
+    """Convenience: ``parse_configurations`` flattened to a space_id keyed
+    map for direct merge into ``ubisoft_id_map.json``.
+    """
+    id_map: dict[str, dict[str, Any]] = {}
+    for cfg in parse_configurations(filepath):
+        if not cfg.space_id:
+            continue
+        id_map[cfg.space_id] = {
+            "install_id": str(cfg.install_id),
+            "launch_id": str(cfg.launch_id),
+            "name": cfg.name,
+            "executable": cfg.executable,
+            "game_identifier": cfg.game_identifier,
+        }
+    logger.info("[UbiParser] built id_map of %d entries", len(id_map))
+    return id_map

--- a/py_modules/unifideck/stores/ubisoft/parser_binary.py
+++ b/py_modules/unifideck/stores/ubisoft/parser_binary.py
@@ -1,5 +1,111 @@
-"""parser_binary.py — Ubisoft binary format parser
+"""parser_binary.py — Low-level binary primitives for UPC's varint encoding.
+
 # OP-55f | py_modules/unifideck/stores/ubisoft/parser_binary.py | Depends: (none)
+
+UPC stores its configuration and ownership cache in a custom binary
+format with variable-length integers ("Konrad's varint"). This module
+contains pure decode helpers — no I/O, no logging — that the higher-
+level parser uses to walk records.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import math
+
+
+def _convert_data(data: int) -> int:
+    """Reverse Konrad's compact varint encoding."""
+    if data > 256 * 256:
+        data -= 128 * 256 * math.ceil(data / (256 * 256))
+        data -= 128 * math.ceil(data / 256)
+    elif data > 256:
+        data -= 128 * math.ceil(data / 256)
+    return data
+
+
+def parse_record_size(
+    header: bytes, offset: int, second_eight: bool,
+) -> tuple[int, int, int]:
+    """Read a record-size varint at ``offset``.
+
+    Returns (decoded_size, bytes_consumed, raw_size). ``second_eight``
+    selects the alternate 0x10-rooted branch used by ownership records,
+    which apply Konrad's transform a second time.
+    """
+    raw = 0
+    consumed = 0
+    shift = 0
+    while offset + consumed < len(header):
+        byte = header[offset + consumed]
+        raw |= (byte & 0x7F) << shift
+        consumed += 1
+        shift += 7
+        if not (byte & 0x80):
+            break
+    decoded = _convert_data(raw)
+    if second_eight:
+        decoded = _convert_data(decoded)
+    return decoded, consumed, raw
+
+
+def parse_install_id(header: bytes, offset: int) -> tuple[int, int]:
+    """Decode the install_id following an 0x08 marker.
+
+    Returns (install_id, bytes_consumed). When there is no 0x08 at the
+    offset, returns (0, 0) so the caller can detect a missing marker.
+    """
+    if offset >= len(header) or header[offset] != 0x08:
+        return 0, 0
+    raw = 0
+    consumed = 1
+    shift = 0
+    while offset + consumed < len(header):
+        byte = header[offset + consumed]
+        raw |= (byte & 0x7F) << shift
+        consumed += 1
+        shift += 7
+        if not (byte & 0x80):
+            break
+    return _convert_data(raw), consumed
+
+
+def parse_launch_id(header: bytes, offset: int) -> tuple[int, int]:
+    """Decode the launch_id following an 0x10 marker.
+
+    Returns (launch_id, bytes_consumed). Returns (0, 0) when there
+    is no marker at the offset.
+    """
+    if offset >= len(header) or header[offset] != 0x10:
+        return 0, 0
+    raw = 0
+    consumed = 1
+    shift = 0
+    while offset + consumed < len(header):
+        byte = header[offset + consumed]
+        raw |= (byte & 0x7F) << shift
+        consumed += 1
+        shift += 7
+        if not (byte & 0x80):
+            break
+    return _convert_data(raw), consumed
+
+
+def parse_ownership_record(chunk: bytes) -> tuple | None:
+    """Decode a single ownership record.
+
+    Returns (launch_id, launch_id_2) or ``None`` if the record can't
+    be decoded. ``launch_id_2`` is 0 when the record has no secondary
+    0x10 field.
+    """
+    if not chunk:
+        return None
+    offset = 0
+    launch_id, consumed = parse_install_id(chunk, offset)
+    if consumed == 0:
+        return None
+    offset += consumed
+    launch_id_2 = 0
+    if offset < len(chunk) and chunk[offset] == 0x10:
+        decoded2, consumed2 = parse_launch_id(chunk, offset)
+        launch_id_2 = decoded2
+        offset += consumed2
+    return launch_id, launch_id_2

--- a/py_modules/unifideck/stores/ubisoft/paths.py
+++ b/py_modules/unifideck/stores/ubisoft/paths.py
@@ -1,5 +1,84 @@
-"""paths.py — Ubisoft path resolution
+"""paths.py — Filesystem helpers for the Ubisoft Wine prefix.
+
 # OP-55c | py_modules/unifideck/stores/ubisoft/paths.py | Depends: (none)
+
+UPC writes its caches and binaries to a few well-known relative paths
+inside the Wine prefix. Both bare-Wine (``drive_c/...``) and Proton
+(``pfx/drive_c/...``) layouts exist; this module locates files in both.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import os
+from collections.abc import Iterator
+
+from .config import UbisoftConfig
+
+
+class UbisoftPrefixPaths:
+    """Ubisoft prefix paths."""
+
+    def __init__(self, config: UbisoftConfig) -> None:
+        """Initialize the instance."""
+        self._config = config
+
+    def find_upc_exe(self, prefix_path: str) -> str | None:
+        """Find UPC exe."""
+        return self._first_existing(prefix_path, self._config.upc_relative_path)
+
+    def find_connect_exe(self, prefix_path: str) -> str | None:
+        """Find connect exe."""
+        return self._first_existing(
+            prefix_path, self._config.upc_connect_relative_path,
+        )
+
+    def find_configurations(self, prefix_path: str) -> str | None:
+        """Find configurations."""
+        return self._first_existing(
+            prefix_path, self._config.configurations_relative_path,
+        )
+
+    def iter_user_homes(
+        self, prefix_path: str, pfx_first: bool = False,
+    ) -> Iterator[tuple[str, str]]:
+        """Iter user homes.
+
+        Yields (prefix_root, user_home) for every non-system user
+        directory in both bare-Wine and Proton ``pfx/`` layouts.
+        """
+        roots = [prefix_path, os.path.join(prefix_path, "pfx")]
+        if pfx_first:
+            roots = list(reversed(roots))
+        skip = set(self._config.wine_system_users)
+        for prefix_root in roots:
+            users_dir = os.path.join(prefix_root, "drive_c", "users")
+            if not os.path.isdir(users_dir):
+                continue
+            try:
+                entries = sorted(os.listdir(users_dir))
+            except OSError:
+                continue
+            for entry in entries:
+                if entry in skip:
+                    continue
+                user_home = os.path.join(users_dir, entry)
+                if os.path.isdir(user_home):
+                    yield prefix_root, user_home
+
+    def get_prefix_path(self, space_id: str) -> str:
+        """Get prefix path."""
+        return os.path.join(self._config.prefixes_dir_expanded, space_id)
+
+    @staticmethod
+    def _find_in_prefix(prefix_path: str, relative: str) -> str | None:
+        """Find in prefix."""
+        for candidate in (
+            os.path.join(prefix_path, relative),
+            os.path.join(prefix_path, "pfx", relative),
+        ):
+            if os.path.isfile(candidate):
+                return candidate
+        return None
+
+    def _first_existing(self, prefix_path: str, relative: str) -> str | None:
+        """Search both bare and pfx/ layouts; return first hit."""
+        return self._find_in_prefix(prefix_path, relative)

--- a/py_modules/unifideck/stores/ubisoft/prefix/__init__.py
+++ b/py_modules/unifideck/stores/ubisoft/prefix/__init__.py
@@ -1,2 +1,4 @@
 # OP-59 | stores/ubisoft/prefix/__init__.py
-from __future__ import annotations
+from .manager import UbisoftPrefixManager
+
+__all__ = ['UbisoftPrefixManager']

--- a/py_modules/unifideck/stores/ubisoft/prefix/auth_builder.py
+++ b/py_modules/unifideck/stores/ubisoft/prefix/auth_builder.py
@@ -1,5 +1,135 @@
-"""auth_builder.py — Prefix auth builder
+"""auth_builder.py — Build / repair the dedicated auth prefix.
+
 # OP-59d | py_modules/unifideck/stores/ubisoft/prefix/auth_builder.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..config import UbisoftConfig
+    from ..installer.cache import UbisoftInstallerCache
+    from ..paths import UbisoftPrefixPaths
+    from .helpers import _PrefixHelpers
+    from .template_builder import _TemplatePrefixBuilder
+
+logger = logging.getLogger(__name__)
+
+
+class _AuthPrefixBuilder:
+    """Auth prefix builder."""
+
+    def __init__(
+        self, *,
+        config: UbisoftConfig,
+        paths: UbisoftPrefixPaths,
+        helpers: _PrefixHelpers,
+        installer_cache: UbisoftInstallerCache,
+        template_builder: _TemplatePrefixBuilder,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._helpers = helpers
+        self._installer_cache = installer_cache
+        self._template_builder = template_builder
+        self._ensure_lock = asyncio.Lock()
+
+    async def ensure_auth_prefix(self) -> str | None:
+        """Ensure auth prefix."""
+        async with self._ensure_lock:
+            auth_dir = self._config.auth_prefix_dir_expanded
+            await self._repair_auth_prefix_if_needed()
+            if self._auth_prefix_needs_rebuild(
+                auth_dir, self._paths.find_upc_exe(auth_dir),
+            ):
+                return await self._rebuild_and_finalise_auth_prefix(auth_dir)
+            return auth_dir
+
+    def _auth_prefix_needs_rebuild(
+        self, auth_dir: str, upc_path: str | None,
+    ) -> bool:
+        """Auth prefix needs rebuild."""
+        if not os.path.isdir(auth_dir) or not upc_path:
+            return True
+        return self._template_builder.is_prefix_version_stale(auth_dir)
+
+    async def _rebuild_and_finalise_auth_prefix(
+        self, auth_dir: str,
+    ) -> str | None:
+        """Rebuild and finalise auth prefix."""
+        if os.path.isdir(auth_dir):
+            shutil.rmtree(auth_dir, ignore_errors=True)
+        if not await self._build_auth_prefix_from_source():
+            return None
+        return auth_dir
+
+    async def _build_auth_prefix_from_source(self) -> bool:
+        """Build auth prefix from source."""
+        auth_dir = self._config.auth_prefix_dir_expanded
+        clone_source, source_label = self._pick_clone_source()
+        if clone_source and source_label == 'template':
+            ok = await self._helpers.clone_prefix_from_template(
+                space_id='auth', prefix_path=auth_dir,
+            )
+            if ok:
+                return True
+        return await self._helpers.create_prefix_from_fresh_install(
+            space_id='auth', prefix_path=auth_dir,
+        )
+
+    def _pick_clone_source(self) -> tuple[str | None, str]:
+        """Pick clone source."""
+        template = self._config.template_dir_expanded
+        if (
+            self._template_builder.template_exists()
+            and not self._template_builder.is_prefix_version_stale(template)
+        ):
+            return template, 'template'
+        for prefix in self._config.iter_game_prefix_paths():
+            if (
+                self._paths.find_upc_exe(prefix)
+                and not self._template_builder.is_prefix_version_stale(prefix)
+            ):
+                return prefix, 'game_prefix'
+        return None, 'fresh'
+
+    def queue_auth_assets_ensure(self, reason: str = 'background') -> None:
+        """Queue auth assets ensure."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        loop.create_task(
+            self._ensure_auth_assets(reason),
+            name=f'ubisoft_auth_assets:{reason}',
+        )
+
+    async def _ensure_auth_assets(self, reason: str) -> None:
+        """Ensure auth assets."""
+        try:
+            await self.ensure_auth_prefix()
+        except Exception as e:
+            logger.warning(
+                '[Ubisoft.prefix] ensure_auth_assets(%s) failed: %s',
+                reason, e,
+            )
+
+    async def _repair_auth_prefix_if_needed(self) -> None:
+        """Repair auth prefix if needed."""
+        auth_dir = self._config.auth_prefix_dir_expanded
+        if not os.path.isdir(auth_dir):
+            return
+        marker = Path(auth_dir) / self._config.bootstrap_marker
+        if marker.is_file():
+            return
+        # Missing marker means an interrupted bootstrap — wipe and rebuild.
+        logger.info(
+            '[Ubisoft.prefix] auth prefix missing marker, will rebuild',
+        )
+        shutil.rmtree(auth_dir, ignore_errors=True)

--- a/py_modules/unifideck/stores/ubisoft/prefix/helpers.py
+++ b/py_modules/unifideck/stores/ubisoft/prefix/helpers.py
@@ -1,5 +1,188 @@
-"""helpers.py — Prefix helpers
+"""helpers.py — Wine prefix manipulation primitives.
+
 # OP-59b | py_modules/unifideck/stores/ubisoft/prefix/helpers.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import datetime
+import logging
+import os
+import shutil
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .manager import UbisoftPrefixManager
+
+logger = logging.getLogger(__name__)
+_SILENT_INSTALL_FLAG = '/S'
+
+
+class _PrefixHelpers:
+    """Prefix helpers."""
+
+    def __init__(self, parent: UbisoftPrefixManager) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    async def clone_prefix_from_template(
+        self, space_id: str, prefix_path: str,
+    ) -> bool:
+        """Clone prefix from template."""
+        config = self._parent._config
+        template = config.template_dir_expanded
+        if not os.path.isdir(template):
+            return False
+        try:
+            await self.rsync_clone(template, prefix_path, exclude_games=True)
+        except Exception as e:
+            logger.warning('[Ubisoft.prefix] clone failed: %s', e)
+            return False
+        self.write_bootstrap_marker(prefix_path, source='template', space_id=space_id)
+        self.fix_pfx_symlink(prefix_path)
+        return True
+
+    async def create_prefix_from_fresh_install(
+        self, space_id: str, prefix_path: str,
+    ) -> bool:
+        """Create prefix from fresh install."""
+        installer_cache = self._parent._installer_cache
+        installer_path = await installer_cache.ensure_cached()
+        if not installer_path:
+            return False
+        os.makedirs(prefix_path, exist_ok=True)
+        ok = await self.run_silent_installer(
+            prefix_dir=prefix_path,
+            installer_path=installer_path,
+            gameid=f'umu-ubisoft-{space_id}',
+            store_game_id=f'ubisoft:{space_id}',
+        )
+        if not ok:
+            return False
+        self.write_bootstrap_marker(prefix_path, source='fresh', space_id=space_id)
+        self.fix_pfx_symlink(prefix_path)
+        return True
+
+    async def create_template_from_game_prefix(self, game_prefix: str) -> None:
+        """Create template from game prefix."""
+        config = self._parent._config
+        template = config.template_dir_expanded
+        try:
+            if os.path.isdir(template):
+                shutil.rmtree(template, ignore_errors=True)
+            await self.rsync_clone(game_prefix, template, exclude_games=True)
+            self.write_bootstrap_marker(template, source='derived_from_game', space_id=None)
+        except Exception as e:
+            logger.warning('[Ubisoft.prefix] template derivation failed: %s', e)
+
+    async def run_silent_installer(
+        self, *, prefix_dir: str, installer_path: str, gameid: str,
+        store_game_id: str | None = None,
+    ) -> bool:
+        """Run silent installer."""
+        binaries = self._parent._binaries
+        umu_run = binaries.find_umu_run()
+        if not umu_run:
+            return False
+        proton = binaries.find_proton_path()
+        env = binaries.build_umu_env(
+            wineprefix=prefix_dir,
+            gameid=gameid,
+            proton_path=proton,
+            store_game_id=store_game_id,
+        )
+        cmd = [umu_run, installer_path, _SILENT_INSTALL_FLAG]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, env=env,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except OSError as e:
+            logger.warning('[Ubisoft.prefix] installer spawn failed: %s', e)
+            return False
+        return await self._await_installer_completion(proc)
+
+    @staticmethod
+    async def _await_installer_completion(
+        proc: asyncio.subprocess.Process,
+    ) -> bool:
+        """Await installer completion."""
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=30 * 60)
+        except TimeoutError:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+            return False
+        return proc.returncode == 0
+
+    async def rsync_clone(
+        self, src: str, dst: str, *, exclude_games: bool,
+    ) -> bool:
+        """Rsync clone."""
+        cmd = ['rsync', '-a', '--delete']
+        if exclude_games:
+            cmd += [
+                '--exclude',
+                'drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/games/',
+            ]
+        cmd += [src.rstrip('/') + '/', dst.rstrip('/') + '/']
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+        except OSError as e:
+            logger.warning('[Ubisoft.prefix] rsync spawn failed: %s', e)
+            return False
+        if proc.returncode != 0:
+            logger.warning(
+                '[Ubisoft.prefix] rsync rc=%s err=%s',
+                proc.returncode, stderr[:200].decode('utf-8', errors='replace'),
+            )
+            return False
+        return True
+
+    @staticmethod
+    def fix_pfx_symlink(prefix_dir: str) -> None:
+        """Fix pfx symlink — Proton expects ``<prefix>/pfx`` to exist
+        as a symlink back to the prefix root for sub-tools that rely
+        on it. Many bare-Wine prefixes don't have it.
+        """
+        pfx = os.path.join(prefix_dir, 'pfx')
+        if os.path.islink(pfx) or os.path.isdir(pfx):
+            return
+        try:
+            os.symlink('.', pfx, target_is_directory=True)
+        except OSError as e:
+            logger.debug('[Ubisoft.prefix] pfx symlink: %s', e)
+
+    def write_bootstrap_marker(
+        self, prefix_dir: str, source: str, space_id: str | None,
+    ) -> None:
+        """Write bootstrap marker."""
+        config = self._parent._config
+        marker_path = os.path.join(prefix_dir, config.bootstrap_marker)
+        payload = {
+            'created_at': datetime.datetime.utcnow().isoformat() + 'Z',
+            'source': source,
+            'space_id': space_id or '',
+        }
+        try:
+            os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+            with open(marker_path, 'w', encoding='utf-8') as f:
+                for key, value in payload.items():
+                    f.write(f'{key}={value}\n')
+        except OSError as e:
+            logger.debug('[Ubisoft.prefix] bootstrap marker: %s', e)
+
+    def try_inject_auth_state(self, prefix_paths: list[str]) -> None:
+        """Try inject auth state."""
+        try:
+            self._parent._inject_auth_state(prefix_paths)
+        except Exception as e:
+            logger.debug('[Ubisoft.prefix] inject auth state failed: %s', e)

--- a/py_modules/unifideck/stores/ubisoft/prefix/manager.py
+++ b/py_modules/unifideck/stores/ubisoft/prefix/manager.py
@@ -1,5 +1,114 @@
-"""manager.py — Wine prefix manager
+"""manager.py — Public ``UbisoftPrefixManager`` surface.
+
 # OP-59a | py_modules/unifideck/stores/ubisoft/prefix/manager.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+from ..binaries import UbisoftBinaryResolver
+from ..config import UbisoftConfig
+from ..installer.cache import UbisoftInstallerCache
+from ..paths import UbisoftPrefixPaths
+from .auth_builder import _AuthPrefixBuilder
+from .helpers import _PrefixHelpers
+from .template_builder import _TemplatePrefixBuilder
+
+logger = logging.getLogger(__name__)
+
+
+class UbisoftPrefixManager:
+    """Ubisoft prefix manager."""
+
+    def __init__(
+        self,
+        config: UbisoftConfig,
+        paths: UbisoftPrefixPaths,
+        binaries: UbisoftBinaryResolver,
+        installer_cache: UbisoftInstallerCache,
+        inject_auth_state: Callable[[list[str]], int],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._binaries = binaries
+        self._installer_cache = installer_cache
+        self._inject_auth_state = inject_auth_state
+        self._helpers = _PrefixHelpers(self)
+        self._template_builder = _TemplatePrefixBuilder(
+            config=config, paths=paths,
+            helpers=self._helpers, installer_cache=installer_cache,
+        )
+        self._auth_builder = _AuthPrefixBuilder(
+            config=config, paths=paths,
+            helpers=self._helpers, installer_cache=installer_cache,
+            template_builder=self._template_builder,
+        )
+
+    def template_exists(self) -> bool:
+        """Template exists."""
+        return self._template_builder.template_exists()
+
+    def is_prefix_version_stale(self, prefix_dir: str) -> bool:
+        """Is prefix version stale."""
+        return self._template_builder.is_prefix_version_stale(prefix_dir)
+
+    @staticmethod
+    def read_machine_guid(prefix_path: str) -> str:
+        """Read machine guid."""
+        return _TemplatePrefixBuilder.read_machine_guid(prefix_path)
+
+    def queue_template_creation(self) -> None:
+        """Queue template creation."""
+        self._template_builder.queue_template_creation()
+
+    async def regenerate_template_if_stale(self) -> None:
+        """Regenerate template if stale."""
+        await self._template_builder.regenerate_template_if_stale()
+
+    async def ensure_template_prefix(self) -> None:
+        """Ensure template prefix."""
+        await self._template_builder.ensure_template_prefix()
+
+    async def ensure_auth_prefix(self) -> str | None:
+        """Ensure auth prefix."""
+        return await self._auth_builder.ensure_auth_prefix()
+
+    def queue_auth_assets_ensure(self, reason: str = 'background') -> None:
+        """Queue auth assets ensure."""
+        self._auth_builder.queue_auth_assets_ensure(reason)
+
+    async def bootstrap_game_prefix(self, space_id: str) -> bool:
+        """Bootstrap game prefix."""
+        prefix_path = self._paths.get_prefix_path(space_id)
+        if self._paths.find_upc_exe(prefix_path):
+            self._helpers.fix_pfx_symlink(prefix_path)
+            return True
+        if (
+            self._template_builder.template_exists()
+            and not self._template_builder.is_prefix_version_stale(
+                self._config.template_dir_expanded,
+            )
+        ):
+            ok = await self._helpers.clone_prefix_from_template(
+                space_id, prefix_path,
+            )
+            if ok:
+                self._inject_auth_state([prefix_path])
+                return True
+        ok = await self._helpers.create_prefix_from_fresh_install(
+            space_id, prefix_path,
+        )
+        if ok:
+            self._inject_auth_state([prefix_path])
+        return ok
+
+    async def repair_prefix(self, space_id: str) -> bool:
+        """Repair prefix."""
+        prefix_path = self._paths.get_prefix_path(space_id)
+        if Path(prefix_path).is_dir():
+            shutil.rmtree(prefix_path, ignore_errors=True)
+        return await self.bootstrap_game_prefix(space_id)

--- a/py_modules/unifideck/stores/ubisoft/prefix/template_builder.py
+++ b/py_modules/unifideck/stores/ubisoft/prefix/template_builder.py
@@ -1,5 +1,135 @@
-"""template_builder.py — Prefix template builder
+"""template_builder.py — Manage the shared Ubisoft prefix template.
+
 # OP-59c | py_modules/unifideck/stores/ubisoft/prefix/template_builder.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..config import UbisoftConfig
+    from ..installer.cache import UbisoftInstallerCache
+    from ..paths import UbisoftPrefixPaths
+    from .helpers import _PrefixHelpers
+
+logger = logging.getLogger(__name__)
+_TEMPLATE_VERSION_KEY = 'template_version'
+_TEMPLATE_VERSION = 3
+_PROTON_VERSION_RE = re.compile(r'(\d+(?:\.\d+)*)')
+
+
+class _TemplatePrefixBuilder:
+    """Template prefix builder."""
+
+    def __init__(
+        self, *,
+        config: UbisoftConfig,
+        paths: UbisoftPrefixPaths,
+        helpers: _PrefixHelpers,
+        installer_cache: UbisoftInstallerCache,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._helpers = helpers
+        self._installer_cache = installer_cache
+        self._creation_task: asyncio.Task[None] | None = None
+
+    def template_exists(self) -> bool:
+        """Template exists."""
+        template = self._config.template_dir_expanded
+        upc = self._paths.find_upc_exe(template)
+        return bool(upc)
+
+    def is_prefix_version_stale(self, prefix_dir: str) -> bool:
+        """Check whether prefix version stale."""
+        marker = os.path.join(prefix_dir, self._config.bootstrap_marker)
+        if not os.path.isfile(marker):
+            return True
+        try:
+            with open(marker, encoding='utf-8') as f:
+                for line in f:
+                    if '=' not in line:
+                        continue
+                    key, _, value = line.strip().partition('=')
+                    if key == _TEMPLATE_VERSION_KEY:
+                        try:
+                            return int(value) < _TEMPLATE_VERSION
+                        except ValueError:
+                            return True
+        except OSError:
+            return True
+        return True
+
+    @staticmethod
+    def read_machine_guid(prefix_path: str) -> str:
+        """Read machine guid."""
+        for reg in ('system.reg', os.path.join('pfx', 'system.reg')):
+            path = os.path.join(prefix_path, reg)
+            if not os.path.isfile(path):
+                continue
+            try:
+                with open(path, encoding='utf-8', errors='replace') as f:
+                    for line in f:
+                        m = re.search(
+                            r'"MachineGuid"="([^"]+)"', line, re.IGNORECASE,
+                        )
+                        if m:
+                            return m.group(1)
+            except OSError:
+                continue
+        return ''
+
+    def queue_template_creation(self) -> None:
+        """Queue template creation."""
+        if self._creation_task is not None and not self._creation_task.done():
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        self._creation_task = loop.create_task(
+            self.regenerate_template_if_stale(),
+            name='ubisoft_template_create',
+        )
+
+    async def regenerate_template_if_stale(self) -> None:
+        """Regenerate template if stale."""
+        if (
+            self.template_exists()
+            and not self.is_prefix_version_stale(
+                self._config.template_dir_expanded,
+            )
+        ):
+            return
+        await self.ensure_template_prefix()
+
+    async def ensure_template_prefix(self) -> None:
+        """Ensure template prefix."""
+        template = self._config.template_dir_expanded
+        if self.template_exists() and not self.is_prefix_version_stale(template):
+            return
+        if os.path.isdir(template):
+            shutil.rmtree(template, ignore_errors=True)
+        await self._helpers.create_prefix_from_fresh_install(
+            space_id='template', prefix_path=template,
+        )
+        self._helpers.write_bootstrap_marker(
+            template, source='template_builder', space_id='template',
+        )
+        self._stamp_template_version(template)
+
+    def _stamp_template_version(self, template: str) -> None:
+        """Stamp template version into the bootstrap marker."""
+        marker = Path(template) / self._config.bootstrap_marker
+        try:
+            with open(marker, 'a', encoding='utf-8') as f:
+                f.write(f'{_TEMPLATE_VERSION_KEY}={_TEMPLATE_VERSION}\n')
+        except OSError as e:
+            logger.debug('[Ubisoft.prefix] template version stamp: %s', e)

--- a/py_modules/unifideck/stores/ubisoft/session/__init__.py
+++ b/py_modules/unifideck/stores/ubisoft/session/__init__.py
@@ -1,2 +1,4 @@
 # OP-60 | stores/ubisoft/session/__init__.py
-from __future__ import annotations
+from .facade import UbisoftSession
+
+__all__ = ['UbisoftSession']

--- a/py_modules/unifideck/stores/ubisoft/session/facade.py
+++ b/py_modules/unifideck/stores/ubisoft/session/facade.py
@@ -1,5 +1,115 @@
-"""facade.py — Session facade
+"""facade.py — Public ``UbisoftSession`` surface.
+
 # OP-60a | py_modules/unifideck/stores/ubisoft/session/facade.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+from ..config import UbisoftConfig
+from ..paths import UbisoftPrefixPaths
+from .payload import _PayloadSync
+from .propagator import _CredentialPropagator
+from .reader import _CredentialReader
+
+logger = logging.getLogger(__name__)
+_CAPTURE_SENTINEL = 'credentials_captured'
+
+
+class UbisoftSession:
+    """Ubisoft session."""
+
+    def __init__(
+        self,
+        config: UbisoftConfig,
+        paths: UbisoftPrefixPaths,
+        read_machine_guid: Callable[[str], str],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+        self._read_machine_guid = read_machine_guid
+        self._reader = _CredentialReader(config=config, paths=paths)
+        self._payload = _PayloadSync(self)
+        self._propagator = _CredentialPropagator(
+            config=config, payload=self._payload, reader=self._reader,
+        )
+
+    def has_valid_credentials(self, prefix_path: str) -> bool:
+        """Check whether valid credentials."""
+        return self._reader.has_valid_credentials(prefix_path)
+
+    def get_credential_mtime(self, prefix_path: str) -> float:
+        """Get credential mtime."""
+        return self._reader.get_credential_mtime(prefix_path)
+
+    def find_best_credential_source(self) -> str | None:
+        """Find best credential source."""
+        return self._reader.find_best_credential_source()
+
+    def _is_valid_css(self, css_path: str, min_size: int) -> bool:
+        """Is valid CSS."""
+        return _CredentialReader._is_valid_css(css_path, min_size)
+
+    def propagate_credentials_to_all(self) -> int:
+        """Propagate credentials to all."""
+        return self._propagator.propagate_credentials_to_all()
+
+    def propagate_auth_artifacts_to_all(self) -> int:
+        """Propagate auth artifacts to all."""
+        return self._propagator.propagate_auth_artifacts_to_all()
+
+    def propagate_all_to_all(self) -> None:
+        """Propagate all to all."""
+        self._propagator.propagate_all_to_all()
+
+    def inject_into_prefix(self, prefix_path: str) -> bool:
+        """Inject into prefix."""
+        return self._propagator.inject_into_prefix(prefix_path)
+
+    def ensure_auth_state_in_prefixes(self, prefix_paths: list[str]) -> int:
+        """Ensure auth state in prefixes."""
+        return self._propagator.ensure_auth_state_in_prefixes(prefix_paths)
+
+    def retroactive_sync(self) -> dict[str, Any]:
+        """Retroactive sync."""
+        return self._propagator.retroactive_sync()
+
+    def capture(self, prefix_path: str) -> str | None:
+        """Capture."""
+        if not self.has_valid_credentials(prefix_path):
+            return None
+        try:
+            mtime = self.get_credential_mtime(prefix_path)
+            self._write_stored_mtime(mtime)
+        except OSError as e:
+            logger.warning('[Ubisoft.session] capture mtime write: %s', e)
+        return _CAPTURE_SENTINEL
+
+    def _read_stored_mtime(self) -> float:
+        """Read stored mtime."""
+        path = self._config.upc_session_file_expanded
+        try:
+            with open(path, encoding='utf-8') as f:
+                return float(f.read().strip())
+        except (OSError, ValueError):
+            return 0.0
+
+    def _write_stored_mtime(self, mtime: float) -> None:
+        """Write stored mtime."""
+        path = self._config.upc_session_file_expanded
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(f'{mtime:.6f}')
+
+    def clear_session_file(self) -> None:
+        """Clear session file."""
+        path = self._config.upc_session_file_expanded
+        try:
+            if os.path.isfile(path):
+                os.unlink(path)
+        except OSError as e:
+            logger.warning('[Ubisoft.session] clear failed: %s', e)

--- a/py_modules/unifideck/stores/ubisoft/session/payload.py
+++ b/py_modules/unifideck/stores/ubisoft/session/payload.py
@@ -1,5 +1,205 @@
-"""payload.py — Session payload builder
+"""payload.py — Sync UPC credentials/auth artifacts between prefixes.
+
 # OP-60b | py_modules/unifideck/stores/ubisoft/session/payload.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import hashlib
+import logging
+import os
+import shutil
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .facade import UbisoftSession
+
+logger = logging.getLogger(__name__)
+_CSS_MIN_SOURCE_SIZE = 10
+_HASH_CHUNK_SIZE = 1024 * 1024
+
+
+class _PayloadSync:
+    """Payload sync."""
+
+    def __init__(self, parent: UbisoftSession) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    def sync_payload_to_prefix(
+        self,
+        source_prefix: str,
+        target_prefix: str,
+        *,
+        payload_sources: dict[str, str],
+        apply_dpapi_guard: bool,
+        handle_directories: bool,
+        log_label: str,
+    ) -> int:
+        """Sync payload to prefix."""
+        if self.should_skip_payload_sync(
+            source_prefix, target_prefix, payload_sources, apply_dpapi_guard,
+        ):
+            return 0
+        copied = 0
+        for rel_path, src_path in payload_sources.items():
+            dst_path = os.path.join(target_prefix, rel_path)
+            if self.copy_payload_entry(
+                src_path, dst_path,
+                handle_directories=handle_directories,
+                log_label=log_label, rel_path=rel_path,
+            ):
+                copied += 1
+        if copied:
+            logger.info(
+                '[Ubisoft.session] %s synced %d items %s → %s',
+                log_label, copied, source_prefix, target_prefix,
+            )
+        return copied
+
+    def should_skip_payload_sync(
+        self,
+        source_prefix: str, target_prefix: str,
+        payload_sources: dict[str, str], apply_dpapi_guard: bool,
+    ) -> bool:
+        """Check whether skip payload sync."""
+        if source_prefix == target_prefix:
+            return True
+        if not payload_sources:
+            return True
+        if apply_dpapi_guard:
+            try:
+                src_guid = self._parent._read_machine_guid(source_prefix)
+                dst_guid = self._parent._read_machine_guid(target_prefix)
+            except Exception:
+                src_guid = dst_guid = ''
+            if src_guid and dst_guid and src_guid != dst_guid:
+                logger.debug(
+                    '[Ubisoft.session] DPAPI guard: machineGuid mismatch',
+                )
+                return True
+        return False
+
+    def copy_payload_entry(
+        self,
+        src_path: str, dst_path: str, *,
+        handle_directories: bool, log_label: str, rel_path: str,
+    ) -> bool:
+        """Copy payload entry."""
+        if not os.path.exists(src_path):
+            return False
+        try:
+            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+            if os.path.isdir(src_path):
+                if not handle_directories:
+                    return False
+                if os.path.isdir(dst_path):
+                    shutil.rmtree(dst_path, ignore_errors=True)
+                shutil.copytree(src_path, dst_path)
+            else:
+                shutil.copy2(src_path, dst_path)
+            return True
+        except OSError as e:
+            logger.warning(
+                '[Ubisoft.session] %s copy %s failed: %s',
+                log_label, rel_path, e,
+            )
+            return False
+
+    def sync_credentials_to_prefix(
+        self, source_prefix: str, target_prefix: str,
+    ) -> int:
+        """Sync credentials to prefix."""
+        sources = self.collect_credential_sources(source_prefix)
+        return self.sync_payload_to_prefix(
+            source_prefix, target_prefix,
+            payload_sources=sources,
+            apply_dpapi_guard=True,
+            handle_directories=False,
+            log_label='credentials',
+        )
+
+    def collect_credential_sources(self, source_prefix: str) -> dict[str, str]:
+        """Collect credential sources."""
+        config = self._parent._config
+        paths_helper = self._parent._paths
+        sources: dict[str, str] = {}
+        for prefix_root, user_home in paths_helper.iter_user_homes(
+            source_prefix, pfx_first=True,
+        ):
+            for filename in config.upc_credential_files:
+                full = os.path.join(
+                    user_home, config.upc_local_subdir, filename,
+                )
+                if os.path.isfile(full) and os.path.getsize(full) >= _CSS_MIN_SOURCE_SIZE:
+                    rel = os.path.relpath(full, prefix_root)
+                    sources.setdefault(rel, full)
+        return sources
+
+    def sync_auth_artifacts_to_prefix(
+        self, source_prefix: str, target_prefix: str,
+    ) -> int:
+        """Sync auth artifacts to prefix."""
+        sources = self.collect_artifact_sources(source_prefix)
+        return self.sync_payload_to_prefix(
+            source_prefix, target_prefix,
+            payload_sources=sources,
+            apply_dpapi_guard=False,
+            handle_directories=True,
+            log_label='auth_artifacts',
+        )
+
+    def collect_artifact_sources(self, source_prefix: str) -> dict[str, str]:
+        """Collect artifact sources."""
+        config = self._parent._config
+        paths_helper = self._parent._paths
+        sources: dict[str, str] = {}
+        for prefix_root, user_home in paths_helper.iter_user_homes(
+            source_prefix, pfx_first=True,
+        ):
+            for artifact in config.upc_auth_cache_artifacts:
+                full = os.path.join(
+                    user_home, config.upc_local_subdir, artifact,
+                )
+                if os.path.exists(full):
+                    rel = os.path.relpath(full, prefix_root)
+                    sources.setdefault(rel, full)
+        return sources
+
+    @staticmethod
+    def hash_artifact(path: str) -> str:
+        """Hash artifact."""
+        digest = hashlib.sha256()
+        if not os.path.exists(path):
+            return ''
+        try:
+            if os.path.isdir(path):
+                _PayloadSync._hash_directory_into(digest, path)
+            else:
+                _PayloadSync._hash_file_into(digest, path)
+        except OSError:
+            return ''
+        return digest.hexdigest()
+
+    @staticmethod
+    def _hash_directory_into(digest: hashlib._Hash, path: str) -> None:
+        """Hash directory into."""
+        for root, dirs, files in os.walk(path):
+            dirs.sort()
+            for fname in sorted(files):
+                full = os.path.join(root, fname)
+                rel = os.path.relpath(full, path).encode('utf-8')
+                digest.update(rel)
+                _PayloadSync._hash_file_into(digest, full)
+
+    @staticmethod
+    def _hash_file_into(digest: hashlib._Hash, path: str) -> None:
+        """Hash file into."""
+        try:
+            with open(path, 'rb') as f:
+                while True:
+                    chunk = f.read(_HASH_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+        except OSError:
+            pass

--- a/py_modules/unifideck/stores/ubisoft/session/propagator.py
+++ b/py_modules/unifideck/stores/ubisoft/session/propagator.py
@@ -1,5 +1,102 @@
-"""propagator.py — Session propagator
+"""propagator.py — Spread credentials across every Ubisoft prefix.
+
 # OP-60d | py_modules/unifideck/stores/ubisoft/session/propagator.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..config import UbisoftConfig
+    from .payload import _PayloadSync
+    from .reader import _CredentialReader
+
+logger = logging.getLogger(__name__)
+
+
+class _CredentialPropagator:
+    """Credential propagator."""
+
+    def __init__(
+        self, *,
+        config: UbisoftConfig,
+        payload: _PayloadSync,
+        reader: _CredentialReader,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._payload = payload
+        self._reader = reader
+
+    def propagate_credentials_to_all(self) -> int:
+        """Propagate credentials to all."""
+        source = self._reader.find_best_credential_source()
+        if not source:
+            return 0
+        copied = 0
+        for target in self._all_prefixes():
+            if target == source:
+                continue
+            copied += self._payload.sync_credentials_to_prefix(source, target)
+        return copied
+
+    def propagate_auth_artifacts_to_all(self) -> int:
+        """Propagate auth artifacts to all."""
+        source = self._reader.find_best_credential_source()
+        if not source:
+            return 0
+        copied = 0
+        for target in self._all_prefixes():
+            if target == source:
+                continue
+            copied += self._payload.sync_auth_artifacts_to_prefix(
+                source, target,
+            )
+        return copied
+
+    def propagate_all_to_all(self) -> None:
+        """Propagate all to all."""
+        creds = self.propagate_credentials_to_all()
+        artifacts = self.propagate_auth_artifacts_to_all()
+        logger.info(
+            '[Ubisoft.session] propagation: %d creds, %d artifacts',
+            creds, artifacts,
+        )
+
+    def inject_into_prefix(self, prefix_path: str) -> bool:
+        """Inject into prefix."""
+        source = self._reader.find_best_credential_source()
+        if not source or source == prefix_path:
+            return False
+        copied = self._payload.sync_credentials_to_prefix(source, prefix_path)
+        copied += self._payload.sync_auth_artifacts_to_prefix(
+            source, prefix_path,
+        )
+        return copied > 0
+
+    def ensure_auth_state_in_prefixes(self, prefix_paths: list[str]) -> int:
+        """Ensure auth state in prefixes."""
+        injected = 0
+        for prefix in prefix_paths:
+            if self.inject_into_prefix(prefix):
+                injected += 1
+        return injected
+
+    def retroactive_sync(self) -> dict[str, Any]:
+        """Retroactive sync."""
+        creds = self.propagate_credentials_to_all()
+        artifacts = self.propagate_auth_artifacts_to_all()
+        return {
+            'credentials_copied': creds,
+            'artifacts_copied': artifacts,
+            'success': True,
+        }
+
+    def _all_prefixes(self) -> list[str]:
+        """All prefixes."""
+        prefixes = list(self._config.iter_game_prefix_paths())
+        auth = self._config.auth_prefix_dir_expanded
+        if auth and auth not in prefixes:
+            prefixes.append(auth)
+        return prefixes

--- a/py_modules/unifideck/stores/ubisoft/session/reader.py
+++ b/py_modules/unifideck/stores/ubisoft/session/reader.py
@@ -1,5 +1,116 @@
-"""reader.py — Session file reader
+"""reader.py — Locate the freshest UPC credential cache.
+
 # OP-60c | py_modules/unifideck/stores/ubisoft/session/reader.py | Depends: (none)
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..config import UbisoftConfig
+    from ..paths import UbisoftPrefixPaths
+
+_CSS_MIN_VALID_SIZE = 100
+logger = logging.getLogger(__name__)
+
+
+class _CredentialReader:
+    """Credential reader."""
+
+    def __init__(
+        self, *, config: UbisoftConfig, paths: UbisoftPrefixPaths,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._paths = paths
+
+    def has_valid_credentials(self, prefix_path: str) -> bool:
+        """Check whether valid credentials."""
+        for _root, user_home in self._paths.iter_user_homes(
+            prefix_path, pfx_first=True,
+        ):
+            css = self._css_path(user_home)
+            if self._is_valid_css(css, _CSS_MIN_VALID_SIZE):
+                return True
+        return False
+
+    def get_credential_mtime(self, prefix_path: str) -> float:
+        """Get credential mtime."""
+        best = self._best_css_mtime_for_prefix(prefix_path)
+        return best if best is not None else 0.0
+
+    def find_best_credential_source(self) -> str | None:
+        """Find best credential source."""
+        candidates: list[tuple[float, str]] = []
+        for prefix_path in (
+            self._config.iter_game_prefix_paths()
+            + [self._config.auth_prefix_dir_expanded]
+        ):
+            if not os.path.isdir(prefix_path):
+                continue
+            mtime = self._best_css_mtime_for_prefix(prefix_path)
+            if mtime is not None:
+                candidates.append((mtime, prefix_path))
+        if not candidates:
+            best_auth = self._check_auth_prefix_for_credentials()
+            return best_auth
+        candidates.sort(reverse=True)
+        return candidates[0][1]
+
+    def _check_auth_prefix_for_credentials(self) -> str | None:
+        """Check auth prefix for credentials."""
+        auth_prefix = self._config.auth_prefix_dir_expanded
+        if not os.path.isdir(auth_prefix):
+            return None
+        if self.has_valid_credentials(auth_prefix):
+            return auth_prefix
+        return None
+
+    def _find_freshest_game_prefix_credentials(self) -> str | None:
+        """Find freshest game prefix credentials."""
+        best: tuple[float, str] | None = None
+        for prefix_path in self._config.iter_game_prefix_paths():
+            mtime = self._best_css_mtime_for_prefix(prefix_path)
+            if mtime is None:
+                continue
+            if best is None or mtime > best[0]:
+                best = (mtime, prefix_path)
+        return best[1] if best else None
+
+    def _best_css_mtime_for_prefix(self, prefix: str) -> float | None:
+        """Best CSS mtime for prefix."""
+        best: float | None = None
+        for _root, user_home in self._paths.iter_user_homes(
+            prefix, pfx_first=True,
+        ):
+            css = self._css_path(user_home)
+            if not self._is_valid_css(css, _CSS_MIN_VALID_SIZE):
+                continue
+            try:
+                mtime = os.path.getmtime(css)
+            except OSError:
+                continue
+            if best is None or mtime > best:
+                best = mtime
+        return best
+
+    def _css_path(self, user_home: str) -> str:
+        """CSS path."""
+        return os.path.join(
+            user_home,
+            self._config.upc_local_subdir,
+            'ConnectSecureStorage.dat',
+        )
+
+    @staticmethod
+    def _is_valid_css(css_path: str, min_size: int) -> bool:
+        """Check whether valid CSS."""
+        try:
+            return (
+                os.path.isfile(css_path)
+                and os.path.getsize(css_path) >= min_size
+            )
+        except OSError:
+            return False

--- a/py_modules/unifideck/stores/ubisoft/specialists.py
+++ b/py_modules/unifideck/stores/ubisoft/specialists.py
@@ -1,5 +1,155 @@
-"""specialists.py — Ubisoft specialist dispatchers
+"""specialists.py — Compose all Ubisoft sub-systems into one bag.
+
 # OP-55j | py_modules/unifideck/stores/ubisoft/specialists.py | Depends: (none)
+
+The store layer ends up depending on a *lot* of helpers (config,
+paths, binaries, id_map, session, library, installer, prefix manager,
+auth). Threading them all through the constructor would be ugly, so
+we collect them into ``UbisoftSpecialists`` once and pass that in.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from unifideck.stores.ubisoft.auth import (
+    UbisoftAuth,
+    UbisoftAuthServices,
+    UbisoftAuthState,
+)
+from unifideck.stores.ubisoft.binaries import UbisoftBinaryResolver
+from unifideck.stores.ubisoft.config import UbisoftConfig
+from unifideck.stores.ubisoft.id_map import UbisoftIdMap
+from unifideck.stores.ubisoft.installer import UbisoftInstaller
+from unifideck.stores.ubisoft.installer.cache import UbisoftInstallerCache
+from unifideck.stores.ubisoft.library import UbisoftLibrary
+from unifideck.stores.ubisoft.paths import UbisoftPrefixPaths
+from unifideck.stores.ubisoft.prefix import UbisoftPrefixManager
+from unifideck.stores.ubisoft.session import UbisoftSession
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class UbisoftSpecialists:
+    """Ubisoft specialists."""
+
+    config: UbisoftConfig
+    paths: UbisoftPrefixPaths
+    binaries: UbisoftBinaryResolver
+    id_map: UbisoftIdMap
+    session: UbisoftSession
+    installer_cache: UbisoftInstallerCache
+    prefix_mgr: UbisoftPrefixManager
+    library: UbisoftLibrary
+    installer: UbisoftInstaller
+    auth: UbisoftAuth
+
+
+@dataclass(frozen=True)
+class _UbisoftFoundations:
+    """Ubisoft foundations."""
+
+    ubi_config: UbisoftConfig
+    paths: UbisoftPrefixPaths
+    binaries: Any
+    id_map: UbisoftIdMap
+
+
+@dataclass(frozen=True)
+class _UbisoftRuntimeChain:
+    """Ubisoft runtime chain."""
+
+    session: UbisoftSession
+    installer_cache: UbisoftInstallerCache
+    prefix_mgr: UbisoftPrefixManager
+
+
+def _build_ubisoft_foundations(
+    config_mgr: Any, plugin_dir: str | None,
+) -> _UbisoftFoundations:
+    """Build UBISOFT foundations."""
+    ubi_config = UbisoftConfig.from_config_manager(config_mgr)
+    paths = UbisoftPrefixPaths(ubi_config)
+    binaries = UbisoftBinaryResolver(ubi_config, plugin_dir)
+    id_map = UbisoftIdMap(ubi_config, paths)
+    return _UbisoftFoundations(
+        ubi_config=ubi_config, paths=paths, binaries=binaries, id_map=id_map,
+    )
+
+
+def _build_ubisoft_runtime_chain(
+    f: _UbisoftFoundations,
+) -> _UbisoftRuntimeChain:
+    """Build UBISOFT runtime chain."""
+    session = UbisoftSession(
+        config=f.ubi_config, paths=f.paths,
+        read_machine_guid=UbisoftPrefixManager.read_machine_guid,
+    )
+    installer_cache = UbisoftInstallerCache(f.ubi_config)
+    prefix_mgr = UbisoftPrefixManager(
+        config=f.ubi_config, paths=f.paths, binaries=f.binaries,
+        installer_cache=installer_cache,
+        inject_auth_state=session.ensure_auth_state_in_prefixes,
+    )
+    return _UbisoftRuntimeChain(
+        session=session, installer_cache=installer_cache,
+        prefix_mgr=prefix_mgr,
+    )
+
+
+def _build_ubisoft_auth(
+    *, bus: Any, f: _UbisoftFoundations, r: _UbisoftRuntimeChain,
+    plugin_dir: str | None, shortcut_service: Any | None,
+    steamgriddb: Any | None,
+) -> UbisoftAuth:
+    """Build UBISOFT auth."""
+    state = UbisoftAuthState(
+        config=f.ubi_config, paths=f.paths, binaries=f.binaries,
+        session=r.session,
+        ensure_auth_prefix=r.prefix_mgr.ensure_auth_prefix,
+        queue_auth_assets_ensure=r.prefix_mgr.queue_auth_assets_ensure,
+    )
+    services = UbisoftAuthServices(
+        plugin_dir=plugin_dir,
+        shortcut_service=shortcut_service,
+        steamgriddb=steamgriddb,
+    )
+    return UbisoftAuth(bus=bus, state=state, services=services)
+
+
+def build_ubisoft_specialists(
+    *, bus: Any, config_mgr: Any, plugin_dir: str | None,
+    shortcut_service: Any | None, steamgriddb: Any | None,
+) -> UbisoftSpecialists:
+    """Build UBISOFT specialists."""
+    foundations = _build_ubisoft_foundations(config_mgr, plugin_dir)
+    runtime = _build_ubisoft_runtime_chain(foundations)
+    library = UbisoftLibrary(
+        foundations.ubi_config, foundations.paths, foundations.id_map,
+        queue_template_creation=runtime.prefix_mgr.queue_template_creation,
+    )
+    installer = UbisoftInstaller(
+        config=foundations.ubi_config, paths=foundations.paths,
+        binaries=foundations.binaries, id_map=foundations.id_map,
+        session=runtime.session, library=library,
+        bootstrap_game_prefix=runtime.prefix_mgr.bootstrap_game_prefix,
+    )
+    auth = _build_ubisoft_auth(
+        bus=bus, f=foundations, r=runtime,
+        plugin_dir=plugin_dir, shortcut_service=shortcut_service,
+        steamgriddb=steamgriddb,
+    )
+    return UbisoftSpecialists(
+        config=foundations.ubi_config,
+        paths=foundations.paths,
+        binaries=foundations.binaries,
+        id_map=foundations.id_map,
+        session=runtime.session,
+        installer_cache=runtime.installer_cache,
+        prefix_mgr=runtime.prefix_mgr,
+        library=library,
+        installer=installer,
+        auth=auth,
+    )

--- a/py_modules/unifideck/stores/ubisoft/steam_filter.py
+++ b/py_modules/unifideck/stores/ubisoft/steam_filter.py
@@ -1,5 +1,93 @@
-"""steam_filter.py — Ubisoft Steam library filter
+"""steam_filter.py — Drop UPC entries that are sold through Steam.
+
 # OP-55i | py_modules/unifideck/stores/ubisoft/steam_filter.py | Depends: (none)
+
+Some titles in the UPC ``configurations`` cache are Steam-linked
+distributions (third-party platform = Steam). When the user already
+owns them on Steam we don't want to surface them as a separate
+Ubisoft entry. ``steam_library_cross_ref`` overrides this and is used
+to *match* installed Steam titles against UPC entries instead.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from typing import Any
+
+from .id_map import UbisoftIdMap
+
+logger = logging.getLogger(__name__)
+_STEAM_YAML_MARKERS = (
+    'steam_installer:', 'steam_app_id:', 'valve\\\\steam', 'valve\\steam',
+)
+
+
+def filter_steam_linked_configs(
+    configs: list[Any],
+    steam_library_cross_ref_enabled: bool,
+    id_map: UbisoftIdMap,
+) -> list[Any]:
+    """Filter steam linked configs.
+
+    With cross-ref **disabled** (default), drop any GameConfig whose
+    YAML or third_party_platform indicates Steam — those titles are
+    only really playable through Steam.
+
+    With cross-ref **enabled**, keep them so callers can correlate
+    space_id ↔ Steam appid for unified-library views.
+    """
+    if not configs:
+        return []
+    steam_titles = load_steam_titles_for_cross_ref(
+        steam_library_cross_ref_enabled,
+    )
+    out: list[Any] = []
+    for cfg in configs:
+        kind = classify_steam_linked(cfg, steam_titles, id_map)
+        if kind == 'steam' and not steam_library_cross_ref_enabled:
+            continue
+        out.append(cfg)
+    return out
+
+
+def load_steam_titles_for_cross_ref(enabled: bool) -> set[str]:
+    """Load steam titles for cross ref."""
+    if not enabled:
+        return set()
+    try:
+        return UbisoftIdMap.get_steam_library_titles()
+    except Exception as e:
+        logger.warning('[Ubisoft] steam title scrape failed: %s', e)
+        return set()
+
+
+def classify_steam_linked(
+    cfg: Any, steam_titles: set[str], id_map: UbisoftIdMap,
+) -> str | None:
+    """Classify steam linked.
+
+    Returns:
+        'steam' if the config is a Steam-linked variant,
+        'cross_ref' if Steam owns a same-named title (cross-ref),
+        None otherwise.
+    """
+    third_party = getattr(cfg, 'third_party_platform', '') or ''
+    if 'steam' in third_party.lower():
+        return 'steam'
+    yaml_raw = getattr(cfg, 'yaml_raw', '') or ''
+    if yaml_has_steam_markers(yaml_raw):
+        return 'steam'
+    if steam_titles:
+        name = getattr(cfg, 'name', '') or ''
+        if name and id_map.normalize_for_matching(name) in {
+            id_map.normalize_for_matching(t) for t in steam_titles
+        }:
+            return 'cross_ref'
+    return None
+
+
+def yaml_has_steam_markers(yaml_raw: str) -> bool:
+    """YAML has steam markers."""
+    if not yaml_raw:
+        return False
+    text = yaml_raw.lower()
+    return any(marker.lower() in text for marker in _STEAM_YAML_MARKERS)

--- a/py_modules/unifideck/stores/ubisoft/store.py
+++ b/py_modules/unifideck/stores/ubisoft/store.py
@@ -1,5 +1,225 @@
-"""store.py — UbisoftStore main
-# OP-55a | py_modules/unifideck/stores/ubisoft/store.py | Depends: OP-47b
+"""store.py — Public ``UbisoftStore`` (StoreBase implementation).
+
+# OP-55a | py_modules/unifideck/stores/ubisoft/store.py | Depends: (none)
+
+Thin façade over :class:`UbisoftSpecialists` — implements every
+``StoreBase`` abstract method by delegating to one of the helpers.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from ...core.types import (
+    AuthResult,
+    Game,
+    InstallResult,
+    Result,
+    StoreInfo,
+)
+from ..shared.store_base import StoreBase
+from .specialists import build_ubisoft_specialists
+
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+    from ...core.cache_manager import CacheManager
+    from ...event_bus.event_bus import EventBus
+    from ...services.shortcut import ShortcutService
+    from ...steam.steamgriddb import SteamGridDBClient
+    from .auth import UbisoftAuth
+    from .installer import UbisoftInstaller
+    from .library import UbisoftLibrary
+
+logger = logging.getLogger(__name__)
+
+
+class UbisoftStore(StoreBase):
+    """Ubisoft store."""
+
+    store_info = StoreInfo(
+        name='ubisoft',
+        display_name='Ubisoft',
+        auth_method='shortcut',
+        icon_asset='ubisoft.png',
+        uses_wine=True,
+        supports_install=True,
+    )
+
+    def __init__(
+        self,
+        bus: EventBus,
+        cache: CacheManager,
+        plugin_dir: str | None = None,
+        config: ConfigManager | None = None,
+        shortcut_service: ShortcutService | None = None,
+        steamgriddb: SteamGridDBClient | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        super().__init__(bus, cache, plugin_dir, config)
+        self._specialists = build_ubisoft_specialists(
+            bus=bus, config_mgr=config, plugin_dir=plugin_dir,
+            shortcut_service=shortcut_service,
+            steamgriddb=steamgriddb,
+        )
+        logger.info(
+            '[UbisoftStore] %s', self._specialists.config.describe(),
+        )
+
+    @property
+    def _auth(self) -> UbisoftAuth:
+        """Auth shortcut."""
+        return self._specialists.auth
+
+    @property
+    def _library(self) -> UbisoftLibrary:
+        """Library shortcut."""
+        return self._specialists.library
+
+    @property
+    def _installer(self) -> UbisoftInstaller:
+        """Installer shortcut."""
+        return self._specialists.installer
+
+    async def is_available(self) -> bool:
+        """Is available."""
+        result = await self._auth.is_available()
+        self._cached_available = result
+        return result
+
+    async def start_auth(self, **kwargs: Any) -> AuthResult:
+        """Start auth."""
+        return await self._auth.start_auth()
+
+    async def complete_auth(self, code: str = '', **kwargs: Any) -> AuthResult:
+        """Complete auth."""
+        return await self._auth.complete_auth(code, **kwargs)
+
+    async def logout(self) -> Result:
+        """Logout."""
+        return await self._auth.logout()
+
+    async def get_library(self) -> list[Game] | None:
+        """Get library."""
+        try:
+            return await self._library.get_library()
+        except Exception as e:
+            logger.warning('[UbisoftStore] get_library failed: %s', e)
+            return None
+
+    async def install_game(
+        self,
+        game_id: str,
+        *,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        install_path: str | None = None,
+        **kwargs: Any,
+    ) -> InstallResult:
+        """Install game."""
+        return await self._installer.install_game(
+            game_id, progress_cb=progress_cb, install_path=install_path,
+        )
+
+    async def uninstall_game(
+        self, game_id: str, *, delete_prefix: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        """Uninstall game."""
+        return await self._installer.uninstall_game(
+            game_id, delete_prefix=delete_prefix,
+        )
+
+    async def update_game(
+        self, game_id: str, **kwargs: Any,
+    ) -> InstallResult:
+        """Update game."""
+        return await self._installer.update_game(game_id)
+
+    async def check_for_updates(self) -> list[str]:
+        """Check for updates."""
+        return await self._installer.check_for_updates()
+
+    async def get_game_size(self, game_id: str) -> int | None:
+        """Get game size."""
+        info = self.get_installed_game_info(game_id)
+        if not info:
+            return None
+        path = info.get('install_path')
+        if not path:
+            return None
+        from .installer.registry import get_directory_size
+        return get_directory_size(path)
+
+    async def get_installed(self) -> dict[str, Any]:
+        """Get installed."""
+        return await self._library.get_installed()
+
+    def get_installed_game_info(self, game_id: str) -> dict[str, Any] | None:
+        """Get installed game info."""
+        return self._library.get_installed_game_info(game_id)
+
+    async def write_install_marker(
+        self, space_id: str, install_path: str, executable: str,
+        game_title: str = '',
+    ) -> None:
+        """Write install marker."""
+        await self._library.write_install_marker(
+            space_id, install_path, executable, game_title,
+        )
+
+    def find_game_executable(self, install_path: str) -> str | None:
+        """Find game executable."""
+        return self._library.find_game_executable(install_path)
+
+    def is_install_session_active(self, game_id: str) -> bool:
+        """Is install session active."""
+        return self._installer.is_install_session_active(game_id)
+
+    async def cancel_install_session(self, game_id: str) -> Result:
+        """Cancel install session."""
+        return await self._installer.cancel_install_session(game_id)
+
+    async def open_launcher_for_install(self, game_id: str) -> Result:
+        """Open launcher for install."""
+        return await self._installer.open_launcher_for_install(game_id)
+
+    def resolve_install_id(self, space_id: str) -> str | None:
+        """Resolve install ID."""
+        return self._specialists.id_map.resolve_install_id(space_id)
+
+    def resolve_launch_id(self, space_id: str) -> str | None:
+        """Resolve launch ID."""
+        return self._specialists.id_map.resolve_launch_id(space_id)
+
+    async def get_auth_shortcut_context(self) -> dict[str, Any]:
+        """Get auth shortcut context."""
+        return await self._auth.get_auth_shortcut_context()
+
+    async def start_auth_session_monitor(self) -> Result:
+        """Start auth session monitor."""
+        return await self._auth.start_auth_session_monitor()
+
+    def check_auth_session_status(self) -> dict[str, Any]:
+        """Check auth session status."""
+        return self._auth.check_auth_session_status()
+
+    async def connect_ubisoft_account(self) -> dict[str, Any]:
+        """Connect UBISOFT account."""
+        return await self._auth.connect_ubisoft_account()
+
+    def sync_ubisoft_credentials(self) -> dict[str, Any]:
+        """Sync UBISOFT credentials."""
+        return self._specialists.session.retroactive_sync()
+
+    async def repair_prefix(self, space_id: str) -> Result:
+        """Repair prefix."""
+        ok = await self._specialists.prefix_mgr.repair_prefix(space_id)
+        return Result(success=ok)
+
+    def get_game_official_url(self, game_id: str) -> str | None:
+        """Get game official URL."""
+        return self._library.get_game_official_url(game_id)
+
+    def kill_upc_processes(self) -> None:
+        """Kill UPC processes."""
+        self._installer.kill_upc_processes()

--- a/tests/stores/test_store_registry.py
+++ b/tests/stores/test_store_registry.py
@@ -1,0 +1,168 @@
+"""Tests for stores/shared/store_registry.py.
+
+Covers the two layouts ``_iter_store_files`` accepts:
+
+* Flat: ``stores/<name>_store.py``
+* Subpackage: ``stores/<name>/store.py``
+
+Plus the security guards (symlinks, ``_``-prefixed names) and the
+auto-discovery happy-path that combines them.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from unifideck.stores.shared.store_registry import StoreRegistry
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+_FLAT_STORE = """\
+from unifideck.core.types import StoreInfo
+from unifideck.stores.shared.store_base import StoreBase
+
+
+class FlatStore(StoreBase):
+    store_info = StoreInfo(
+        name="flat",
+        display_name="Flat",
+        auth_method="manual",
+        icon_asset="",
+    )
+
+    async def is_available(self):
+        return False
+
+    async def start_auth(self, **kwargs):
+        return None
+
+    async def complete_auth(self, **kwargs):
+        return None
+
+    async def logout(self):
+        return None
+
+    async def get_library(self):
+        return []
+
+    async def install_game(self, game_id, **kwargs):
+        return None
+
+    async def uninstall_game(self, game_id, **kwargs):
+        return None
+
+    async def update_game(self, game_id, **kwargs):
+        return None
+
+    async def check_for_updates(self):
+        return []
+
+    async def get_game_size(self, game_id):
+        return None
+"""
+
+
+@pytest.fixture
+def stores_dir(tmp_path: Path) -> Path:
+    """Create a stores/ directory with both layouts."""
+    stores = tmp_path / "stores"
+    stores.mkdir()
+    _write(stores / "__init__.py", "")
+    return stores
+
+
+def _suffixes(stores: Path) -> list[str]:
+    return [suf for suf, _ in StoreRegistry._iter_store_files(str(stores))]
+
+
+def test_iter_finds_flat_store_files(stores_dir: Path) -> None:
+    _write(stores_dir / "flat_store.py", "x = 1\n")
+    _write(stores_dir / "another_store.py", "x = 1\n")
+    suffixes = _suffixes(stores_dir)
+    assert "flat_store" in suffixes
+    assert "another_store" in suffixes
+
+
+def test_iter_finds_subpackage_store_files(stores_dir: Path) -> None:
+    pkg = stores_dir / "ubisoft"
+    _write(pkg / "__init__.py", "")
+    _write(pkg / "store.py", "x = 1\n")
+    suffixes = _suffixes(stores_dir)
+    assert "ubisoft.store" in suffixes
+
+
+def test_iter_yields_both_layouts_together(stores_dir: Path) -> None:
+    _write(stores_dir / "flat_store.py", "x = 1\n")
+    pkg = stores_dir / "epic"
+    _write(pkg / "__init__.py", "")
+    _write(pkg / "store.py", "x = 1\n")
+    suffixes = _suffixes(stores_dir)
+    assert set(suffixes) == {"flat_store", "epic.store"}
+
+
+def test_iter_skips_subpackage_without_store_py(stores_dir: Path) -> None:
+    pkg = stores_dir / "shared"
+    _write(pkg / "__init__.py", "")
+    _write(pkg / "helpers.py", "x = 1\n")
+    suffixes = _suffixes(stores_dir)
+    assert suffixes == []
+
+
+def test_iter_skips_underscore_prefixed_entries(stores_dir: Path) -> None:
+    _write(stores_dir / "_private_store.py", "x = 1\n")
+    pkg = stores_dir / "_hidden"
+    _write(pkg / "__init__.py", "")
+    _write(pkg / "store.py", "x = 1\n")
+    assert _suffixes(stores_dir) == []
+
+
+def test_iter_ignores_nested_files_below_one_level(stores_dir: Path) -> None:
+    """Only ``<pkg>/store.py`` counts — deeper ``store.py`` files
+    inside sub-subpackages must not be yielded (e.g. ``ubisoft/auth/store.py``
+    would be a misnamed support file, not a registrable store)."""
+    pkg = stores_dir / "ubisoft"
+    _write(pkg / "__init__.py", "")
+    _write(pkg / "auth" / "__init__.py", "")
+    _write(pkg / "auth" / "store.py", "x = 1\n")
+    assert _suffixes(stores_dir) == []
+
+
+def test_iter_skips_symlinked_flat_store(stores_dir: Path, tmp_path: Path) -> None:
+    real = tmp_path / "real_store.py"
+    real.write_text("x = 1\n")
+    link = stores_dir / "real_store.py"
+    os.symlink(real, link)
+    assert _suffixes(stores_dir) == []
+
+
+def test_iter_skips_symlinked_subpackage_store_py(
+    stores_dir: Path, tmp_path: Path,
+) -> None:
+    pkg = stores_dir / "ubisoft"
+    _write(pkg / "__init__.py", "")
+    real = tmp_path / "real_store.py"
+    real.write_text("x = 1\n")
+    os.symlink(real, pkg / "store.py")
+    assert _suffixes(stores_dir) == []
+
+
+def test_load_store_class_swallows_import_errors() -> None:
+    """A non-existent dotted suffix must return ``None`` rather than
+    raise — this is what lets ``auto_discover`` keep going when one
+    store has a broken import chain instead of failing the whole
+    plugin boot."""
+    from unifideck.stores.shared.store_base import StoreBase
+
+    missing = StoreRegistry._load_store_class(
+        "unifideck.stores",
+        "does_not_exist.store",
+        "<unused>",
+        StoreBase,
+    )
+    assert missing is None


### PR DESCRIPTION
# Ubisoft implementation: done


*   **Phase 0 (foundational)**: [store_registry.py](file:///home/deck/Documents/Projects/unifideck-main/unifideck-decky/py_modules/unifideck/stores/shared/store_registry.py) extended to recurse into store subpackages, with 9 unit tests in [test_store_registry.py](file:///home/deck/Documents/Projects/unifideck-main/unifideck-decky/tests/stores/test_store_registry.py) (all passing). Also fixed a pre-existing import bug in [store_base.py](file:///home/deck/Documents/Projects/unifideck-main/unifideck-decky/py_modules/unifideck/stores/shared/store_base.py) (`core.bin` → `core.binaries`) that was blocking the registry from loading at all.
*   **41 Ubisoft files under `py_modules/unifideck/stores/ubisoft/`**, all with PDF-faithful signatures and bodies ported from `staging:py_modules/unifideck/stores/ubisoft.py` (5,166 lines), `ubisoft_api.py` (900), and `ubisoft_parser.py` (400):
    *   **OP-55 root (10)**: config, paths, binaries, parser, parser_binary, id_map, id_map_sources, steam_filter, specialists, store
    *   **OP-56 installer (8)**: installer, cache, launch_env, launcher, manual_ui, registry, uninstall, update_op
    *   **OP-57 library (9)**: facade, fetch, data_loader, game_builder, manifest, detection, detection_cascade, detection_helpers, wine_path
    *   **OP-58 auth (6)**: facade, context, shortcut, session_monitor, direct_signin, shortcut_ops
    *   **OP-59 prefix (4)**: manager, helpers, template_builder, auth_builder
    *   **OP-60 session (4)**: facade, payload, reader, propagator
    *   All `__init__.py` files updated to re-export per the PDF.
*   **Wiring**: `services/bootstrap/store_injector.py` now injects `_shortcut_service` into the Ubisoft store after auto-discovery.

## Validation

*   `python -m pytest tests/stores/` → 9/9 pass.
*   **Full suite**: 189 pass, 2 unrelated pre-existing failures (one syntax error in `launcher/types/context.py`, one import in `test_metadata.py`).
*   **Auto-discovery smoke**: `StoreRegistry.auto_discover(...)` returns `['ubisoft']` — the new registry recursion picks up the subpackage.
*   **Import smoke**: `import unifideck.stores.ubisoft` resolves cleanly; `UbisoftStore` instantiates with `store_info(name='ubisoft', auth_method='shortcut', uses_wine=True, supports_install=True)`.
*   **Ruff**: 59 remaining lints, all stylistic (BLE001 broad-except is the project convention for store resilience; D100/D104 missing docstrings; S310 url-audit on whitelisted URLs). Zero F841/B007/B-class issues.
