### PR TITLE
fix(i18n): send the DeepL key in the Authorization header, not the form body

### DIFF
--- a/scripts/deepl_client.py
+++ b/scripts/deepl_client.py
@@ -65,9 +65,15 @@ def _post(
     source_lang: str,
     api_key: str,
 ) -> str:
-    """POST the translate request and return the raw response body."""
+    """POST the translate request and return the raw response body.
+
+    The key travels in the ``Authorization`` header, not the form
+    body: DeepL removed form-body auth in November 2025 and now
+    answers ``403 Legacy authentication method 'form body' is no
+    longer supported`` to any request carrying ``auth_key`` there.
+    See https://developers.deepl.com/docs/getting-started/auth
+    """
     params: list[tuple[str, str]] = [
-        ("auth_key", api_key),
         ("target_lang", target_lang),
         ("source_lang", source_lang),
         # preserve_formatting keeps {placeholders} intact so
@@ -84,7 +90,10 @@ def _post(
     req = urllib.request.Request(
         endpoint_for(api_key),
         data=data,
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": f"DeepL-Auth-Key {api_key}",
+        },
     )
     try:
         with urllib.request.urlopen(  # noqa: S310 — trusted host


### PR DESCRIPTION
## Problem

`Build plugin artifact` fails at the **Translate en-US.json via DeepL** step whenever
`en-US.json` has changed, so no plugin zip is produced:

```
[translate] fatal: RuntimeError: DeepL API error 403 for FR: {"message":"Legacy
authentication method 'form body' is no longer supported. Please update to
header-based authentication. ..."}
[translate] → fr-FR (FR): 127 keys
##[error]Process completed with exit code 2.
```

`scripts/deepl_client.py` passes the key as an `auth_key` form field. DeepL
[removed that method in November 2025](https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods)
and now rejects every such request with 403, on the first target language, before any
translation happens.

This isn't fork-specific: it fires with a valid key present. The step only appears to
"pass" today because it short-circuits when `en-US.json` is unchanged — any PR that
touches a UI string hits it.

## Fix

Move the key to `Authorization: DeepL-Auth-Key <key>`, which is what the current API
expects. One file, +12/-3.

Endpoint selection is untouched — `endpoint_for()` still picks free vs pro from the
`:fx` suffix.

## Verification

Ran the full pipeline on a fork with a real free-tier key:

- **before** — 403 at `fr-FR`, build dead at 12s
- **after** — all 15 target locales translated (16 files, ~12.5k lines), plugin zip
  produced, `Build plugin artifact` green

`Tests`, `Quality` and `Complexity Gates` also green on the same commit.

## Notes

Two pre-existing ruff findings in this file (`I001` unsorted imports, `RUF100` unused
`noqa: S310`) are left alone — they're unrelated to this change and fixing them here
would widen the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
