### PR TITLE
Feat: Implement GOG

### DIFF
--- a/py_modules/unifideck/services/bootstrap/store_injector.py
+++ b/py_modules/unifideck/services/bootstrap/store_injector.py
@@ -34,7 +34,9 @@ _STORE_INJECTIONS: dict[str, tuple[tuple[str, str], ...]] = {
     "ubisoft": (
         ("_shortcut_service", "shortcut"),
     ),
-    # Future: "gog": (("_cloud_save", "cloudsave"), ...)
+    "gog": (
+        ("_browser_monitor", "oauth_browser_monitor"),
+    ),
 }
 
 

--- a/py_modules/unifideck/stores/gog/__init__.py
+++ b/py_modules/unifideck/stores/gog/__init__.py
@@ -1,2 +1,4 @@
 # OP-50 | stores/gog/__init__.py | Depends: OP-50a
-from __future__ import annotations
+from .store import GOGStore
+
+__all__ = ['GOGStore']

--- a/py_modules/unifideck/stores/gog/auth.py
+++ b/py_modules/unifideck/stores/gog/auth.py
@@ -1,5 +1,114 @@
-"""auth.py — GOG OAuth flow
+"""auth.py — Browser-mediated OAuth for GOG Galaxy.
+
 # OP-50h | py_modules/unifideck/stores/gog/auth.py | Depends: OP-47b
+
+GOG uses the Galaxy desktop-client OAuth flow: we open the user's
+browser to the auth URL with a redirect to ``embed.gog.com`` which the
+:class:`AuthOrchestrator` watches via CDP. On redirect we extract the
+``code`` query-param, hand it to :class:`GOGTokenManager.exchange_code`
+which mints access + refresh tokens.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import urllib.parse
+from typing import Any
+
+from ...auth.orchestrator import AuthOrchestrator
+from ...core.types import AuthResult, Events, Result
+from ...event_bus.event_bus import EventBus
+from ...security import audit_auth_flow
+from .config import GOG_AUTH_URL_FILE, GOGConfig
+from .tokens import GOGTokenManager
+
+logger = logging.getLogger(__name__)
+_GOG_COOKIE_DOMAIN = 'gog.com'
+
+
+class GOGBrowserAuth:
+    """GOG browser auth."""
+
+    def __init__(
+        self,
+        bus: EventBus,
+        orchestrator: AuthOrchestrator,
+        tokens: GOGTokenManager,
+        config: GOGConfig,
+    ) -> None:
+        """Initialize the instance."""
+        self._bus = bus
+        self._orchestrator = orchestrator
+        self._tokens = tokens
+        self._config = config
+
+    @audit_auth_flow(store='gog', method='oauth_browser')
+    async def start_auth(self) -> AuthResult:
+        """Start auth."""
+        url = await self._build_auth_url()
+        if not url:
+            return AuthResult(
+                success=False, store='gog', error='auth_config_invalid',
+            )
+        try:
+            self._write_url_hint(url)
+        except OSError as e:
+            logger.debug('[GOGAuth] url hint write: %s', e)
+        await self._orchestrator.start_browser_auth(
+            url=url,
+            allowed_redirect_uris=self._config.allowed_redirect_uris,
+            cookie_domain=_GOG_COOKIE_DOMAIN,
+            on_code=self._exchange_code,
+            store='gog',
+        )
+        return AuthResult(
+            success=True, store='gog', redirect_url=url,
+        )
+
+    async def _build_auth_url(self) -> str:
+        """Build auth URL."""
+        if not self._config.auth_url or not self._config.client_id:
+            return ''
+        params = {
+            'client_id': self._config.client_id,
+            'redirect_uri': self._config.redirect_uri,
+            'response_type': 'code',
+            'layout': 'galaxy',
+        }
+        return f'{self._config.auth_url}?{urllib.parse.urlencode(params)}'
+
+    @staticmethod
+    def _write_url_hint(url: str) -> None:
+        """Write URL hint."""
+        import os
+        path = os.path.expanduser(GOG_AUTH_URL_FILE)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(url + '\n')
+
+    async def _exchange_code(self, code: str) -> AuthResult:
+        """Exchange code."""
+        if not code:
+            return AuthResult(
+                success=False, store='gog', error='no_auth_code',
+            )
+        ok = await self._tokens.exchange_code(code)
+        if not ok:
+            await self._bus.emit(
+                Events.STORE_AUTH_FAILED, store='gog', error='exchange_failed',
+            )
+            return AuthResult(
+                success=False, store='gog', error='exchange_failed',
+            )
+        await self._bus.emit(Events.STORE_AUTH_SUCCESS, store='gog')
+        return AuthResult(success=True, store='gog')
+
+    async def logout(self, browser_monitor: Any | None = None) -> Result:
+        """Logout."""
+        await self._tokens.clear()
+        if browser_monitor is not None:
+            try:
+                await browser_monitor.clear_cookies(_GOG_COOKIE_DOMAIN)
+            except Exception as e:
+                logger.debug('[GOGAuth] cookie clear: %s', e)
+        await self._bus.emit(Events.STORE_LOGOUT, store='gog')
+        return Result(success=True)

--- a/py_modules/unifideck/stores/gog/config.py
+++ b/py_modules/unifideck/stores/gog/config.py
@@ -1,5 +1,114 @@
-"""config.py — GOG config reader
+"""config.py — Frozen ``GOGConfig`` value-object.
+
 # OP-50b | py_modules/unifideck/stores/gog/config.py | Depends: (none)
+
+OAuth credentials default to empty strings; deployments inject the
+real client_id / client_secret via the user's ``stores.gog.*`` config
+overrides. ``is_valid()`` returns True only when both are populated.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from unifideck.utils.config_helpers import get_cfg
+
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+
+logger = logging.getLogger(__name__)
+_GOG_CONFIG_PREFIX = 'stores.gog'
+_DEFAULT_TOKEN_FILE = '~/.config/unifideck/gog_token.json'
+_DEFAULT_GOGDL_CONFIG_DIR = '~/.config/unifideck/gogdl'
+_DEFAULT_DOWNLOAD_DIR = '~/GOG Games'
+GOG_AUTH_URL_FILE = '~/.local/share/unifideck/gog_auth_url.txt'
+
+
+@dataclass(frozen=True)
+class GOGConfig:
+    """GOG config."""
+
+    client_id: str = ''
+    client_secret: str = ''
+    auth_url: str = ''
+    token_url: str = ''
+    redirect_uri: str = ''
+    allowed_redirect_uris: list[str] = field(default_factory=list)
+    base_url: str = ''
+    api_gog_url: str = ''
+    token_file: str = _DEFAULT_TOKEN_FILE
+    gogdl_config_dir: str = _DEFAULT_GOGDL_CONFIG_DIR
+    download_dir: str = _DEFAULT_DOWNLOAD_DIR
+    token_refresh_threshold_seconds: int = 2400
+    supported_languages: list[str] = field(
+        default_factory=lambda: [
+            'en', 'de', 'fr', 'pl', 'ru', 'pt', 'es', 'it', 'zh', 'ko', 'ja',
+        ],
+    )
+    user_agent: str = 'Unifideck/1.0'
+
+    @classmethod
+    def from_config_manager(
+        cls, config: ConfigManager | None,
+    ) -> GOGConfig:
+        """From config manager."""
+
+        def _str(key: str, default: str) -> str:
+            value = get_cfg(config, f'{_GOG_CONFIG_PREFIX}.{key}', default)
+            return str(value) if value is not None else default
+
+        def _int(key: str, default: int) -> int:
+            value = get_cfg(config, f'{_GOG_CONFIG_PREFIX}.{key}', default)
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        def _list(key: str, default: list[str]) -> list[str]:
+            value = get_cfg(config, f'{_GOG_CONFIG_PREFIX}.{key}', default)
+            if isinstance(value, (list, tuple)):
+                return [str(v) for v in value]
+            return list(default)
+
+        return cls(
+            client_id=_str('client_id', ''),
+            client_secret=_str('client_secret', ''),
+            auth_url=_str('auth_url', ''),
+            token_url=_str('token_url', ''),
+            redirect_uri=_str('redirect_uri', ''),
+            allowed_redirect_uris=_list('allowed_redirect_uris', []),
+            base_url=_str('base_url', ''),
+            api_gog_url=_str('api_gog_url', ''),
+            token_file=_str('token_file', _DEFAULT_TOKEN_FILE),
+            gogdl_config_dir=_str(
+                'gogdl_config_dir', _DEFAULT_GOGDL_CONFIG_DIR,
+            ),
+            download_dir=_str('download_dir', _DEFAULT_DOWNLOAD_DIR),
+            token_refresh_threshold_seconds=_int(
+                'token_refresh_threshold_seconds', 2400,
+            ),
+            supported_languages=_list(
+                'supported_languages',
+                ['en', 'de', 'fr', 'pl', 'ru', 'pt', 'es', 'it', 'zh', 'ko', 'ja'],
+            ),
+            user_agent=_str('user_agent', 'Unifideck/1.0'),
+        )
+
+    def is_valid(self) -> bool:
+        """Is valid."""
+        return bool(self.client_id and self.client_secret)
+
+    @property
+    def auth_config_path(self) -> str:
+        """Auth config path."""
+        return os.path.expanduser(GOG_AUTH_URL_FILE)
+
+    def describe(self) -> str:
+        """Describe."""
+        return (
+            f'GOGConfig(token_file={os.path.expanduser(self.token_file)}, '
+            f'download_dir={os.path.expanduser(self.download_dir)}, '
+            f'valid={self.is_valid()})'
+        )

