### PR TITLE
Align locale handling with UI settings and propagate to launch paths

### DIFF
--- a/py_modules/unifideck/config/config_manager.py
+++ b/py_modules/unifideck/config/config_manager.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 _FALLBACK: dict[str, Any] = {
     "data_dir": "~/.local/share/unifideck",
     "ui": {
-        "language": "en-US",
+        "locale": "auto",
     },
     "sync": {
         "interval_seconds": 300,
@@ -95,8 +95,8 @@ class ConfigManager:
     defaults_path="/path/to/defaults/config.json",
     user_path="~/.config/unifideck/config.json",
     )
-    lang = config.get("ui.language", default="en-US")
-    config.set("ui.language", "fr-FR") # persisted.
+    lang = config.get("ui.locale", default="auto")
+    config.set("ui.locale", "fr-FR") # persisted.
     """
 
     def __init__(

--- a/py_modules/unifideck/launcher/bootstrap.py
+++ b/py_modules/unifideck/launcher/bootstrap.py
@@ -62,9 +62,10 @@ def build_launcher_service(config: Any | None = None) -> Any:
             "bootstrap: cloudsave service unavailable — "
             "launching without cloud-save sync",
         )
+    from unifideck.utils.locale import get_unifideck_locale
     edge_browser = EdgeBrowser(
         cdp_port=config.get_int("edge.cdp_port", 9222),
-        locale_fn=lambda: config.get_str("ui.locale", "en-US"),
+        locale_fn=lambda: get_unifideck_locale(config),
     )
     return LauncherService(
         bus=bus,

--- a/py_modules/unifideck/launcher/proton/compat/epic.py
+++ b/py_modules/unifideck/launcher/proton/compat/epic.py
@@ -87,6 +87,21 @@ def build_legendary_env(
     env["HEROIC_APP_RUNNER"] = "legendary"
     if config_path:
         env["LEGENDARY_CONFIG_PATH"] = config_path
+    try:
+        from unifideck.launcher.bootstrap import _load_standalone_config
+        from unifideck.launcher.proton.language_setup import (
+            get_unifideck_language,
+        )
+        from unifideck.utils.locale import locale_to_epic_language
+
+        env["EPIC_LANG"] = locale_to_epic_language(
+            get_unifideck_language(_load_standalone_config()),
+        )
+    except Exception:
+        logger.exception(
+            "[compat.epic] EPIC_LANG resolution failed, using en",
+        )
+        env.setdefault("EPIC_LANG", "en")
     return env
 
 

--- a/py_modules/unifideck/launcher/proton/handlers/epic.py
+++ b/py_modules/unifideck/launcher/proton/handlers/epic.py
@@ -93,7 +93,7 @@ async def epic_launch(plan: ProtonLaunchPlan) -> int:
     )
     apply_rockstar_egs_setup(plan)
     legendary_bin, env = await _prepare_epic_env(plan)
-    argv = _build_legendary_argv(plan, legendary_bin)
+    argv = _build_legendary_argv(plan, legendary_bin, env)
     rc = await run_umu_with_retry(
         argv, env=env, on_start=plan.on_process_start,
     )
@@ -126,7 +126,9 @@ async def _prepare_epic_env(
 
 
 def _build_legendary_argv(
-    plan: ProtonLaunchPlan, legendary_bin: str,
+    plan: ProtonLaunchPlan,
+    legendary_bin: str,
+    launch_env: dict[str, str] | None = None,
 ) -> list[str]:
     """Assemble the ``legendary launch`` argv (offline, language, overrides)."""
     from unifideck.launcher.proton.compat.epic import detect_offline
@@ -141,6 +143,11 @@ def _build_legendary_argv(
     if detect_offline():
         argv.append("--offline")
         logger.info("[launcher.proton.epic] offline mode — passing --offline")
+    epic_lang = (
+        (launch_env or {}).get("EPIC_LANG")
+        or (plan.env or {}).get("EPIC_LANG")
+        or os.environ.get("EPIC_LANG", "en")
+    )
     argv.extend([
         "--wrapper",
         # legendary is a PyInstaller onefile binary; it may hand its own
@@ -151,7 +158,7 @@ def _build_legendary_argv(
         # libz.so.1). Force-clear both right at the boundary.
         f"env -u LD_LIBRARY_PATH -u LD_PRELOAD {plan.python_bin} {plan.umu_wrapper}",
         "--language",
-        os.environ.get("EPIC_LANG", "en"),
+        epic_lang,
     ])
     exe_override = _resolve_exe_override(plan)
     if exe_override:

--- a/py_modules/unifideck/launcher/proton/handlers/generic.py
+++ b/py_modules/unifideck/launcher/proton/handlers/generic.py
@@ -48,11 +48,9 @@ async def _amazon_launch(plan: ProtonLaunchPlan) -> int:
 
     """Amazon launch."""
     try:
-        from unifideck.config.config_manager import ConfigManager
+        from unifideck.launcher.bootstrap import _load_standalone_config
         from unifideck.launcher.proton.language_setup import apply_amazon_language
-        _cfg = ConfigManager(
-            str(plan.context.plugin_dir / "defaults" / "config.json"),
-        )
+        _cfg = _load_standalone_config()
         apply_amazon_language(str(plan.prefix_path), config=_cfg)
     except Exception as err:
         logger.warning(

--- a/py_modules/unifideck/launcher/proton/handlers/ubisoft.py
+++ b/py_modules/unifideck/launcher/proton/handlers/ubisoft.py
@@ -460,11 +460,9 @@ def _apply_language_setup(plan: ProtonLaunchPlan) -> None:
 
     """Apply language setup."""
     try:
-        from unifideck.config.config_manager import ConfigManager
+        from unifideck.launcher.bootstrap import _load_standalone_config
         from unifideck.launcher.proton.language_setup import apply_ubisoft_language
-        _cfg = ConfigManager(
-            str(plan.context.plugin_dir / "defaults" / "config.json"),
-        )
+        _cfg = _load_standalone_config()
         apply_ubisoft_language(
             str(plan.prefix_path),
             space_id=plan.context.game_id,

--- a/py_modules/unifideck/services/bootstrap/constructor.py
+++ b/py_modules/unifideck/services/bootstrap/constructor.py
@@ -144,9 +144,10 @@ def _wire_edge_browser(
     """
     try:
         from unifideck.auth.edge_browser import EdgeBrowser
+        from unifideck.utils.locale import get_unifideck_locale
         container.edge_browser = EdgeBrowser(
             cdp_port=cdp_port,
-            locale_fn=lambda: str(config.get("ui.locale", "en-US")),
+            locale_fn=lambda: get_unifideck_locale(config),
         )
         logger.info("[bootstrap] edge_browser wired")
     except Exception as e:

--- a/py_modules/unifideck/utils/locale.py
+++ b/py_modules/unifideck/utils/locale.py
@@ -178,6 +178,11 @@ def get_unifideck_locale(config: ConfigManager | None) -> str:
     return "en-US"
 
 
+def locale_to_epic_language(tag: str) -> str:
+    """Map a BCP-47 tag to legendary's ``--language`` code."""
+    return tag.split("-", maxsplit=1)[0].lower()
+
+
 def get_unifideck_market(config: ConfigManager | None) -> str:
     """Return the ISO 3166-1 alpha-2 market code.
 

--- a/py_modules/unifideck/utils/locale.py
+++ b/py_modules/unifideck/utils/locale.py
@@ -8,10 +8,11 @@ edit to config.json, and this module picks it up automatically
 on the next plugin start.
 
 Resolution priority:
-  1. User preference → ConfigManager key 'ui.language'
-     (only if the saved value is a tag present in
-     i18n.locales; unknown saved tags are silently ignored
-     and we fall through to system detection)
+  1. User preference → ConfigManager key 'ui.locale'
+     (the ``"auto"`` sentinel falls through to system
+     detection; only if the saved value is a concrete tag
+     present in i18n.locales is it returned as-is — unknown
+     saved tags fall through to system detection)
   2. System POSIX → locale.getlocale() → mapped to the first
      i18n.locales entry whose tag begins with the same 2-
      letter prefix (case-insensitive)
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Config keys used by this module.
-_USER_LANGUAGE_KEY = "ui.language"
+_USER_LANGUAGE_KEY = "ui.locale"
 
 # The locale_config module lives in scripts/ which is a sibling
 # of py_modules/. It's not on the default Python path so we add
@@ -135,7 +136,7 @@ def get_unifideck_locale(config: ConfigManager | None) -> str:
     lc = get_locale_config(config)
     # ─── 1. Explicit user preference ──────────────────────────
     saved = get_cfg(config, _USER_LANGUAGE_KEY, None)
-    if isinstance(saved, str) and saved:
+    if isinstance(saved, str) and saved and saved != "auto":
         # Normalise: accept both 'fr-FR' and 'fr_FR' for
         # compatibility with POSIX-style values.
         normalised = saved.replace("_", "-")

--- a/tests/unit/test_epic_wrapper_env.py
+++ b/tests/unit/test_epic_wrapper_env.py
@@ -20,6 +20,8 @@ from unifideck.launcher.proton.compat import epic as compat_epic
 from unifideck.launcher.proton.handlers.epic import _build_legendary_argv
 from unifideck.launcher.proton.infrastructure.core import ProtonLaunchPlan
 
+_SAMPLE_TAG = "ja-JP"
+
 
 def _plan() -> ProtonLaunchPlan:
     return ProtonLaunchPlan(
@@ -35,8 +37,21 @@ def _plan() -> ProtonLaunchPlan:
 
 def test_wrapper_force_clears_ld_env(monkeypatch):
     monkeypatch.setattr(compat_epic, "detect_offline", lambda: False)
+    monkeypatch.setattr(
+        "unifideck.launcher.bootstrap._load_standalone_config",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "unifideck.launcher.proton.language_setup.get_unifideck_language",
+        lambda _cfg: _SAMPLE_TAG,
+    )
 
-    argv = _build_legendary_argv(_plan(), "/plugin/bin/legendary")
+    plan = _plan()
+    env = compat_epic.build_legendary_env(plan, "")
+    assert env["EPIC_LANG"] == "ja"
+
+    argv = _build_legendary_argv(plan, "/plugin/bin/legendary", env)
+    assert argv[argv.index("--language") + 1] == "ja"
 
     wrapper_cmd = argv[argv.index("--wrapper") + 1]
     assert wrapper_cmd == (

--- a/tests/unit/test_unifideck_locale.py
+++ b/tests/unit/test_unifideck_locale.py
@@ -1,0 +1,43 @@
+"""Locale resolution: ui.locale preference drives backend locale."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from unifideck.utils import locale as locale_mod
+
+# Arbitrary BCP-47 tags for assertions — not a product default.
+_SAVED_TAG = "ja-JP"
+_SYSTEM_TAG = "it-IT"
+
+
+class _StubConfig:
+    def __init__(self, values: dict[str, Any]) -> None:
+        self._values = values
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+
+def test_ui_locale_preference_is_used() -> None:
+    cfg = _StubConfig({"ui.locale": _SAVED_TAG})
+    assert locale_mod.get_unifideck_locale(cfg) == _SAVED_TAG
+
+
+def test_ui_locale_auto_falls_through_to_system(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        locale_mod,
+        "_detect_system_locale",
+        lambda _lc: _SYSTEM_TAG,
+    )
+    cfg = _StubConfig({"ui.locale": "auto"})
+    assert locale_mod.get_unifideck_locale(cfg) == _SYSTEM_TAG
+
+
+def test_locale_to_epic_language() -> None:
+    assert locale_mod.locale_to_epic_language(_SAVED_TAG) == "ja"
+    assert locale_mod.locale_to_epic_language("en-US") == "en"


### PR DESCRIPTION
Fixes #403.

I worked with AI to build a fix for the locale issue. Tested it locally on _Darksiders 2_ and it’s working as expected. I haven't verified _SWEP1Racer_ yet since I'd need to reinstall it first.

This PR fixes a mismatch where the plugin's config UI was saving settings under `ui.locale`, but the backend was still reading `ui.language` — causing the backend to stay stuck on English regardless of what was selected.

To resolve this, locale and language preferences are now standardized on ui.locale across the entire codebase, including defaults and docs. Setting the value to "auto" triggers automatic system locale detection, while specific language tags are passed directly. Internal consumers like EdgeBrowser and various launcher handlers now rely on the new get_unifideck_locale utility to ensure predictable behavior and fallbacks.

For Epic Games / Legendary integration, this adds explicit mapping logic to convert full locale strings into the format Legendary expects (e.g. "ja-JP" becomes "ja"), complete with fallback error handling and updated argument building. Amazon and Ubisoft launchers have also been updated to use the standardized locale resolution and config loading, cleaning up redundant config manager calls. Finally, new unit tests cover the locale resolution helper, "auto" detection, language mapping, and Epic Games wrapper updates.