### PR TITLE
feat/security: prefix unused __aexit__ params with underscore. Close vulture issues

### DIFF
--- a/py_modules/unifideck/security/ephemeral_creds.py
+++ b/py_modules/unifideck/security/ephemeral_creds.py
@@ -193,8 +193,13 @@ class EphemeralCredentialContext:
     async def __aexit__(
         self,
         exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: Any,
+        # ``_exc`` and ``_tb`` are part of the async
+        # context-manager protocol signature but are not used
+        # here (only ``exc_type`` is inspected); the leading
+        # underscores mark them intentionally unused so static
+        # analysers (vulture) don't flag them.
+        _exc: BaseException | None,
+        _tb: Any,
     ) -> None:
         """Re-encrypt rotated plaintext (on success) + wipe tempdir.
 

--- a/py_modules/unifideck/security/ephemeral_creds_inplace.py
+++ b/py_modules/unifideck/security/ephemeral_creds_inplace.py
@@ -151,8 +151,13 @@ class InPlaceEphemeralFile:
     async def __aexit__(
         self,
         exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: Any,
+        # ``_exc`` and ``_tb`` are part of the async
+        # context-manager protocol signature but are not used
+        # here (only ``exc_type`` is inspected); the leading
+        # underscores mark them intentionally unused so static
+        # analysers (vulture) don't flag them.
+        _exc: BaseException | None,
+        _tb: Any,
     ) -> None:
         """Re-encrypt rotated plaintext (success); wipe in all cases.
 


### PR DESCRIPTION
# mark unused `__aexit__` params as `_exc` / `_tb`

## Summary

`vulture` (≥80 % confidence) flagged dead variables in the two new
`security/ephemeral_creds*` modules:

| File | Line | Symbol |
|------|------|--------|
| `py_modules/unifideck/security/ephemeral_creds.py` | 196–197 | `exc`, `tb` |
| `py_modules/unifideck/security/ephemeral_creds_inplace.py` | 154–155 | `exc`, `tb` |

These are **not** real dead code: `exc` and `tb` are the 2nd and 3rd
parameters of the async context-manager protocol
(`async def __aexit__(self, exc_type, exc, tb)`). They are
structurally required by `async with` even though only `exc_type` is
inspected in these implementations. Removing them would break the
context manager at runtime.

This PR renames them to `_exc` / `_tb` — the idiomatic Python
convention for "required but intentionally unused" — so static
analysis is clean without altering behaviour.

## Changes

- `EphemeralCredentialContext.__aexit__` (`ephemeral_creds.py`):
  `exc` → `_exc`, `tb` → `_tb`, with an explanatory comment.
- `InPlaceEphemeralFile.__aexit__` (`ephemeral_creds_inplace.py`):
  same rename + comment.
- `exc_type` is **unchanged** (it is used: `if exc_type is None:`).

## Rationale

Static analysis can't tell a protocol-mandated parameter from a
genuinely dead one. The underscore prefix is the standard signal
that a parameter must exist for interface conformance but is not
consumed. This keeps `vulture` actionable (real findings aren't
drowned out by protocol noise) without a whitelist entry or an
inline `# noqa`.

## Behaviour impact

None. The context-manager protocol is preserved (three positional
parameters, same order, same types); only the local names change.
No call site references these parameters by keyword.

## Validation

- [x] `python -m ast` parse OK on both files
- [x] `vulture --min-confidence 80` → **0 findings** on both files
- [x] `exc_type` still inspected (`if exc_type is None:`)
- [x] No other occurrence of `exc` / `tb` in either file (rename is safe)
- [x] No behavioural change (signature shape unchanged)