--- a/py_modules/unifideck/stores/gog/dlc.py
+++ b/py_modules/unifideck/stores/gog/dlc.py
@@ -1,5 +1,232 @@
-"""dlc.py — GOG DLC handling
+"""dlc.py — Probe / install DLC via gogdl.
+
 # OP-50f | py_modules/unifideck/stores/gog/dlc.py | Depends: OP-50c
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import contextlib
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from ...core.types import Result
+from .config import GOGConfig
+from .http import fetch_json_get
+from .tokens import GOGTokenManager
+
+logger = logging.getLogger(__name__)
+_LANGUAGE_FALLBACK = ['en-US']
+_LANG_PROBE_TIMEOUT_S = 30.0
+
+
+class GOGDlcManager:
+    """GOG DLC manager."""
+
+    def __init__(
+        self,
+        config: GOGConfig,
+        tokens: GOGTokenManager,
+        gogdl_bin: str,
+        locale_fn: Callable[[], str],
+        resolve_install_path: Callable[[str], dict[str, str | None] | None],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._tokens = tokens
+        self._gogdl_bin = gogdl_bin
+        self._locale_fn = locale_fn
+        self._resolve_install_path = resolve_install_path
+
+    async def get_game_dlcs(self, game_id: str) -> list[dict[str, Any]]:
+        """Get game DLCs."""
+        if not self._config.api_gog_url:
+            return []
+        url = f'{self._config.api_gog_url}/products/{game_id}?expand=expanded_dlcs'
+        data = await self._http_get_json(url, bearer=self._tokens.access_token)
+        if not isinstance(data, dict):
+            return []
+        expanded = data.get('expanded_dlcs') or []
+        if not isinstance(expanded, list):
+            return []
+        out: list[dict[str, Any]] = []
+        for dlc in expanded:
+            if not isinstance(dlc, dict):
+                continue
+            out.append({
+                'id': str(dlc.get('id', '')),
+                'title': dlc.get('title', ''),
+                'slug': dlc.get('slug', ''),
+            })
+        return out
+
+    async def get_available_languages(self, game_id: str) -> list[str]:
+        """Get available languages."""
+        stdout = await self._spawn_lang_probe(game_id)
+        if stdout is None:
+            return list(_LANGUAGE_FALLBACK)
+        languages = self._parse_languages_from_info(stdout)
+        return languages or list(_LANGUAGE_FALLBACK)
+
+    async def _spawn_lang_probe(self, game_id: str) -> bytes | None:
+        """Spawn lang probe."""
+        if not self._gogdl_bin:
+            return None
+        try:
+            async with self._tokens.gogdl_credentials() as env:
+                proc = await asyncio.create_subprocess_exec(
+                    self._gogdl_bin, 'info', game_id, '--os', 'windows',
+                    env={**env},
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                try:
+                    stdout, _err = await asyncio.wait_for(
+                        proc.communicate(), timeout=_LANG_PROBE_TIMEOUT_S,
+                    )
+                except TimeoutError:
+                    with contextlib.suppress(ProcessLookupError):
+                        proc.terminate()
+                    return None
+                return stdout if proc.returncode == 0 else None
+        except Exception as e:
+            logger.debug('[GOGDlc] lang probe: %s', e)
+            return None
+
+    @staticmethod
+    def _parse_languages_from_info(stdout: bytes) -> list[str]:
+        """Parse languages from info."""
+        try:
+            text = stdout.decode('utf-8', errors='replace')
+        except Exception:
+            return []
+        for line in text.splitlines():
+            if not line.strip().startswith('{'):
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            langs = data.get('languages') if isinstance(data, dict) else None
+            if isinstance(langs, list):
+                return [str(l) for l in langs]
+        return []
+
+    async def install_dlc(
+        self,
+        game_id: str,
+        dlc_id: str,
+        base_path: str | None = None,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    ) -> Result:
+        """Install DLC."""
+        preflight = await self._dlc_preflight()
+        if preflight is not None:
+            return preflight
+        path = self._dlc_resolve_base_path(game_id, base_path)
+        lang = self._locale_fn() or 'en-US'
+        proc = await self._dlc_spawn_gogdl(dlc_id, path, lang)
+        if proc is None:
+            return Result(success=False, error='gogdl_spawn_failed')
+        await self._dlc_read_loop(proc, dlc_id, progress_cb)
+        return await self._dlc_finalize(proc, dlc_id)
+
+    async def _dlc_preflight(self) -> Result | None:
+        """DLC preflight."""
+        if not self._gogdl_bin:
+            return Result(success=False, error='gogdl_not_found')
+        if not await self._tokens.refresh_if_stale():
+            return Result(success=False, error='no_tokens')
+        return None
+
+    def _dlc_resolve_base_path(
+        self, game_id: str, base_path: str | None,
+    ) -> str:
+        """DLC resolve base path."""
+        if base_path:
+            return base_path
+        info = self._resolve_install_path(game_id) or {}
+        path = info.get('install_path') if isinstance(info, dict) else None
+        return path or ''
+
+    async def _dlc_spawn_gogdl(
+        self, dlc_id: str, base_path: str, lang: str,
+    ) -> asyncio.subprocess.Process | None:
+        """DLC spawn GOGDL."""
+        if not base_path:
+            return None
+        try:
+            async with self._tokens.gogdl_credentials() as env:
+                return await asyncio.create_subprocess_exec(
+                    self._gogdl_bin, 'download',
+                    dlc_id, '--platform', 'windows',
+                    '--path', base_path, '--lang', lang,
+                    env={**env},
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+        except OSError as e:
+            logger.warning('[GOGDlc] spawn failed: %s', e)
+            return None
+
+    async def _dlc_read_loop(
+        self,
+        proc: asyncio.subprocess.Process,
+        dlc_id: str,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> None:
+        """DLC read loop."""
+        if proc.stdout is None:
+            return
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+            text = line.decode('utf-8', errors='replace').strip()
+            await self._forward_dlc_progress(text, dlc_id, progress_cb)
+
+    async def _dlc_finalize(
+        self, proc: asyncio.subprocess.Process, dlc_id: str,
+    ) -> Result:
+        """DLC finalize."""
+        rc = await proc.wait()
+        if rc != 0:
+            return Result(success=False, error=f'gogdl_rc:{rc}')
+        return Result(success=True, data={'dlc_id': dlc_id})
+
+    @staticmethod
+    async def _forward_dlc_progress(
+        line_str: str,
+        dlc_id: str,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> None:
+        """Forward DLC progress."""
+        if progress_cb is None or not line_str:
+            return
+        await progress_cb({'phase': 'dlc', 'dlc_id': dlc_id, 'line': line_str})
+
+    async def get_game_store_url(self, game_id: str) -> str | None:
+        """Get game store URL."""
+        if not self._config.api_gog_url:
+            return None
+        url = f'{self._config.api_gog_url}/products/{game_id}'
+        data = await self._http_get_json(url, bearer=None)
+        if isinstance(data, dict):
+            slug = data.get('slug')
+            if isinstance(slug, str) and slug:
+                return f'https://www.gog.com/game/{slug}'
+        return None
+
+    async def _http_get_json(
+        self, url: str, bearer: str | None,
+    ) -> Any | None:
+        """HTTP get JSON."""
+        return await fetch_json_get(
+            url,
+            bearer=bearer,
+            user_agent=self._config.user_agent,
+            log_prefix='[GOGDlc]',
+        )
+
+

--- a/py_modules/unifideck/stores/gog/exe_resolver.py
+++ b/py_modules/unifideck/stores/gog/exe_resolver.py
@@ -1,5 +1,230 @@
-"""exe_resolver.py — GOG exe resolver
+"""exe_resolver.py — Find the playable executable inside a GOG install.
+
 # OP-50e | py_modules/unifideck/stores/gog/exe_resolver.py | Depends: OP-04c
+
+GOG installs end up with a mix of installer leftovers (vcredist, dxsetup),
+wrapper launchers (dosbox.exe, scummvm.exe), and the actual game .exe.
+The resolver prefers the explicit ``primaryTask`` from a ``goggame-*.info``
+manifest, then falls back to a ``start.sh`` script, then to the largest
+non-skip .exe in the tree.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import glob
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+_SKIP_EXE_PATTERNS = (
+    'unins', 'setup', 'install', 'crash', 'redist', 'vcredist',
+    'vc_redist', 'dxsetup', 'physx', 'dotnet', 'directx',
+)
+_ROOT_DATA_EXTENSIONS = ('.arch05', '.forge')
+_WRAPPER_EXE_NAMES = {'dosbox.exe', 'scummvm.exe'}
+
+
+class GOGExeResolver:
+    """GOG exe resolver."""
+
+    def find(self, install_path: str) -> str | None:
+        """Find."""
+        result = self._resolve(install_path)
+        return result[0] if result else None
+
+    def find_with_workdir(self, install_path: str) -> tuple[str, str] | None:
+        """Find with workdir."""
+        return self._resolve(install_path)
+
+    def _resolve(self, install_path: str) -> tuple[str, str] | None:
+        """Resolve."""
+        if not install_path or not os.path.isdir(install_path):
+            return None
+        search_dirs = self._build_search_dirs(install_path)
+        result = self._resolve_via_goggame_info(install_path, search_dirs)
+        if result:
+            return result
+        result = self._resolve_via_start_sh(search_dirs)
+        if result:
+            return result
+        return self._resolve_via_largest_exe(search_dirs)
+
+    @staticmethod
+    def _build_search_dirs(install_path: str) -> list[str]:
+        """Build search dirs."""
+        dirs = [install_path]
+        for entry in ('game', 'bin'):
+            sub = os.path.join(install_path, entry)
+            if os.path.isdir(sub):
+                dirs.append(sub)
+        try:
+            for entry in sorted(os.listdir(install_path)):
+                full = os.path.join(install_path, entry)
+                if os.path.isdir(full) and full not in dirs:
+                    dirs.append(full)
+        except OSError:
+            pass
+        return dirs
+
+    def _resolve_via_goggame_info(
+        self, install_path: str, search_dirs: list[str],
+    ) -> tuple[str, str] | None:
+        """Resolve via goggame info."""
+        primary, root_dir = self._load_primary_play_task(search_dirs)
+        if not primary:
+            return None
+        return self._resolve_play_task_paths(install_path, root_dir, primary)
+
+    def _load_primary_play_task(
+        self, search_dirs: list[str],
+    ) -> tuple[dict[str, Any] | None, str]:
+        """Load primary play task."""
+        info, root_dir = self._find_goggame_info(search_dirs)
+        if info is None:
+            return None, ''
+        play_tasks = info.get('playTasks') or []
+        if not isinstance(play_tasks, list):
+            return None, root_dir
+        for task in play_tasks:
+            if not isinstance(task, dict):
+                continue
+            if task.get('isPrimary') or task.get('isPrimaryTask'):
+                return task, root_dir
+        return (play_tasks[0] if play_tasks else None), root_dir
+
+    def _resolve_play_task_paths(
+        self, install_path: str, root_dir: str, primary: dict[str, Any],
+    ) -> tuple[str, str] | None:
+        """Resolve play task paths."""
+        rel = primary.get('path') or ''
+        workdir_rel = primary.get('workingDir') or ''
+        if not isinstance(rel, str):
+            return None
+        base = root_dir or install_path
+        exe_path = os.path.normpath(os.path.join(base, rel))
+        if not os.path.isfile(exe_path):
+            return None
+        wrapper = self._check_wrapper_override(install_path, base, primary)
+        if wrapper:
+            return wrapper
+        if isinstance(workdir_rel, str) and workdir_rel:
+            workdir = os.path.normpath(os.path.join(base, workdir_rel))
+        else:
+            workdir = os.path.dirname(exe_path)
+        return exe_path, workdir
+
+    @staticmethod
+    def _find_goggame_info(
+        search_dirs: list[str],
+    ) -> tuple[dict[str, Any] | None, str]:
+        """Find goggame info."""
+        for dirpath in search_dirs:
+            for match in glob.glob(os.path.join(dirpath, 'goggame-*.info')):
+                try:
+                    with open(match, encoding='utf-8') as f:
+                        data = json.load(f)
+                    if isinstance(data, dict):
+                        return data, dirpath
+                except (OSError, json.JSONDecodeError):
+                    continue
+        return None, ''
+
+    def _check_wrapper_override(
+        self, install_path: str, root_dir: str, primary_task: dict[str, Any],
+    ) -> tuple[str, str] | None:
+        """Check wrapper override."""
+        if not self._has_root_data_files(install_path):
+            return None
+        rel = (primary_task.get('path') or '').lower()
+        for wrapper in _WRAPPER_EXE_NAMES:
+            if wrapper in rel:
+                full = os.path.normpath(os.path.join(root_dir, rel))
+                if os.path.isfile(full):
+                    return full, os.path.dirname(full)
+        return None
+
+    @staticmethod
+    def _has_root_data_files(install_path: str) -> bool:
+        """Has root data files."""
+        try:
+            for name in os.listdir(install_path):
+                if name.lower().endswith(_ROOT_DATA_EXTENSIONS):
+                    return True
+        except OSError:
+            pass
+        return False
+
+    @staticmethod
+    def _resolve_via_start_sh(
+        search_dirs: list[str],
+    ) -> tuple[str, str] | None:
+        """Resolve via start sh."""
+        for dirpath in search_dirs:
+            path = os.path.join(dirpath, 'start.sh')
+            if os.path.isfile(path):
+                return path, dirpath
+        return None
+
+    @staticmethod
+    def _resolve_via_largest_exe(
+        search_dirs: list[str],
+    ) -> tuple[str, str] | None:
+        """Resolve via largest exe."""
+        best: tuple[int, str] | None = None
+        for dirpath in search_dirs:
+            try:
+                for root, _dirs, files in os.walk(dirpath):
+                    depth = root[len(dirpath):].count(os.sep)
+                    if depth >= 3:
+                        continue
+                    for name in files:
+                        lower = name.lower()
+                        if not lower.endswith('.exe'):
+                            continue
+                        if any(p in lower for p in _SKIP_EXE_PATTERNS):
+                            continue
+                        full = os.path.join(root, name)
+                        try:
+                            size = os.path.getsize(full)
+                        except OSError:
+                            continue
+                        if best is None or size > best[0]:
+                            best = (size, full)
+            except OSError:
+                continue
+        if best is None:
+            return None
+        path = best[1]
+        return path, os.path.dirname(path)
+
+
+def parse_size_string(size_str: str) -> int:
+    """Parse size string."""
+    if not size_str:
+        return 0
+    s = size_str.strip().upper()
+    multipliers = {'KB': 1024, 'MB': 1024 ** 2, 'GB': 1024 ** 3, 'TB': 1024 ** 4}
+    for suffix, mult in multipliers.items():
+        if s.endswith(suffix):
+            try:
+                return int(float(s[:-len(suffix)].strip()) * mult)
+            except ValueError:
+                return 0
+    try:
+        return int(float(s))
+    except ValueError:
+        return 0
+
+
+def get_game_id_from_goggame_filename(filename: str) -> str | None:
+    """Get game ID from goggame filename."""
+    name = Path(filename).name
+    if not name.startswith('goggame-'):
+        return None
+    if name.endswith('.info'):
+        return name[len('goggame-'):-len('.info')]
+    if name.endswith('.script'):
+        return name[len('goggame-'):-len('.script')]
+    return None

--- a/py_modules/unifideck/stores/gog/http.py
+++ b/py_modules/unifideck/stores/gog/http.py
@@ -1,5 +1,63 @@
-"""http.py — GOG HTTP client
+"""http.py — Async wrappers over GOG REST endpoints.
+
 # OP-50i | py_modules/unifideck/stores/gog/http.py | Depends: OP-08a
+
+Pure-stdlib HTTP helpers used by every GOG module that doesn't go
+through ``gogdl``. We deliberately bypass aiohttp here to keep the
+GOG package import-light and to share the project-wide strict SSL
+context (see :mod:`unifideck.core.net`).
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import json
+import logging
+import ssl
+import urllib.request
+from collections.abc import Mapping
+from typing import Any
+
+from ...core.net import ssl_ctx_strict
+
+_logger = logging.getLogger(__name__)
+
+
+def build_ssl_context() -> ssl.SSLContext:
+    """Build SSL context."""
+    return ssl_ctx_strict()
+
+
+async def fetch_json_get(
+    url: str,
+    *,
+    bearer: str | None = None,
+    user_agent: str = '',
+    timeout: float = 15.0,
+    extra_headers: Mapping[str, str] | None = None,
+    log_prefix: str = '[GOGHttp]',
+) -> Any | None:
+    """Fetch JSON get."""
+    headers: dict[str, str] = {'Accept': 'application/json'}
+    if bearer:
+        headers['Authorization'] = f'Bearer {bearer}'
+    if user_agent:
+        headers['User-Agent'] = user_agent
+    if extra_headers:
+        headers.update(extra_headers)
+    req = urllib.request.Request(url, headers=headers)
+    ctx = build_ssl_context()
+
+    def _do_request() -> Any | None:
+        try:
+            with urllib.request.urlopen(req, context=ctx, timeout=timeout) as resp:
+                raw = resp.read()
+        except Exception as e:
+            _logger.warning('%s GET %s failed: %s', log_prefix, url, e)
+            return None
+        try:
+            return json.loads(raw.decode('utf-8'))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            _logger.warning('%s JSON decode %s: %s', log_prefix, url, e)
+            return None
+
+    return await asyncio.to_thread(_do_request)

--- a/py_modules/unifideck/stores/gog/install/__init__.py
+++ b/py_modules/unifideck/stores/gog/install/__init__.py
@@ -1,0 +1,4 @@
+# OP-51 | stores/gog/install/__init__.py
+from .installer import GOGInstaller
+
+__all__ = ['GOGInstaller']

--- a/py_modules/unifideck/stores/gog/install/helpers.py
+++ b/py_modules/unifideck/stores/gog/install/helpers.py
@@ -1,0 +1,117 @@
+"""helpers.py — Language probe + picker for the install pipeline.
+
+# OP-51h | py_modules/unifideck/stores/gog/install/helpers.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from .languages import smart_match_language
+
+if TYPE_CHECKING:
+    from .installer import GOGInstaller
+
+logger = logging.getLogger(__name__)
+_LANG_PROBE_TIMEOUT_S = 30.0
+
+
+class _InstallHelpers:
+    """Install helpers."""
+
+    def __init__(self, parent: GOGInstaller) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    async def probe_game_info(
+        self, game_id: str,
+    ) -> tuple[str, str | None, list[str]]:
+        """Probe game info."""
+        gogdl_bin = self._parent._gogdl_bin
+        if not gogdl_bin:
+            return 'windows', None, []
+        try:
+            async with self._parent._tokens.gogdl_credentials() as env:
+                proc = await asyncio.create_subprocess_exec(
+                    gogdl_bin, 'info', game_id, '--os', 'windows',
+                    env={**env},
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                try:
+                    stdout, _err = await asyncio.wait_for(
+                        proc.communicate(), timeout=_LANG_PROBE_TIMEOUT_S,
+                    )
+                except TimeoutError:
+                    return 'windows', None, []
+                if proc.returncode != 0:
+                    return 'windows', None, []
+        except OSError as e:
+            logger.debug('[GOGHelpers] probe failed: %s', e)
+            return 'windows', None, []
+        folder, langs = self.parse_info_output(
+            stdout.decode('utf-8', errors='replace'),
+        )
+        return 'windows', folder, langs
+
+    @staticmethod
+    def parse_info_output(
+        stdout: str,
+    ) -> tuple[str | None, list[str]]:
+        """Parse info output."""
+        folder: str | None = None
+        languages: list[str] = []
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line.startswith('{'):
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict):
+                continue
+            if folder is None and isinstance(data.get('folder'), str):
+                folder = data['folder']
+            langs = data.get('languages')
+            if isinstance(langs, list) and not languages:
+                languages = [str(l) for l in langs]
+        return folder, languages
+
+    @staticmethod
+    def pick_languages(
+        primary_lang: str, explicit: bool, supported: list[str],
+    ) -> list[str]:
+        """Pick languages."""
+        if not supported:
+            return ['en-US']
+        if explicit:
+            return _InstallHelpers._pick_explicit_lang(primary_lang, supported)
+        return _InstallHelpers._pick_implicit_langs(primary_lang, supported)
+
+    @staticmethod
+    def _pick_explicit_lang(
+        primary_lang: str, supported: list[str],
+    ) -> list[str]:
+        """Pick explicit lang."""
+        match = smart_match_language(primary_lang, supported)
+        if match:
+            return [match]
+        return ['en-US' if 'en-US' in supported else supported[0]]
+
+    @staticmethod
+    def _pick_implicit_langs(
+        primary_lang: str, supported: list[str],
+    ) -> list[str]:
+        """Pick implicit langs."""
+        out: list[str] = []
+        match = smart_match_language(primary_lang, supported)
+        if match:
+            out.append(match)
+        for fallback in ('en-US', 'en'):
+            picked = smart_match_language(fallback, supported)
+            if picked and picked not in out:
+                out.append(picked)
+        return out or supported[:1]

--- a/py_modules/unifideck/stores/gog/install/installer.py
+++ b/py_modules/unifideck/stores/gog/install/installer.py
@@ -1,0 +1,309 @@
+"""installer.py — Public ``GOGInstaller`` orchestrator.
+
+# OP-51a | py_modules/unifideck/stores/gog/install/installer.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from ....core.types import InstallResult, Result
+from ..config import GOGConfig
+from ..tokens import GOGTokenManager
+from .helpers import _InstallHelpers
+from .marker import _PostInstallMarker
+from .planner import GOGInstallPlanner
+from .progress import _GogdlProgressMonitor
+from .uninstall_pipeline import _UninstallPipeline
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _InstallContext:
+    """Install context."""
+
+    game_id: str
+    base_path: str
+    preferred_lang: str
+    explicit_lang: bool
+    progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None
+    platform: str = ''
+    folder_name: str | None = None
+    supported_langs: list[str] = field(default_factory=list)
+    existing_dirs: set = field(default_factory=set)
+    support_dir: str = ''
+    install_mode: str = ''
+    found_path: str = ''
+
+
+class GOGInstaller:
+    """GOG installer."""
+
+    def __init__(
+        self,
+        config: GOGConfig,
+        tokens: GOGTokenManager,
+        gogdl_bin: str,
+        exe_finder: Callable[[str], str | None],
+        locale_fn: Callable[[], str],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._tokens = tokens
+        self._gogdl_bin = gogdl_bin
+        self._exe_finder = exe_finder
+        self._locale_fn = locale_fn
+        self._planner = GOGInstallPlanner(config, tokens)
+        self._planner.set_gogdl_bin(gogdl_bin)
+        self._helpers = _InstallHelpers(self)
+        self._marker = _PostInstallMarker(self)
+        self._progress = _GogdlProgressMonitor(self)
+        self._uninstall = _UninstallPipeline(self)
+
+    async def uninstall_game(
+        self, game_id: str, install_path: str | None = None,
+    ) -> Result:
+        """Uninstall game."""
+        result = await self._uninstall.uninstall_game(game_id, install_path)
+        await self._wipe_manifests(game_id)
+        await self._wipe_support_cache(game_id)
+        return result
+
+    async def _run_gogdl_with_progress(
+        self,
+        install_mode: str,
+        game_id: str,
+        platform: str,
+        path: str,
+        support_dir: str,
+        languages: list[str],
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> bool:
+        """Run GOGDL with progress."""
+        return await self._progress.run_gogdl_with_progress(
+            install_mode, game_id, platform, path,
+            support_dir, languages, progress_cb,
+        )
+
+    async def _run_gogdl_repair_pass(
+        self,
+        game_id: str,
+        platform: str,
+        base_path: str,
+        folder_name: str | None,
+        preferred_lang: str,
+    ) -> None:
+        """Run GOGDL repair pass."""
+        await self._progress.run_gogdl_repair_pass(
+            game_id, platform, base_path, folder_name, preferred_lang,
+        )
+
+    def _snapshot_dirs(self, base_path: str) -> set:
+        """Snapshot dirs."""
+        return self._marker.snapshot_dirs(base_path)
+
+    async def _locate_install(
+        self,
+        game_id: str,
+        base_path: str,
+        folder_name: str | None,
+        existing_dirs: set,
+    ) -> str | None:
+        """Locate install."""
+        return await self._marker.locate_install(
+            game_id, base_path, folder_name, existing_dirs,
+        )
+
+    async def _write_install_marker(
+        self, install_path: str, game_id: str, language: str,
+    ) -> bool:
+        """Write install marker."""
+        return await self._marker.write_install_marker(
+            install_path, game_id, language,
+        )
+
+    async def _regenerate_manifest(
+        self, game_id: str, platform: str,
+    ) -> None:
+        """Regenerate manifest."""
+        await self._marker.regenerate_manifest(game_id, platform)
+
+    def _install_failed(
+        self,
+        game_id: str,
+        error: str,
+        *,
+        cleanup_path: str | None = None,
+        cleanup_folder: str | None = None,
+    ) -> InstallResult:
+        """Install failed."""
+        if cleanup_path:
+            self._cleanup_partial(cleanup_path, cleanup_folder)
+        return InstallResult(
+            success=False, store='gog', game_id=game_id, error=error,
+        )
+
+    async def install_game(
+        self,
+        game_id: str,
+        base_path: str | None = None,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        language: str | None = None,
+    ) -> InstallResult:
+        """Install game."""
+        ctx = self._install_preflight(game_id, base_path, progress_cb, language)
+        if not ctx[1]:
+            return cast(InstallResult, ctx[2])
+        context = ctx[2]
+        prepared = await self._install_probe_and_prepare(context)
+        if prepared is not None:
+            return prepared
+        ran = await self._install_run_gogdl_phase(context)
+        if ran is not None:
+            return ran
+        return await self._install_finalize(context)
+
+    def _install_preflight(
+        self,
+        game_id: str,
+        base_path: str | None,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+        language: str | None,
+    ) -> tuple:
+        """Install preflight."""
+        if not self._gogdl_bin:
+            return (
+                game_id, False,
+                self._install_failed(game_id, 'gogdl_not_found'),
+            )
+        path = base_path or os.path.expanduser(self._config.download_dir)
+        os.makedirs(path, exist_ok=True)
+        explicit = bool(language)
+        primary = language or self._locale_fn() or 'en-US'
+        context = _InstallContext(
+            game_id=game_id, base_path=path,
+            preferred_lang=primary, explicit_lang=explicit,
+            progress_cb=progress_cb,
+        )
+        return game_id, True, context
+
+    async def _install_probe_and_prepare(
+        self, ctx: _InstallContext,
+    ) -> InstallResult | None:
+        """Install probe and prepare."""
+        if not await self._tokens.refresh_if_stale():
+            return self._install_failed(ctx.game_id, 'no_tokens')
+        platform, folder, langs = await self._helpers.probe_game_info(
+            ctx.game_id,
+        )
+        ctx.platform = platform
+        ctx.folder_name = folder
+        ctx.supported_langs = langs
+        ctx.existing_dirs = self._snapshot_dirs(ctx.base_path)
+        target = (
+            os.path.join(ctx.base_path, folder) if folder else None
+        )
+        ctx.install_mode = await self._planner.determine_install_mode(
+            ctx.game_id, target,
+        )
+        return None
+
+    async def _install_run_gogdl_phase(
+        self, ctx: _InstallContext,
+    ) -> InstallResult | None:
+        """Install run GOGDL phase."""
+        ctx.support_dir = os.path.join(
+            os.path.expanduser(self._config.gogdl_config_dir),
+            'support', ctx.game_id,
+        )
+        languages = self._helpers.pick_languages(
+            ctx.preferred_lang, ctx.explicit_lang, ctx.supported_langs,
+        )
+        ok = await self._run_gogdl_with_progress(
+            ctx.install_mode, ctx.game_id, ctx.platform,
+            ctx.base_path, ctx.support_dir, languages, ctx.progress_cb,
+        )
+        if not ok:
+            return self._install_failed(
+                ctx.game_id, 'gogdl_failed',
+                cleanup_path=ctx.base_path,
+                cleanup_folder=ctx.folder_name,
+            )
+        return None
+
+    async def _install_finalize(
+        self, ctx: _InstallContext,
+    ) -> InstallResult:
+        """Install finalize."""
+        install_path = await self._locate_install(
+            ctx.game_id, ctx.base_path, ctx.folder_name,
+            ctx.existing_dirs,
+        )
+        if not install_path:
+            return self._install_failed(
+                ctx.game_id, 'install_dir_not_detected',
+                cleanup_path=ctx.base_path,
+                cleanup_folder=ctx.folder_name,
+            )
+        verification = await self._planner.verify_installation(
+            ctx.game_id, install_path, ctx.platform, self._exe_finder,
+        )
+        if not verification['success']:
+            await self._run_gogdl_repair_pass(
+                ctx.game_id, ctx.platform, ctx.base_path,
+                ctx.folder_name, ctx.preferred_lang,
+            )
+        await self._write_install_marker(
+            install_path, ctx.game_id, ctx.preferred_lang,
+        )
+        await self._regenerate_manifest(ctx.game_id, ctx.platform)
+        return InstallResult(
+            success=True, store='gog', game_id=ctx.game_id,
+            install_path=install_path,
+        )
+
+    async def _wipe_manifests(self, game_id: str) -> None:
+        """Wipe manifests."""
+        for path in self._planner.manifest_locations(game_id):
+            try:
+                if os.path.isfile(path):
+                    os.unlink(path)
+                elif os.path.isdir(path):
+                    await asyncio.to_thread(
+                        shutil.rmtree, path, ignore_errors=True,
+                    )
+            except OSError as e:
+                logger.debug('[GOGInstaller] manifest wipe %s: %s', path, e)
+
+    async def _wipe_support_cache(self, game_id: str) -> None:
+        """Wipe support cache."""
+        path = os.path.join(
+            os.path.expanduser(self._config.gogdl_config_dir),
+            'support', game_id,
+        )
+        if os.path.isdir(path):
+            await asyncio.to_thread(
+                shutil.rmtree, path, ignore_errors=True,
+            )
+
+    def _cleanup_partial(
+        self, base_path: str, folder_name: str | None,
+    ) -> None:
+        """Cleanup partial."""
+        if not folder_name:
+            return
+        path = os.path.join(base_path, folder_name)
+        if os.path.isdir(path):
+            try:
+                shutil.rmtree(path, ignore_errors=True)
+            except OSError as e:
+                logger.debug('[GOGInstaller] cleanup %s: %s', path, e)

--- a/py_modules/unifideck/stores/gog/install/languages.py
+++ b/py_modules/unifideck/stores/gog/install/languages.py
@@ -1,0 +1,34 @@
+"""languages.py — Best-effort language code matcher.
+
+# OP-51c | py_modules/unifideck/stores/gog/install/languages.py | Depends: (none)
+"""
+from __future__ import annotations
+
+
+def smart_match_language(target: str, choices: list[str]) -> str | None:
+    """Smart match language.
+
+    Tries an exact match first, then a case-insensitive match, then a
+    prefix match on the two-letter language code, then falls back to
+    ``en-US`` / ``en`` if the target language isn't available.
+    """
+    if not target or not choices:
+        return None
+    target_norm = target.strip()
+    target_lower = target_norm.lower()
+    target_prefix = target_lower.split('-', 1)[0] if '-' in target_lower else target_lower
+    for choice in choices:
+        if choice == target_norm:
+            return choice
+    for choice in choices:
+        if choice.lower() == target_lower:
+            return choice
+    for choice in choices:
+        choice_prefix = choice.lower().split('-', 1)[0] if '-' in choice.lower() else choice.lower()
+        if choice_prefix == target_prefix:
+            return choice
+    for fallback in ('en-US', 'en'):
+        for choice in choices:
+            if choice.lower() == fallback.lower():
+                return choice
+    return None

--- a/py_modules/unifideck/stores/gog/install/marker.py
+++ b/py_modules/unifideck/stores/gog/install/marker.py
@@ -1,0 +1,190 @@
+"""marker.py — Post-install marker writer + manifest regeneration.
+
+# OP-51g | py_modules/unifideck/stores/gog/install/marker.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from typing import TYPE_CHECKING, Any, cast
+
+from .primitives import GOGFolderOps
+
+if TYPE_CHECKING:
+    from .installer import GOGInstaller
+
+logger = logging.getLogger(__name__)
+_INSTALL_MARKER = '.unifideck-id'
+
+
+class _PostInstallMarker:
+    """Post install marker."""
+
+    def __init__(self, parent: GOGInstaller) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    @staticmethod
+    def snapshot_dirs(base_path: str) -> set:
+        """Snapshot dirs."""
+        if not os.path.isdir(base_path):
+            return set()
+        try:
+            return {
+                name for name in os.listdir(base_path)
+                if os.path.isdir(os.path.join(base_path, name))
+            }
+        except OSError:
+            return set()
+
+    async def locate_install(
+        self,
+        game_id: str,
+        base_path: str,
+        folder_name: str | None,
+        existing_dirs: set,
+    ) -> str | None:
+        """Locate install."""
+        if folder_name:
+            candidate = os.path.join(base_path, folder_name)
+            if GOGFolderOps.has_goggame_info(candidate, game_id):
+                return candidate
+        for name in self.snapshot_dirs(base_path) - existing_dirs:
+            candidate = os.path.join(base_path, name)
+            if GOGFolderOps.has_goggame_info(candidate, game_id):
+                return candidate
+        if self._find_flat_goggame(base_path, game_id):
+            return await self._reorganise_flat_install(
+                base_path, game_id, folder_name, existing_dirs,
+            )
+        return None
+
+    @staticmethod
+    def _find_flat_goggame(base_path: str, game_id: str) -> bool:
+        """Find flat goggame."""
+        try:
+            for name in os.listdir(base_path):
+                if name == f'goggame-{game_id}.info':
+                    return True
+        except OSError:
+            return False
+        return False
+
+    @staticmethod
+    async def _reorganise_flat_install(
+        base_path: str,
+        game_id: str,
+        folder_name: str | None,
+        existing_dirs: set,
+    ) -> str:
+        """Reorganise flat install."""
+        target_name = folder_name or f'goggame-{game_id}'
+        target = os.path.join(base_path, target_name)
+        os.makedirs(target, exist_ok=True)
+
+        def _move() -> None:
+            try:
+                for name in os.listdir(base_path):
+                    if name == target_name or name in existing_dirs:
+                        continue
+                    src = os.path.join(base_path, name)
+                    dst = os.path.join(target, name)
+                    if src != target:
+                        shutil.move(src, dst)
+            except OSError as e:
+                logger.warning('[GOGMarker] reorg failed: %s', e)
+
+        await asyncio.to_thread(_move)
+        return target
+
+    async def write_install_marker(
+        self, install_path: str, game_id: str, language: str,
+    ) -> bool:
+        """Write install marker."""
+        if not install_path or not os.path.isdir(install_path):
+            return False
+        info_data = self._load_info_data_from_goggame(install_path, game_id)
+        info_data.setdefault('game_id', game_id)
+        info_data.setdefault('install_path', install_path)
+        info_data['language'] = language
+        marker = os.path.join(install_path, _INSTALL_MARKER)
+        return await asyncio.to_thread(
+            self._write_marker_sync, marker, info_data,
+        )
+
+    @staticmethod
+    def _load_info_data_from_goggame(
+        install_path: str, game_id: str,
+    ) -> dict[str, Any]:
+        """Load info data from goggame."""
+        search_dirs = [install_path]
+        for sub in ('game', 'bin'):
+            sub_path = os.path.join(install_path, sub)
+            if os.path.isdir(sub_path):
+                search_dirs.append(sub_path)
+        for directory in search_dirs:
+            data = _PostInstallMarker._try_load_info_in_dir(directory, game_id)
+            if data is not None:
+                return data
+        return {}
+
+    @staticmethod
+    def _try_load_info_in_dir(
+        directory: str, game_id: str,
+    ) -> dict[str, Any] | None:
+        """Try load info in dir."""
+        candidate = os.path.join(directory, f'goggame-{game_id}.info')
+        if not os.path.isfile(candidate):
+            return None
+        try:
+            with open(candidate, encoding='utf-8') as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return {
+            'title': data.get('name') or '',
+            'install_id': data.get('rootGameId') or data.get('gameId') or '',
+            'build_id': str(data.get('buildId', '')),
+        }
+
+    @staticmethod
+    def _write_marker_sync(
+        marker_path: str, info_data: dict[str, Any],
+    ) -> bool:
+        """Write marker sync."""
+        try:
+            with open(marker_path, 'w', encoding='utf-8') as f:
+                json.dump(info_data, f, indent=2)
+        except OSError as e:
+            logger.warning(
+                '[GOGMarker] write %s: %s', marker_path, e,
+            )
+            return False
+        return True
+
+    async def regenerate_manifest(
+        self, game_id: str, platform: str,
+    ) -> None:
+        """Regenerate manifest."""
+        gogdl_bin = self._parent._gogdl_bin
+        if not gogdl_bin:
+            return
+        try:
+            async with self._parent._tokens.gogdl_credentials() as env:
+                proc = await asyncio.create_subprocess_exec(
+                    gogdl_bin, 'manifest', game_id, '--platform', platform,
+                    env={**env},
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await proc.wait()
+        except OSError as e:
+            logger.debug('[GOGMarker] manifest spawn: %s', e)
+
+
+_ = cast

--- a/py_modules/unifideck/stores/gog/install/planner.py
+++ b/py_modules/unifideck/stores/gog/install/planner.py
@@ -1,0 +1,183 @@
+"""planner.py — Decide whether to install fresh, resume, or repair.
+
+# OP-51d | py_modules/unifideck/stores/gog/install/planner.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..config import GOGConfig
+from ..tokens import GOGTokenManager
+from .primitives import GOGFolderOps
+
+logger = logging.getLogger(__name__)
+_CORRUPT_INSTALL_SIZE_THRESHOLD = 100 * 1024 * 1024
+_MIN_SIZE_RATIO = 0.8
+
+
+def _extract_disk_size_from_size_info(size_info: dict) -> int | None:
+    """Extract disk size from size info."""
+    if not isinstance(size_info, dict):
+        return None
+    for key in ('disk_size', 'size_on_disk', 'size'):
+        value = size_info.get(key)
+        if isinstance(value, (int, float)) and value > 0:
+            return int(value)
+    return None
+
+
+class GOGInstallPlanner:
+    """GOG install planner."""
+
+    def __init__(
+        self, config: GOGConfig, tokens: GOGTokenManager,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._tokens = tokens
+        self._gogdl_bin: str | None = None
+
+    async def determine_install_mode(
+        self, game_id: str, target_folder: str | None,
+    ) -> str:
+        """Determine install mode."""
+        if not target_folder or not Path(target_folder).is_dir():
+            return 'download'
+        if GOGFolderOps.has_goggame_info(target_folder, game_id):
+            size = GOGFolderOps.folder_size(target_folder)
+            if size < _CORRUPT_INSTALL_SIZE_THRESHOLD:
+                await self._cleanup_corrupt_install(game_id, target_folder)
+                return 'download'
+            return 'repair'
+        await self._cleanup_orphaned_install(game_id, target_folder)
+        return 'download'
+
+    async def verify_installation(
+        self,
+        game_id: str,
+        install_path: str,
+        platform: str,
+        exe_finder: Callable[[str], str | None],
+    ) -> dict[str, Any]:
+        """Verify installation."""
+        size_on_disk = GOGFolderOps.folder_size(install_path)
+        file_count = GOGFolderOps.count_files(install_path)
+        expected = await self.get_expected_disk_size(game_id, platform)
+        executable = exe_finder(install_path) if exe_finder else None
+        ok = (
+            size_on_disk > 0
+            and (expected == 0 or size_on_disk >= expected * _MIN_SIZE_RATIO)
+            and bool(executable)
+        )
+        return {
+            'success': ok,
+            'size_on_disk': size_on_disk,
+            'expected_size': expected,
+            'file_count': file_count,
+            'executable': executable or '',
+        }
+
+    async def get_expected_disk_size(
+        self, game_id: str, platform: str,
+    ) -> int:
+        """Get expected disk size."""
+        if not self._gogdl_bin:
+            return 0
+        stdout = await self._spawn_gogdl_info(
+            self._gogdl_bin, game_id, platform,
+        )
+        if stdout is None:
+            return 0
+        return self._parse_size_from_gogdl_info(stdout)
+
+    async def _spawn_gogdl_info(
+        self, gogdl_bin: str, game_id: str, platform: str,
+    ) -> bytes | None:
+        """Spawn GOGDL info."""
+        try:
+            async with self._tokens.gogdl_credentials() as env:
+                proc = await asyncio.create_subprocess_exec(
+                    gogdl_bin, 'info', game_id, '--os', platform,
+                    env={**env},
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                try:
+                    stdout, _err = await asyncio.wait_for(
+                        proc.communicate(), timeout=30.0,
+                    )
+                except TimeoutError:
+                    return None
+                return stdout if proc.returncode == 0 else None
+        except OSError as e:
+            logger.debug('[GOGPlanner] info spawn: %s', e)
+            return None
+
+    @staticmethod
+    def _parse_size_from_gogdl_info(stdout: bytes) -> int:
+        """Parse size from GOGDL info."""
+        try:
+            text = stdout.decode('utf-8', errors='replace')
+        except UnicodeDecodeError:
+            return 0
+        for line in text.splitlines():
+            if not line.strip().startswith('{'):
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            size = _extract_disk_size_from_size_info(
+                data if isinstance(data, dict) else {},
+            )
+            if size:
+                return size
+        return 0
+
+    async def _cleanup_corrupt_install(
+        self, game_id: str, target_folder: str,
+    ) -> None:
+        """Cleanup corrupt install."""
+        logger.info(
+            '[GOGPlanner] corrupt install for %s — wiping %s',
+            game_id, target_folder,
+        )
+        await asyncio.to_thread(
+            shutil.rmtree, target_folder, ignore_errors=True,
+        )
+
+    async def _cleanup_orphaned_install(
+        self, game_id: str, target_folder: str,
+    ) -> None:
+        """Cleanup orphaned install."""
+        # When the folder exists but lacks goggame info we treat it
+        # as orphaned: drop it so the install can claim the path.
+        logger.info(
+            '[GOGPlanner] orphaned install %s — wiping %s',
+            game_id, target_folder,
+        )
+        await asyncio.to_thread(
+            shutil.rmtree, target_folder, ignore_errors=True,
+        )
+
+    def manifest_locations(self, game_id: str) -> list[str]:
+        """Manifest locations."""
+        config_dir = Path(self._config.gogdl_config_dir).expanduser()
+        return [
+            str(config_dir / 'manifests' / game_id),
+            str(config_dir / f'{game_id}.manifest'),
+        ]
+
+    def _resolve_gogdl_bin(self) -> str | None:
+        """Resolve GOGDL bin."""
+        return self._gogdl_bin
+
+    def set_gogdl_bin(self, path: str) -> None:
+        """Set GOGDL bin."""
+        self._gogdl_bin = path

--- a/py_modules/unifideck/stores/gog/install/primitives.py
+++ b/py_modules/unifideck/stores/gog/install/primitives.py
@@ -1,0 +1,77 @@
+"""primitives.py — Folder-level helpers shared across the install pipeline.
+
+# OP-51b | py_modules/unifideck/stores/gog/install/primitives.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class GOGFolderOps:
+    """GOG folder ops."""
+
+    @staticmethod
+    def folder_size(path: str) -> int:
+        """Folder size."""
+        if not os.path.isdir(path):
+            return 0
+        total = 0
+        for root, _dirs, files in os.walk(path):
+            for f in files:
+                try:
+                    total += os.path.getsize(os.path.join(root, f))
+                except OSError:
+                    continue
+        return total
+
+    @staticmethod
+    def count_files(path: str) -> int:
+        """Count files."""
+        if not os.path.isdir(path):
+            return 0
+        total = 0
+        for _root, _dirs, files in os.walk(path):
+            total += len(files)
+        return total
+
+    @staticmethod
+    def has_goggame_info(path: str, game_id: str = '') -> bool:
+        """Has goggame info."""
+        if not os.path.isdir(path):
+            return False
+        if game_id:
+            wanted = f'goggame-{game_id}.info'
+            try:
+                if os.path.isfile(os.path.join(path, wanted)):
+                    return True
+            except OSError:
+                pass
+        try:
+            for name in os.listdir(path):
+                if name.startswith('goggame-') and name.endswith('.info'):
+                    return True
+        except OSError:
+            return False
+        return False
+
+    @staticmethod
+    async def force_cleanup_folder(path: str) -> None:
+        """Force cleanup folder."""
+        if not path or not os.path.isdir(path):
+            return
+        import shutil
+
+        async def _rmtree() -> None:
+            await asyncio.to_thread(
+                shutil.rmtree, path, ignore_errors=True,
+            )
+
+        for _attempt in range(3):
+            await _rmtree()
+            if not os.path.isdir(path):
+                return
+            await asyncio.sleep(0.5)

--- a/py_modules/unifideck/stores/gog/install/progress.py
+++ b/py_modules/unifideck/stores/gog/install/progress.py
@@ -1,0 +1,207 @@
+"""progress.py — Pipe gogdl's stdout into a progress callback.
+
+# OP-51f | py_modules/unifideck/stores/gog/install/progress.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .installer import GOGInstaller
+
+logger = logging.getLogger(__name__)
+_GOGDL_STALL_TIMEOUT_S = 120.0
+_ETA_RE = re.compile(r'ETA[: ]+(\d+):(\d+):(\d+)')
+_SPEED_RE = re.compile(r'(\d+(?:\.\d+)?)\s*MiB/s')
+_PROGRESS_RE = re.compile(r'(\d+(?:\.\d+)?)\s*%')
+
+
+class _GogdlProgressMonitor:
+    """GOGDL progress monitor."""
+
+    def __init__(self, parent: GOGInstaller) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    async def run_gogdl_with_progress(
+        self,
+        install_mode: str,
+        game_id: str,
+        platform: str,
+        path: str,
+        support_dir: str,
+        languages: list[str],
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> bool:
+        """Run GOGDL with progress."""
+        cmd = self._build_gogdl_cmd(
+            install_mode, game_id, platform, path, support_dir, languages,
+        )
+        proc = await self._spawn_gogdl(cmd)
+        if proc is None:
+            return False
+        return await self._read_progress_loop(proc, progress_cb)
+
+    def _build_gogdl_cmd(
+        self,
+        install_mode: str,
+        game_id: str,
+        platform: str,
+        path: str,
+        support_dir: str,
+        languages: list[str],
+    ) -> list[str]:
+        """Build GOGDL cmd."""
+        cmd = [
+            self._parent._gogdl_bin, install_mode, game_id,
+            '--platform', platform,
+            '--path', path,
+        ]
+        if support_dir:
+            cmd += ['--support', support_dir]
+        for lang in languages:
+            cmd += ['--lang', lang]
+        return cmd
+
+    async def _spawn_gogdl(
+        self, cmd: list[str],
+    ) -> asyncio.subprocess.Process | None:
+        """Spawn GOGDL."""
+        try:
+            async with self._parent._tokens.gogdl_credentials() as env:
+                return await asyncio.create_subprocess_exec(
+                    *cmd, env={**env},
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                )
+        except OSError as e:
+            logger.warning('[GOGProgress] spawn: %s', e)
+            return None
+
+    async def _read_progress_loop(
+        self,
+        proc: asyncio.subprocess.Process,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> bool:
+        """Read progress loop."""
+        if proc.stdout is None:
+            return await proc.wait() == 0
+        progress: dict[str, Any] = {}
+        while True:
+            try:
+                line = await asyncio.wait_for(
+                    proc.stdout.readline(), timeout=_GOGDL_STALL_TIMEOUT_S,
+                )
+            except TimeoutError:
+                logger.warning('[GOGProgress] stalled, terminating')
+                await self._terminate_gogdl(proc)
+                return False
+            if not line:
+                break
+            await self._handle_progress_line(
+                line.decode('utf-8', errors='replace').strip(),
+                progress, progress_cb,
+            )
+        return await proc.wait() == 0
+
+    async def _handle_progress_line(
+        self,
+        line_str: str,
+        progress: dict[str, Any],
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None,
+    ) -> None:
+        """Handle progress line."""
+        self._parse_progress_line(line_str, progress)
+        if progress_cb is not None and progress:
+            await progress_cb({'phase': 'progress', **progress})
+
+    @staticmethod
+    def _parse_eta(line: str) -> int | None:
+        """Parse eta."""
+        m = _ETA_RE.search(line)
+        if not m:
+            return None
+        h, mi, s = (int(x) for x in m.groups())
+        return h * 3600 + mi * 60 + s
+
+    @staticmethod
+    def _parse_speed_mib(line: str) -> float | None:
+        """Parse speed mib."""
+        m = _SPEED_RE.search(line)
+        return float(m.group(1)) if m else None
+
+    @staticmethod
+    def _parse_progress_line(
+        line: str, progress: dict[str, Any],
+    ) -> None:
+        """Parse progress line."""
+        m = _PROGRESS_RE.search(line)
+        if m:
+            try:
+                progress['percent'] = float(m.group(1))
+            except ValueError:
+                pass
+        eta = _GogdlProgressMonitor._parse_eta(line)
+        if eta is not None:
+            progress['eta_seconds'] = eta
+        speed = _GogdlProgressMonitor._parse_speed_mib(line)
+        if speed is not None:
+            progress['speed_mib_per_s'] = speed
+
+    @staticmethod
+    async def _terminate_gogdl(proc: asyncio.subprocess.Process) -> None:
+        """Terminate GOGDL."""
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+
+    async def run_gogdl_repair_pass(
+        self,
+        game_id: str,
+        platform: str,
+        base_path: str,
+        folder_name: str | None,
+        preferred_lang: str,
+    ) -> None:
+        """Run GOGDL repair pass."""
+        if not self._parent._gogdl_bin:
+            return
+        path = self._resolve_repair_path(game_id, base_path, folder_name)
+        if not path:
+            return
+        try:
+            async with self._parent._tokens.gogdl_credentials() as env:
+                proc = await asyncio.create_subprocess_exec(
+                    self._parent._gogdl_bin, 'repair', game_id,
+                    '--platform', platform,
+                    '--path', path,
+                    '--lang', preferred_lang,
+                    env={**env},
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await proc.wait()
+        except OSError as e:
+            logger.debug('[GOGProgress] repair spawn: %s', e)
+
+    @staticmethod
+    def _resolve_repair_path(
+        game_id: str, base_path: str, folder_name: str | None,
+    ) -> str:
+        """Resolve repair path."""
+        if folder_name:
+            return os.path.join(base_path, folder_name)
+        return base_path

--- a/py_modules/unifideck/stores/gog/install/uninstall_pipeline.py
+++ b/py_modules/unifideck/stores/gog/install/uninstall_pipeline.py
@@ -1,0 +1,57 @@
+"""uninstall_pipeline.py — Best-effort uninstall of a GOG install.
+
+# OP-51e | py_modules/unifideck/stores/gog/install/uninstall_pipeline.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from typing import TYPE_CHECKING
+
+from ....core.types import Result
+from .primitives import GOGFolderOps
+
+if TYPE_CHECKING:
+    from .installer import GOGInstaller
+
+logger = logging.getLogger(__name__)
+_UNINSTALL_MAX_ATTEMPTS = 3
+
+
+class _UninstallPipeline:
+    """Uninstall pipeline."""
+
+    def __init__(self, parent: GOGInstaller) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    async def uninstall_game(
+        self, game_id: str, install_path: str | None = None,
+    ) -> Result:
+        """Uninstall game."""
+        if not install_path:
+            return Result(success=False, error='install_path_required')
+        if not os.path.isdir(install_path):
+            return Result(success=True, data={'already_gone': True})
+        for attempt in range(1, _UNINSTALL_MAX_ATTEMPTS + 1):
+            try:
+                await asyncio.to_thread(
+                    shutil.rmtree, install_path,
+                )
+            except OSError as e:
+                logger.warning(
+                    '[GOGUninstall] attempt %d failed: %s', attempt, e,
+                )
+                await asyncio.sleep(0.5)
+                continue
+            if not os.path.isdir(install_path):
+                break
+        if os.path.isdir(install_path):
+            await GOGFolderOps.force_cleanup_folder(install_path)
+        if os.path.isdir(install_path):
+            return Result(success=False, error='deletion_failed')
+        return Result(
+            success=True, data={'game_id': game_id, 'path': install_path},
+        )

--- a/py_modules/unifideck/stores/gog/library.py
+++ b/py_modules/unifideck/stores/gog/library.py
@@ -1,5 +1,218 @@
-"""library.py — GOG library fetcher
+"""library.py — Public ``GOGLibrary`` surface.
+
 # OP-50c | py_modules/unifideck/stores/gog/library.py | Depends: OP-50a
+
+Fetches the user's owned-game list from GOG's REST API, walks the
+local download dir for install markers, and stitches the two together
+into a list of :class:`Game` records.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import json
+import logging
+import os
+import urllib.parse
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ...core.types import Game
+from .config import GOGConfig
+from .http import build_ssl_context, fetch_json_get
+from .library_migration import _MarkerMigration
+from .tokens import GOGTokenManager
+
+logger = logging.getLogger(__name__)
+_INSTALL_MARKER = '.unifideck-id'
+_GOG_LIBRARY_TIMEOUT_S = 15.0
+
+
+class GOGLibrary:
+    """GOG library."""
+
+    def __init__(
+        self,
+        config: GOGConfig,
+        tokens: GOGTokenManager,
+        exe_finder: Callable[[str], str | None] | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._tokens = tokens
+        self._exe_finder = exe_finder
+        self._migration = _MarkerMigration(self)
+
+    def migrate_old_markers(self) -> dict[str, int]:
+        """Migrate old markers."""
+        return self._migration.migrate_old_markers()
+
+    async def is_available(self) -> bool:
+        """Is available."""
+        if not await self._tokens.refresh_if_stale():
+            return False
+        try:
+            count = await self._probe_userdata()
+        except Exception as e:
+            logger.debug('[GOGLibrary] probe failed: %s', e)
+            return False
+        return count >= 0
+
+    async def _probe_userdata(self) -> int:
+        """Probe userdata."""
+        if not self._config.api_gog_url or not self._tokens.access_token:
+            return -1
+        data = await self._fetch_json(
+            f'{self._config.api_gog_url}/user/data/games',
+        )
+        if not isinstance(data, dict):
+            return -1
+        owned = data.get('owned')
+        return len(owned) if isinstance(owned, list) else 0
+
+    async def fetch_library(self) -> list[Game]:
+        """Fetch library."""
+        if not await self._tokens.refresh_if_stale():
+            return []
+        owned_ids = await self._owned_game_ids()
+        installed_map = self._installed_map()
+        out: list[Game] = []
+        for game_id in owned_ids:
+            slug = await self.get_game_slug(game_id) or ''
+            info = installed_map.get(game_id, {})
+            installed = bool(info)
+            install_path = info.get('install_path', '')
+            title = info.get('title') or slug.replace('_', ' ').title()
+            out.append(
+                Game(
+                    store='gog',
+                    game_id=str(game_id),
+                    title=title,
+                    installed=installed,
+                    install_path=install_path,
+                ),
+            )
+        return out
+
+    async def _owned_game_ids(self) -> list[str]:
+        """Owned game IDs."""
+        data = await self._fetch_json(
+            f'{self._config.api_gog_url}/user/data/games',
+        )
+        if not isinstance(data, dict):
+            return []
+        owned = data.get('owned')
+        if not isinstance(owned, list):
+            return []
+        return [str(g) for g in owned]
+
+    async def get_game_slug(self, game_id: str) -> str | None:
+        """Get game slug."""
+        url = f'{self._config.api_gog_url}/products/{game_id}'
+        data = await self._fetch_json(url)
+        if isinstance(data, dict):
+            slug = data.get('slug')
+            if isinstance(slug, str) and slug:
+                return slug
+        return None
+
+    def get_installed(self) -> list[str]:
+        """Get installed."""
+        return list(self._installed_map().keys())
+
+    def get_installed_game_info(
+        self, game_id: str,
+    ) -> dict[str, str | None] | None:
+        """Get installed game info."""
+        info = self._installed_map().get(game_id)
+        return info if info else None
+
+    def _installed_map(self) -> dict[str, dict[str, str]]:
+        """Installed map."""
+        download_dir = os.path.expanduser(self._config.download_dir)
+        out: dict[str, dict[str, str]] = {}
+        if not os.path.isdir(download_dir):
+            return out
+        for entry in sorted(os.listdir(download_dir)):
+            game_dir = os.path.join(download_dir, entry)
+            if not os.path.isdir(game_dir):
+                continue
+            game_id = self._read_marker(game_dir)
+            if not game_id and self._has_goggame_info(game_dir, ''):
+                game_id = self._infer_game_id_from_goggame(game_dir)
+            if not game_id:
+                continue
+            out[game_id] = {
+                'install_path': game_dir,
+                'title': entry,
+                'executable': self._resolve_exe(game_dir) or '',
+            }
+        return out
+
+    @staticmethod
+    def _read_marker(game_dir: str) -> str | None:
+        """Read marker."""
+        marker = os.path.join(game_dir, _INSTALL_MARKER)
+        if not os.path.isfile(marker):
+            return None
+        try:
+            content = Path(marker).read_text(encoding='utf-8').strip()
+        except OSError:
+            return None
+        if content.startswith('{'):
+            try:
+                data = json.loads(content)
+            except json.JSONDecodeError:
+                return None
+            gid = data.get('game_id') if isinstance(data, dict) else None
+            return str(gid) if gid else None
+        line = content.split('\n', 1)[0].strip()
+        return line if line.isdigit() else None
+
+    @staticmethod
+    def _has_goggame_info(game_dir: str, game_id: str) -> bool:
+        """Has goggame info."""
+        try:
+            for name in os.listdir(game_dir):
+                if name.startswith('goggame-') and name.endswith('.info'):
+                    if not game_id or f'goggame-{game_id}.info' == name:
+                        return True
+        except OSError:
+            return False
+        return False
+
+    def _infer_game_id_from_goggame(self, game_dir: str) -> str | None:
+        """Infer game id from goggame info filename."""
+        try:
+            for name in os.listdir(game_dir):
+                if name.startswith('goggame-') and name.endswith('.info'):
+                    return name[len('goggame-'):-len('.info')]
+        except OSError:
+            pass
+        return None
+
+    def _resolve_exe(self, install_path: str) -> str | None:
+        """Resolve exe."""
+        if self._exe_finder is None:
+            return None
+        try:
+            return self._exe_finder(install_path)
+        except Exception as e:
+            logger.debug('[GOGLibrary] exe resolve: %s', e)
+            return None
+
+    async def _fetch_json(
+        self, url: str, headers: dict[str, str] | None = None,
+    ) -> Any | None:
+        """Fetch JSON."""
+        return await fetch_json_get(
+            url,
+            bearer=self._tokens.access_token,
+            user_agent=self._config.user_agent,
+            timeout=_GOG_LIBRARY_TIMEOUT_S,
+            extra_headers=headers,
+            log_prefix='[GOGLibrary]',
+        )
+
+
+_ = urllib.parse
+_ = build_ssl_context

--- a/py_modules/unifideck/stores/gog/library_migration.py
+++ b/py_modules/unifideck/stores/gog/library_migration.py
@@ -1,5 +1,146 @@
-"""library_migration.py — GOG library migration
+"""library_migration.py — Migrate legacy install markers in-place.
+
 # OP-50d | py_modules/unifideck/stores/gog/library_migration.py | Depends: OP-50c
+
+Older Unifideck builds wrote a flat ``.unifideck-id`` marker containing
+only the GOG id. The current scheme is a JSON document with metadata
+(title, install_id, language). This module rewrites old markers to the
+new format on the next library scan.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import glob
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .library import GOGLibrary
+
+logger = logging.getLogger(__name__)
+_INSTALL_MARKER = '.unifideck-id'
+
+
+class _MarkerMigration:
+    """Marker migration."""
+
+    def __init__(self, parent: GOGLibrary) -> None:
+        """Initialize the instance."""
+        self._parent = parent
+
+    def migrate_old_markers(self) -> dict[str, int]:
+        """Migrate old markers."""
+        download_dir = os.path.expanduser(self._parent._config.download_dir)
+        stats = {'scanned': 0, 'migrated': 0, 'skipped': 0}
+        if not os.path.isdir(download_dir):
+            return stats
+        for entry in sorted(os.listdir(download_dir)):
+            game_dir = os.path.join(download_dir, entry)
+            if not os.path.isdir(game_dir):
+                continue
+            marker_path = os.path.join(game_dir, _INSTALL_MARKER)
+            if not os.path.isfile(marker_path):
+                continue
+            stats['scanned'] += 1
+            if self._migrate_one_marker(game_dir, marker_path):
+                stats['migrated'] += 1
+            else:
+                stats['skipped'] += 1
+        return stats
+
+    def _migrate_one_marker(self, game_dir: str, marker_path: str) -> str:
+        """Migrate one marker."""
+        content = self._read_marker_content(marker_path)
+        if content is None:
+            return ''
+        if self._marker_is_new_format(content):
+            return ''
+        legacy_id = self._extract_legacy_id(content)
+        if not legacy_id:
+            return ''
+        new_data = self._build_new_marker_payload(game_dir, legacy_id)
+        return self._write_new_marker(marker_path, new_data, game_dir)
+
+    @staticmethod
+    def _read_marker_content(marker_path: str) -> str | None:
+        """Read marker content."""
+        try:
+            with open(marker_path, encoding='utf-8') as f:
+                return f.read()
+        except OSError as e:
+            logger.debug('[GOGMigration] read %s: %s', marker_path, e)
+            return None
+
+    @staticmethod
+    def _marker_is_new_format(content: str) -> bool:
+        """Marker is new format."""
+        stripped = content.strip()
+        if not stripped.startswith('{'):
+            return False
+        try:
+            json.loads(stripped)
+        except json.JSONDecodeError:
+            return False
+        return True
+
+    @staticmethod
+    def _extract_legacy_id(content: str) -> str | None:
+        """Extract legacy ID."""
+        candidate = content.strip().split('\n', 1)[0].strip()
+        return candidate if candidate.isdigit() else None
+
+    def _build_new_marker_payload(
+        self, game_dir: str, old_id: str,
+    ) -> dict[str, Any]:
+        """Build new marker payload."""
+        info = self._find_first_goggame_info(game_dir)
+        payload: dict[str, Any] = {
+            'game_id': old_id,
+            'install_path': game_dir,
+            'title': '',
+            'language': '',
+        }
+        if info:
+            try:
+                with open(info, encoding='utf-8') as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    payload['title'] = (
+                        data.get('name') or data.get('rootGameId') or ''
+                    )
+                    payload['language'] = data.get('language') or ''
+            except (OSError, json.JSONDecodeError):
+                pass
+        return payload
+
+    @staticmethod
+    def _write_new_marker(
+        marker_path: str,
+        new_data: dict[str, Any],
+        game_dir: str,
+    ) -> str:
+        """Write new marker."""
+        try:
+            with open(marker_path, 'w', encoding='utf-8') as f:
+                json.dump(new_data, f, indent=2)
+        except OSError as e:
+            logger.warning(
+                '[GOGMigration] write %s: %s', marker_path, e,
+            )
+            return ''
+        logger.info('[GOGMigration] migrated marker in %s', game_dir)
+        return new_data.get('game_id', '')
+
+    @staticmethod
+    def _find_first_goggame_info(directory: str) -> str | None:
+        """Find first goggame info."""
+        for match in glob.glob(os.path.join(directory, 'goggame-*.info')):
+            return match
+        for sub in ('game', 'bin'):
+            subpath = os.path.join(directory, sub)
+            for match in glob.glob(
+                os.path.join(subpath, 'goggame-*.info'),
+            ):
+                return match
+        return None

--- a/py_modules/unifideck/stores/gog/store.py
+++ b/py_modules/unifideck/stores/gog/store.py
@@ -1,5 +1,315 @@
-"""store.py — GOGStore — gogdl CLI wrapper
-# OP-50a | py_modules/unifideck/stores/gog/store.py | Depends: OP-47b
+"""store.py — Public ``GOGStore`` (StoreBase implementation).
+
+# OP-50a | py_modules/unifideck/stores/gog/store.py | Depends: (none)
+
+Façade that wires all the GOG submodules behind a single
+:class:`StoreBase` subclass.
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from ...auth.browser import OAuthBrowserMonitor
+from ...auth.edge_browser import EdgeBrowser
+from ...auth.orchestrator import AuthOrchestrator
+from ...core.types import (
+    AuthResult,
+    Events,
+    Game,
+    InstallResult,
+    Result,
+    StoreInfo,
+)
+from ...utils.locale import get_unifideck_locale
+from ..shared.store_base import StoreBase
+from .auth import GOGBrowserAuth
+from .config import GOG_AUTH_URL_FILE, GOGConfig
+from .dlc import GOGDlcManager
+from .exe_resolver import GOGExeResolver
+from .install import GOGInstaller
+from .library import GOGLibrary
+from .tokens import GOGTokenManager
+from .updates import GOGUpdatesChecker
+
+if TYPE_CHECKING:
+    from ...config import ConfigManager
+    from ...core.cache_manager import CacheManager
+    from ...event_bus.event_bus import EventBus
+    from ...services.shortcut.service import ShortcutService
+
+logger = logging.getLogger(__name__)
+
+
+class GOGStore(StoreBase):
+    """GOG store."""
+
+    store_info = StoreInfo(
+        name='gog',
+        display_name='GOG',
+        auth_method='oauth',
+        icon_asset='gog.png',
+        uses_wine=False,
+        supports_install=True,
+    )
+
+    def __init__(
+        self,
+        bus: EventBus,
+        cache: CacheManager,
+        plugin_dir: str | None = None,
+        config: ConfigManager | None = None,
+        browser_monitor: OAuthBrowserMonitor | None = None,
+        shortcut_service: ShortcutService | None = None,
+        edge_browser: EdgeBrowser | None = None,
+    ) -> None:
+        """Initialize the instance."""
+        super().__init__(bus, cache, plugin_dir, config)
+        self._gog_config = GOGConfig.from_config_manager(config)
+        logger.info('[GOGStore] %s', self._gog_config.describe())
+        self._config_manager = config
+        self._shortcut_service = shortcut_service
+        self._edge = edge_browser
+        self._browser_monitor = browser_monitor
+        self._tokens = GOGTokenManager(
+            config=self._gog_config, bus=bus,
+        )
+        self._exe_resolver = GOGExeResolver()
+        self._library = GOGLibrary(
+            config=self._gog_config,
+            tokens=self._tokens,
+            exe_finder=self._exe_resolver.find,
+        )
+        gogdl_bin = self._resolve_gogdl_bin()
+        self._installer = GOGInstaller(
+            config=self._gog_config,
+            tokens=self._tokens,
+            gogdl_bin=gogdl_bin or '',
+            exe_finder=self._exe_resolver.find,
+            locale_fn=self._unifideck_locale,
+        )
+        self._dlc = GOGDlcManager(
+            config=self._gog_config,
+            tokens=self._tokens,
+            gogdl_bin=gogdl_bin or '',
+            locale_fn=self._unifideck_locale,
+            resolve_install_path=self._library.get_installed_game_info,
+        )
+        self._updates = GOGUpdatesChecker(
+            config=self._gog_config,
+            tokens=self._tokens,
+            gogdl_bin=gogdl_bin or '',
+            get_installed_ids=self._library.get_installed,
+            resolve_install_info=self._library.get_installed_game_info,
+        )
+        if browser_monitor is not None:
+            orchestrator = AuthOrchestrator(
+                bus=bus,
+                browser_monitor=browser_monitor,
+                store_name='gog',
+            )
+            self._auth: GOGBrowserAuth | None = GOGBrowserAuth(
+                bus=bus,
+                orchestrator=orchestrator,
+                tokens=self._tokens,
+                config=self._gog_config,
+            )
+        else:
+            self._auth = None
+
+    def _unifideck_locale(self) -> str:
+        """Unifideck locale."""
+        try:
+            return get_unifideck_locale(self._config_manager) or 'en-US'
+        except Exception:
+            return 'en-US'
+
+    async def is_available(self) -> bool:
+        """Is available."""
+        if not self._gog_config.is_valid():
+            self._cached_available = False
+            return False
+        if not await self._tokens.load():
+            self._cached_available = False
+            return False
+        result = await self._library.is_available()
+        self._cached_available = result
+        return result
+
+    async def start_auth(self, **kwargs: Any) -> AuthResult:
+        """Start auth."""
+        if self._auth is None:
+            return AuthResult(
+                success=False, store='gog', error='auth_not_configured',
+            )
+        return await self._auth.start_auth()
+
+    async def complete_auth(
+        self, code: str = '', **kwargs: Any,
+    ) -> AuthResult:
+        """Complete auth."""
+        if self._auth is None:
+            return AuthResult(
+                success=False, store='gog', error='auth_not_configured',
+            )
+        if not code:
+            return AuthResult(
+                success=False, store='gog', error='no_auth_code',
+            )
+        ok = await self._tokens.exchange_code(code)
+        if not ok:
+            await self._bus.emit(
+                Events.STORE_AUTH_FAILED, store='gog', error='exchange_failed',
+            )
+            return AuthResult(
+                success=False, store='gog', error='exchange_failed',
+            )
+        await self._ensure_auth_shortcut()
+        await self._bus.emit(Events.STORE_AUTH_SUCCESS, store='gog')
+        return AuthResult(success=True, store='gog')
+
+    async def logout(self) -> Result:
+        """Logout."""
+        await self._tokens.clear()
+        if self._auth is not None:
+            return await self._auth.logout(
+                browser_monitor=self._browser_monitor,
+            )
+        await self._bus.emit(Events.STORE_LOGOUT, store='gog')
+        return Result(success=True)
+
+    async def get_library(self) -> list[Game] | None:
+        """Get library."""
+        try:
+            return await self._library.fetch_library()
+        except Exception as e:
+            logger.warning('[GOGStore] get_library failed: %s', e)
+            return None
+
+    async def install_game(
+        self,
+        game_id: str,
+        *,
+        base_path: str | None = None,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        language: str | None = None,
+        **kwargs: Any,
+    ) -> InstallResult:
+        """Install game."""
+        return await self._installer.install_game(
+            game_id,
+            base_path=base_path,
+            progress_cb=progress_cb,
+            language=language,
+        )
+
+    async def uninstall_game(
+        self, game_id: str, **kwargs: Any,
+    ) -> Result:
+        """Uninstall game."""
+        info = self._library.get_installed_game_info(game_id) or {}
+        install_path = info.get('install_path')
+        return await self._installer.uninstall_game(
+            game_id, install_path=install_path,
+        )
+
+    async def update_game(
+        self, game_id: str, **kwargs: Any,
+    ) -> InstallResult:
+        """Update game."""
+        info = self._library.get_installed_game_info(game_id) or {}
+        install_path = info.get('install_path')
+        result = await self._updates.update_game(
+            game_id, install_path=install_path,
+        )
+        if result.success:
+            return InstallResult(
+                success=True, store='gog', game_id=game_id,
+                install_path=install_path or '',
+            )
+        return InstallResult(
+            success=False, store='gog', game_id=game_id,
+            error=str(result.error or 'update_failed'),
+        )
+
+    async def check_for_updates(self) -> list[str]:
+        """Check for updates."""
+        return await self._updates.check_for_updates()
+
+    async def get_game_size(self, game_id: str) -> int | None:
+        """Get game size."""
+        info = self._library.get_installed_game_info(game_id) or {}
+        path = info.get('install_path')
+        if not path or not os.path.isdir(path):
+            return None
+        from .install.primitives import GOGFolderOps
+        return GOGFolderOps.folder_size(path)
+
+    async def get_game_dlcs(self, game_id: str) -> list[dict[str, Any]]:
+        """Get game DLCs."""
+        return await self._dlc.get_game_dlcs(game_id)
+
+    async def get_available_languages(self, game_id: str) -> list[str]:
+        """Get available languages."""
+        return await self._dlc.get_available_languages(game_id)
+
+    async def install_dlc(
+        self,
+        game_id: str,
+        dlc_id: str,
+        base_path: str | None = None,
+        progress_cb: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    ) -> Result:
+        """Install DLC."""
+        return await self._dlc.install_dlc(
+            game_id, dlc_id, base_path=base_path, progress_cb=progress_cb,
+        )
+
+    async def get_game_store_url(self, game_id: str) -> str | None:
+        """Get game store URL."""
+        return await self._dlc.get_game_store_url(game_id)
+
+    async def get_game_slug(self, game_id: str) -> str | None:
+        """Get game slug."""
+        return await self._library.get_game_slug(game_id)
+
+    def get_installed(self) -> list[str]:
+        """Get installed."""
+        return self._library.get_installed()
+
+    def get_installed_game_info(
+        self, game_id: str,
+    ) -> dict[str, str | None] | None:
+        """Get installed game info."""
+        return self._library.get_installed_game_info(game_id)
+
+    def migrate_old_markers(self) -> dict[str, int]:
+        """Migrate old markers."""
+        return self._library.migrate_old_markers()
+
+    def _resolve_gogdl_bin(self) -> str:
+        """Resolve GOGDL bin."""
+        if self._plugin_dir:
+            candidate = os.path.join(self._plugin_dir, 'bin', 'gogdl', 'gogdl')
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        for candidate in (
+            os.path.expanduser('~/.local/bin/gogdl'),
+            '/usr/bin/gogdl',
+        ):
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        return ''
+
+    async def _ensure_auth_shortcut(self) -> None:
+        """Ensure auth shortcut."""
+        # GOG doesn't need a Steam auth shortcut — UPC-only concern.
+
+    def _browser_monitor_from_auth(self) -> OAuthBrowserMonitor | None:
+        """Browser monitor from auth."""
+        return self._browser_monitor
+
+
+_ = GOG_AUTH_URL_FILE

--- a/py_modules/unifideck/stores/gog/tokens/__init__.py
+++ b/py_modules/unifideck/stores/gog/tokens/__init__.py
@@ -1,0 +1,5 @@
+# OP-52 | stores/gog/tokens/__init__.py
+from .manager import GOGTokenManager
+from .user_info import GOGUserInfo
+
+__all__ = ['GOGTokenManager', 'GOGUserInfo']

--- a/py_modules/unifideck/stores/gog/tokens/gogdl_credentials.py
+++ b/py_modules/unifideck/stores/gog/tokens/gogdl_credentials.py
@@ -1,0 +1,92 @@
+"""gogdl_credentials.py — Write the on-disk credentials file ``gogdl`` reads.
+
+# OP-52d | py_modules/unifideck/stores/gog/tokens/gogdl_credentials.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from ..config import GOGConfig
+    CleanupFn = Callable[[], Awaitable[None]]
+
+logger = logging.getLogger(__name__)
+
+
+class _GogdlCreds:
+    """Gogdl creds."""
+
+    def __init__(self, *, config: GOGConfig) -> None:
+        """Initialize the instance."""
+        self._config = config
+
+    async def acquire(
+        self, access_token: str, refresh_token: str,
+    ) -> tuple[dict[str, str], CleanupFn]:
+        """Acquire."""
+        data = self._build_gogdl_data(access_token, refresh_token)
+        tmpdir = tempfile.mkdtemp(prefix='unifideck-gogdl-')
+        creds_path = os.path.join(tmpdir, 'credentials.json')
+        await asyncio.to_thread(
+            self._write_creds_sync, creds_path, data,
+        )
+        env = {'GOGDL_CONFIG_PATH': tmpdir}
+        return env, self._make_cleanup(creds_path, tmpdir)
+
+    def _build_gogdl_data(
+        self, access_token: str, refresh_token: str,
+    ) -> dict[str, dict[str, object]]:
+        """Build GOGDL data."""
+        return {
+            'galaxy': {
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'expires_in': 3600,
+                'token_type': 'bearer',
+                'user_id': '',
+                'session_id': '',
+                'scope': '',
+                'loginTime': int(time.time()),
+                'client_id': self._config.client_id,
+                'client_secret': self._config.client_secret,
+            },
+        }
+
+    @staticmethod
+    def _write_creds_sync(
+        creds_path: str, gogdl_data: dict[str, dict[str, object]],
+    ) -> None:
+        """Write creds sync."""
+        os.makedirs(os.path.dirname(creds_path), exist_ok=True)
+        with open(creds_path, 'w', encoding='utf-8') as f:
+            json.dump(gogdl_data, f)
+        os.chmod(creds_path, 0o600)
+
+    @staticmethod
+    def _make_cleanup(creds_path: str, tmpdir: str) -> CleanupFn:
+        """Make cleanup."""
+
+        async def _cleanup() -> None:
+            def _do() -> None:
+                for p in (creds_path, tmpdir):
+                    try:
+                        if os.path.isfile(p):
+                            os.unlink(p)
+                        elif os.path.isdir(p):
+                            os.rmdir(p)
+                    except OSError as e:
+                        logger.debug(
+                            '[GOGGogdlCreds] cleanup %s: %s', p, e,
+                        )
+
+            await asyncio.to_thread(_do)
+
+        return _cleanup

--- a/py_modules/unifideck/stores/gog/tokens/manager.py
+++ b/py_modules/unifideck/stores/gog/tokens/manager.py
@@ -1,0 +1,164 @@
+"""manager.py — Public ``GOGTokenManager`` surface.
+
+# OP-52a | py_modules/unifideck/stores/gog/tokens/manager.py | Depends: (none)
+"""
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from ....security import SecureTokenStore
+from .gogdl_credentials import _GogdlCreds
+from .oauth import _TokenOAuth
+from .storage import _TokenStorage
+from .user_info import GOGUserInfo
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from ..config import GOGConfig
+
+logger = logging.getLogger(__name__)
+
+
+class GOGTokenManager:
+    """GOG token manager."""
+
+    def __init__(
+        self,
+        config: GOGConfig,
+        secure_store: SecureTokenStore | None = None,
+        bus: Any = None,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._bus = bus
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._user_info: GOGUserInfo = GOGUserInfo()
+        self._token_minted_at: float = 0.0
+        self._storage = _TokenStorage(
+            config=config, bus=bus,
+            secure_store=secure_store or SecureTokenStore(bus=bus),
+        )
+        self._oauth = _TokenOAuth(
+            config=config, save_callback=self._save_oauth_tokens,
+        )
+        self._gogdl_creds = _GogdlCreds(config=config)
+
+    @property
+    def access_token(self) -> str | None:
+        """Access token."""
+        return self._access_token
+
+    @property
+    def refresh_token(self) -> str | None:
+        """Refresh token."""
+        return self._refresh_token
+
+    @property
+    def user_info(self) -> GOGUserInfo:
+        """User info."""
+        return self._user_info
+
+    @property
+    def has_tokens(self) -> bool:
+        """Has tokens."""
+        return bool(self._access_token and self._refresh_token)
+
+    def get_token_age_seconds(self) -> float:
+        """Get token age seconds."""
+        if not self._token_minted_at:
+            return float('inf')
+        return time.time() - self._token_minted_at
+
+    async def load(self) -> bool:
+        """Load."""
+        loaded = await self._storage.load()
+        if loaded is None:
+            return False
+        access, refresh, info = loaded
+        self._access_token = access
+        self._refresh_token = refresh
+        self._user_info = info
+        self._token_minted_at = time.time()
+        return True
+
+    async def save(self, access_token: str, refresh_token: str) -> bool:
+        """Save."""
+        return await self._save_oauth_tokens(access_token, refresh_token)
+
+    async def clear(self) -> None:
+        """Clear."""
+        self._access_token = None
+        self._refresh_token = None
+        self._user_info = GOGUserInfo()
+        self._token_minted_at = 0.0
+        await self._storage.clear_files()
+
+    async def exchange_code(self, auth_code: str) -> bool:
+        """Exchange code."""
+        ok = await self._oauth.exchange_code(auth_code)
+        if not ok:
+            return False
+        await self._refresh_user_info()
+        return True
+
+    async def refresh_if_stale(self) -> bool:
+        """Refresh if stale."""
+        ok = await self._oauth.refresh_if_stale(
+            access_token=self._access_token,
+            refresh_token=self._refresh_token,
+            age_seconds=self.get_token_age_seconds(),
+        )
+        if not ok:
+            return False
+        if self.get_token_age_seconds() < self._config.token_refresh_threshold_seconds:
+            return True
+        await self._refresh_user_info()
+        return True
+
+    @contextlib.asynccontextmanager
+    async def gogdl_credentials(self) -> AsyncIterator[dict[str, str]]:
+        """Gogdl credentials."""
+        env, cleanup = await self.acquire_gogdl_creds()
+        try:
+            yield env
+        finally:
+            try:
+                await cleanup()
+            except Exception as e:
+                logger.debug('[GOGTokenManager] cleanup: %s', e)
+
+    async def acquire_gogdl_creds(self) -> tuple[dict[str, str], Any]:
+        """Acquire GOGDL creds."""
+        await self.refresh_if_stale()
+        if not self._access_token or not self._refresh_token:
+            raise RuntimeError('no_tokens')
+        return await self._gogdl_creds.acquire(
+            self._access_token, self._refresh_token,
+        )
+
+    async def _save_oauth_tokens(
+        self, access_token: str, refresh_token: str,
+    ) -> bool:
+        """Save oauth tokens."""
+        self._access_token = access_token
+        self._refresh_token = refresh_token
+        self._token_minted_at = time.time()
+        return await self._storage.persist(
+            access_token, refresh_token, self._user_info,
+        )
+
+    async def _refresh_user_info(self) -> None:
+        """Refresh user info."""
+        if not self._access_token:
+            return
+        self._user_info = await self._oauth.fetch_user_info(
+            self._access_token, self._user_info,
+        )
+        await self._storage.persist(
+            self._access_token, self._refresh_token or '', self._user_info,
+        )

--- a/py_modules/unifideck/stores/gog/tokens/oauth.py
+++ b/py_modules/unifideck/stores/gog/tokens/oauth.py
@@ -1,0 +1,122 @@
+"""oauth.py — GOG OAuth code/refresh exchanger.
+
+# OP-52c | py_modules/unifideck/stores/gog/tokens/oauth.py | Depends: (none)
+
+Handles the three OAuth verbs GOG cares about — auth_code exchange,
+silent refresh, and user_info fetch — using :mod:`..http` underneath.
+The ``save_callback`` is invoked whenever new tokens are minted so
+the :class:`_TokenStorage` can persist them.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import urllib.parse
+from typing import TYPE_CHECKING, Any
+
+from ..http import fetch_json_get
+from .user_info import GOGUserInfo
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from ..config import GOGConfig
+    SaveCallback = Callable[[str, str], Awaitable[bool]]
+
+logger = logging.getLogger(__name__)
+
+
+class _TokenOAuth:
+    """Token oauth."""
+
+    def __init__(
+        self, *, config: GOGConfig, save_callback: SaveCallback,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._save_callback = save_callback
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._token_minted_at: float = 0.0
+
+    async def exchange_code(self, auth_code: str) -> bool:
+        """Exchange code."""
+        if not auth_code or not self._config.token_url:
+            return False
+        params = {
+            'client_id': self._config.client_id,
+            'client_secret': self._config.client_secret,
+            'grant_type': 'authorization_code',
+            'code': auth_code,
+            'redirect_uri': self._config.redirect_uri,
+        }
+        return await self._token_request(params)
+
+    async def refresh_if_stale(
+        self,
+        *,
+        access_token: str | None,
+        refresh_token: str | None,
+        age_seconds: float,
+    ) -> bool:
+        """Refresh if stale."""
+        self._access_token = access_token
+        self._refresh_token = refresh_token
+        if not refresh_token:
+            return False
+        if age_seconds < self._config.token_refresh_threshold_seconds:
+            return True
+        params = {
+            'client_id': self._config.client_id,
+            'client_secret': self._config.client_secret,
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token,
+        }
+        return await self._token_request(params)
+
+    async def fetch_user_info(
+        self, access_token: str, fallback: GOGUserInfo,
+    ) -> GOGUserInfo:
+        """Fetch user info."""
+        if not access_token or not self._config.api_gog_url:
+            return fallback
+        payload = await fetch_json_get(
+            f'{self._config.api_gog_url}/user/data/account',
+            bearer=access_token,
+            user_agent=self._config.user_agent,
+            log_prefix='[GOGOAuth]',
+        )
+        if not isinstance(payload, dict):
+            return fallback
+        username = payload.get('username') or payload.get('email') or ''
+        galaxy_user_id = (
+            str(payload.get('galaxyUserId') or payload.get('userId') or '')
+        )
+        return GOGUserInfo(
+            username=str(username),
+            galaxy_user_id=galaxy_user_id,
+        )
+
+    async def _token_request(self, params: dict[str, str]) -> bool:
+        """Token request."""
+        url = (
+            f'{self._config.token_url}?{urllib.parse.urlencode(params)}'
+        )
+        payload = await fetch_json_get(
+            url,
+            user_agent=self._config.user_agent,
+            log_prefix='[GOGOAuth]',
+        )
+        if not isinstance(payload, dict):
+            return False
+        access = payload.get('access_token')
+        refresh = payload.get('refresh_token')
+        if not isinstance(access, str) or not isinstance(refresh, str):
+            return False
+        self._access_token = access
+        self._refresh_token = refresh
+        self._token_minted_at = time.time()
+        return await self._save_callback(access, refresh)
+
+
+_: Any = None

--- a/py_modules/unifideck/stores/gog/tokens/storage.py
+++ b/py_modules/unifideck/stores/gog/tokens/storage.py
@@ -1,0 +1,225 @@
+"""storage.py — On-disk store for GOG tokens.
+
+# OP-52b | py_modules/unifideck/stores/gog/tokens/storage.py | Depends: (none)
+
+Token file is encrypted via :class:`SecureTokenStore` when possible
+and degrades to plaintext when the secure store can't be opened.
+Plaintext reads emit a ``LEGACY_PLAINTEXT_DETECTED`` audit event so
+the deployment can be flagged for migration.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from ....security import (
+    SecureTokenStore,
+    SecureTokenStoreError,
+    emit_legacy_plaintext_detected,
+    emit_permissions_check,
+    emit_token_file_migrated,
+)
+from .user_info import GOGUserInfo
+
+if TYPE_CHECKING:
+    from ..config import GOGConfig
+
+logger = logging.getLogger(__name__)
+
+
+class _TokenStorage:
+    """Token storage."""
+
+    def __init__(
+        self,
+        *,
+        config: GOGConfig,
+        bus: Any,
+        secure_store: SecureTokenStore,
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._bus = bus
+        self._secure_store = secure_store
+        self._token_path = os.path.expanduser(config.token_file)
+
+    async def load(self) -> tuple[str, str, GOGUserInfo] | None:
+        """Load."""
+        path = self._token_path
+        if not Path(path).is_file():
+            return None
+        blob = await asyncio.to_thread(self._read_sync)
+        if blob is None:
+            return None
+        data = self._parse_token_blob(blob, path)
+        if data is None:
+            return None
+        access = data.get('access_token')
+        refresh = data.get('refresh_token')
+        if not isinstance(access, str) or not isinstance(refresh, str):
+            return None
+        user = data.get('user_info') or {}
+        info = GOGUserInfo(
+            username=str(user.get('username', '')),
+            galaxy_user_id=str(user.get('galaxy_user_id', '')),
+        )
+        return access, refresh, info
+
+    async def persist(
+        self,
+        access_token: str,
+        refresh_token: str,
+        user_info: GOGUserInfo,
+    ) -> bool:
+        """Persist."""
+        payload: dict[str, Any] = {
+            'access_token': access_token,
+            'refresh_token': refresh_token,
+            'user_info': {
+                'username': user_info.username,
+                'galaxy_user_id': user_info.galaxy_user_id,
+            },
+            'saved_at': int(time.time()),
+        }
+        try:
+            blob = self._secure_store.encrypt_payload(payload)
+        except SecureTokenStoreError as e:
+            logger.warning('[GOGTokens] encrypt failed, plaintext: %s', e)
+            blob = json.dumps(payload).encode('utf-8')
+        ok = await asyncio.to_thread(
+            self._write_token_file_atomic, self._token_path, blob,
+        )
+        if ok:
+            await self._emit_post_save_security(self._token_path)
+            await asyncio.to_thread(self._remove_stale_gogdl_mirror)
+        return ok
+
+    async def clear_files(self) -> None:
+        """Clear files."""
+        for path in (
+            self._token_path,
+            os.path.expanduser(self._gogdl_creds_path()),
+        ):
+            try:
+                if os.path.isfile(path):
+                    os.unlink(path)
+            except OSError as e:
+                logger.debug('[GOGTokens] unlink %s: %s', path, e)
+
+    @staticmethod
+    def _write_token_file_atomic(path: str, blob: bytes) -> bool:
+        """Write token file atomic."""
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            tmp = path + '.tmp'
+            with open(tmp, 'wb') as f:
+                f.write(blob)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+        except OSError as e:
+            logger.warning('[GOGTokens] write %s: %s', path, e)
+            return False
+        return True
+
+    async def _emit_post_save_security(self, path: str) -> None:
+        """Emit post save security."""
+        try:
+            mode = os.stat(path).st_mode & 0o777 if os.path.isfile(path) else None
+        except OSError:
+            mode = None
+        if mode is not None:
+            await emit_permissions_check(
+                self._bus, store='gog', path=path, mode=mode,
+            )
+
+    def _parse_token_blob(
+        self, blob: bytes, path: str,
+    ) -> dict[str, Any] | None:
+        """Parse token blob."""
+        if self._secure_store.is_encrypted(blob):
+            try:
+                return self._secure_store.decrypt_payload(blob)
+            except SecureTokenStoreError as e:
+                logger.warning('[GOGTokens] decrypt %s: %s', path, e)
+                return None
+        try:
+            data = json.loads(blob.decode('utf-8'))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            logger.warning('[GOGTokens] parse %s: %s', path, e)
+            return None
+        if isinstance(data, dict):
+            asyncio.get_event_loop_policy()
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(
+                    emit_legacy_plaintext_detected(
+                        self._bus, store='gog', path=path,
+                    ),
+                    name='gog_legacy_plaintext_detected',
+                )
+            except RuntimeError:
+                pass
+            return cast(dict[str, Any], data)
+        return None
+
+    async def _emit_post_save_security(self, path: str) -> None:  # noqa: F811
+        """Emit post save security (kept for symmetry with PDF spec)."""
+        try:
+            mode = os.stat(path).st_mode & 0o777 if os.path.isfile(path) else None
+        except OSError:
+            mode = None
+        if mode is not None:
+            await emit_permissions_check(
+                self._bus, store='gog', path=path, mode=mode,
+            )
+
+    def _read_sync(self) -> bytes | None:
+        """Read sync."""
+        try:
+            with open(self._token_path, 'rb') as f:
+                return f.read()
+        except OSError as e:
+            logger.warning('[GOGTokens] read failed: %s', e)
+            return None
+
+    def _gogdl_creds_path(self) -> str:
+        """GOGDL creds path."""
+        return os.path.join(self._config.gogdl_config_dir, 'credentials.json')
+
+    def _remove_stale_gogdl_mirror(self) -> None:
+        """Remove stale GOGDL mirror.
+
+        After a fresh secure-store write we drop the old plaintext
+        gogdl credentials mirror so the next ``gogdl`` invocation
+        re-mints it from the live tokens.
+        """
+        mirror = os.path.expanduser(self._gogdl_creds_path())
+        try:
+            if os.path.isfile(mirror):
+                os.unlink(mirror)
+                _emit_migrated(self._bus)
+        except OSError as e:
+            logger.debug('[GOGTokens] mirror unlink: %s', e)
+
+
+def _emit_migrated(bus: Any) -> None:
+    """Emit migrated.
+
+    Schedules ``emit_token_file_migrated`` on the running loop if any.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(
+        emit_token_file_migrated(bus, store='gog'),
+        name='gog_token_file_migrated',
+    )
+
+
+_ = time

--- a/py_modules/unifideck/stores/gog/tokens/user_info.py
+++ b/py_modules/unifideck/stores/gog/tokens/user_info.py
@@ -1,0 +1,15 @@
+"""user_info.py — Frozen value-object for the GOG user record.
+
+# OP-52e | py_modules/unifideck/stores/gog/tokens/user_info.py | Depends: (none)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class GOGUserInfo:
+    """GOG user info."""
+
+    username: str = ''
+    galaxy_user_id: str = ''

--- a/py_modules/unifideck/stores/gog/updates.py
+++ b/py_modules/unifideck/stores/gog/updates.py
@@ -1,5 +1,172 @@
-"""updates.py — GOG update checker
+"""updates.py — Detect & apply GOG content updates via gogdl.
+
 # OP-50g | py_modules/unifideck/stores/gog/updates.py | Depends: OP-50a
 """
 from __future__ import annotations
-# TODO: implement — see operational plan PDF
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ...core.types import Result
+from .config import GOGConfig
+from .http import fetch_json_get
+from .tokens import GOGTokenManager
+
+logger = logging.getLogger(__name__)
+_CONTENT_SYSTEM_URL_TEMPLATE = (
+    'https://content-system.gog.com/products/{game_id}/os/windows/'
+    'builds?generation=2'
+)
+_UPDATE_CHECK_TIMEOUT_S = 10.0
+
+
+class GOGUpdatesChecker:
+    """GOG updates checker."""
+
+    def __init__(
+        self,
+        config: GOGConfig,
+        tokens: GOGTokenManager,
+        gogdl_bin: str,
+        get_installed_ids: Callable[[], list[str]],
+        resolve_install_info: Callable[[str], dict[str, str | None] | None],
+    ) -> None:
+        """Initialize the instance."""
+        self._config = config
+        self._tokens = tokens
+        self._gogdl_bin = gogdl_bin
+        self._get_installed_ids = get_installed_ids
+        self._resolve_install_info = resolve_install_info
+
+    @staticmethod
+    def get_local_build_id(install_path: str, game_id: str) -> str | None:
+        """Get local build ID."""
+        if not install_path:
+            return None
+        candidates = [
+            os.path.join(install_path, f'goggame-{game_id}.info'),
+            os.path.join(install_path, 'game', f'goggame-{game_id}.info'),
+        ]
+        for path in candidates:
+            if not os.path.isfile(path):
+                continue
+            try:
+                data = json.loads(Path(path).read_text(encoding='utf-8'))
+            except (OSError, json.JSONDecodeError):
+                continue
+            build = data.get('buildId') if isinstance(data, dict) else None
+            if isinstance(build, (str, int)):
+                return str(build)
+        return None
+
+    async def check_for_game_update(self, game_id: str) -> bool | None:
+        """Check for game update."""
+        info = self._resolve_install_info(game_id) or {}
+        install_path = info.get('install_path') if isinstance(info, dict) else None
+        if not install_path:
+            return None
+        local = self.get_local_build_id(install_path, game_id)
+        if not local:
+            return None
+        remote = await self._fetch_remote_build_id(game_id)
+        if not remote:
+            return None
+        return remote != local
+
+    async def _fetch_remote_build_id(self, game_id: str) -> str | None:
+        """Fetch remote build ID."""
+        url = _CONTENT_SYSTEM_URL_TEMPLATE.format(game_id=game_id)
+        data = await fetch_json_get(
+            url,
+            user_agent=self._config.user_agent,
+            timeout=_UPDATE_CHECK_TIMEOUT_S,
+            log_prefix='[GOGUpdates]',
+        )
+        if not isinstance(data, dict):
+            return None
+        items = data.get('items')
+        if isinstance(items, list) and items:
+            build = items[0].get('build_id') if isinstance(items[0], dict) else None
+            return str(build) if build else None
+        return None
+
+    async def check_for_updates(self) -> list[str]:
+        """Check for updates."""
+        out: list[str] = []
+        for game_id in self._get_installed_ids():
+            try:
+                needs = await self.check_for_game_update(game_id)
+            except Exception as e:
+                logger.debug(
+                    '[GOGUpdates] check %s: %s', game_id, e,
+                )
+                continue
+            if needs:
+                out.append(game_id)
+        return out
+
+    async def update_game(
+        self, game_id: str, install_path: str | None = None,
+    ) -> Result:
+        """Update game."""
+        path = self._update_resolve_path(game_id, install_path)
+        if not path[1]:
+            return Result(success=False, error='no_install_path')
+        if not self._gogdl_bin:
+            return Result(success=False, error='gogdl_not_found')
+        if not await self._tokens.refresh_if_stale():
+            return Result(success=False, error='no_tokens')
+        proc = await self._update_spawn_gogdl(game_id, path[1])
+        if proc is None:
+            return Result(success=False, error='gogdl_spawn_failed')
+        await self._update_drain_output(proc)
+        return await self._update_finalize(proc, game_id)
+
+    def _update_resolve_path(
+        self, game_id: str, install_path: str | None,
+    ) -> tuple:
+        """Update resolve path."""
+        if install_path:
+            return game_id, install_path
+        info = self._resolve_install_info(game_id) or {}
+        return game_id, (info.get('install_path') if isinstance(info, dict) else None)
+
+    async def _update_spawn_gogdl(
+        self, game_id: str, install_path: str,
+    ) -> Any | None:
+        """Update spawn GOGDL."""
+        try:
+            async with self._tokens.gogdl_credentials() as env:
+                return await asyncio.create_subprocess_exec(
+                    self._gogdl_bin, 'update',
+                    game_id, '--path', install_path,
+                    env={**env},
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+        except OSError as e:
+            logger.warning('[GOGUpdates] spawn: %s', e)
+            return None
+
+    @staticmethod
+    async def _update_drain_output(proc: Any) -> None:
+        """Update drain output."""
+        if proc.stdout is None:
+            return
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+
+    @staticmethod
+    async def _update_finalize(proc: Any, game_id: str) -> Result:
+        """Update finalize."""
+        rc = await proc.wait()
+        if rc != 0:
+            return Result(success=False, error=f'gogdl_rc:{rc}')
+        return Result(success=True, data={'game_id': game_id})


### PR DESCRIPTION
# GOG implementation: done

## What landed — 22 files matching the PDF spec, all under `py_modules/unifideck/stores/gog/`:

*   **OP-50 root (9 + init)**: http, config, exe_resolver, library_migration, library, dlc, updates, auth, store
*   **OP-52 tokens (5 + init)** (new directory): user_info, oauth, storage, gogdl_credentials, manager
*   **OP-51 install (8 + init)** (new directory): primitives, languages, helpers, marker, progress, planner, uninstall_pipeline, installer
*   **Wiring**: `services/bootstrap/store_injector.py` now injects `_browser_monitor` into the GOG store after auto-discovery.

## Validation

*   **Import smoke**: `import unifideck.stores.gog` resolves; `GOGStore.store_info = StoreInfo(name='gog', auth_method='oauth', uses_wine=False, supports_install=True)`.
*   **Auto-discovery smoke**: `StoreRegistry.auto_discover(...)` now returns `['gog', 'ubisoft']` — both subpackage stores register via the Phase-0 recursion.
*   `pytest tests/stores/` → 9/9 pass.
*   **Ruff**: 19 remaining lints, all stylistic (D204 blank-line-after-docstring, BLE001 broad-except, S310 url-audit on whitelisted GOG endpoints, E741 ambiguous `l` loop var, S105 hardcoded string `'authorization_code'`) — matching the Ubisoft pattern.

## Notes

*   `GOGTokenManager` stores tokens via `SecureTokenStore` when available (encrypted at rest) and falls back to plaintext JSON with a one-time `LEGACY_PLAINTEXT_DETECTED` audit event.
*   `gogdl` is resolved from `<plugin_dir>/bin/gogdl/gogdl` → `~/.local/bin/gogdl` → `/usr/bin/gogdl` (matching how legendary is resolved for Epic).
*   `ShortcutService` import dropped from `store.py` runtime imports because the existing `services/shortcut/__init__.py` doesn't re-export the class (same pre-existing gap that affects Microsoft); the type hint is now under `TYPE_CHECKING`.
