### PR TITLE
feat/locale-resolution — make the chosen language reach the games

### DIFF
--- a/py_modules/unifideck/bootstrap/boot.py
+++ b/py_modules/unifideck/bootstrap/boot.py
@@ -130,30 +130,13 @@ async def _boot_layer2_core(plugin: Any, decky_runtime_dir: str) -> Any:
 def _resolve_defaults_path(decky_plugin_dir: str) -> str:
     """Locate the bundled config.json across Decky build layouts.
 
-    Two install layouts are valid in production:
-
-    1. ``<plugin>/defaults/config.json`` — local builds via
-       ``build-plugin.sh build_local`` and dev syncs that preserve
-       the source directory layout.
-    2. ``<plugin>/config.json`` — Decky CLI builds (``decky plugin
-       build``). Decky CLI 0.0.8+ has a convention where the contents
-       of ``defaults/`` get flattened to the install root on first
-       install (so users can edit them, with the file preserved
-       across plugin updates).
-
-    We pick whichever exists, preferring the unflattened layout when
-    both are present (more explicit). Returns the unflattened path
-    even when neither exists — ConfigManager handles "missing
-    defaults" by logging a warning and entering degraded mode, and
-    paths.py has fallback defaults so boot still completes.
+    Delegates to :func:`config.defaults_path.resolve_defaults_config_path`
+    so the plugin backend and the launcher process resolve it identically —
+    the launcher used to hardcode the unflattened layout and therefore found
+    no defaults on a Decky CLI build.
     """
-    nested = str(Path(decky_plugin_dir) / "defaults" / "config.json")
-    if Path(nested).is_file():
-        return nested
-    flattened = str(Path(decky_plugin_dir) / "config.json")
-    if Path(flattened).is_file():
-        return flattened
-    return nested
+    from unifideck.config.defaults_path import resolve_defaults_config_path
+    return resolve_defaults_config_path(decky_plugin_dir)
 
 
 async def _boot_config_and_validate(

--- a/py_modules/unifideck/config/config_manager.py
+++ b/py_modules/unifideck/config/config_manager.py
@@ -34,7 +34,13 @@ logger = logging.getLogger(__name__)
 _FALLBACK: dict[str, Any] = {
     "data_dir": "~/.local/share/unifideck",
     "ui": {
-        "language": "en-US",
+        # ``locale``, matching defaults/config.json — NOT ``language``,
+        # which nothing declares and nothing writes. That stray key made
+        # every locale lookup return "en-US": ``get_unifideck_locale``
+        # reads it as an explicit user preference, and a fallback value
+        # is indistinguishable from a real choice, so resolution never
+        # reached the Steam language or the POSIX locale below it.
+        "locale": "auto",
     },
     "sync": {
         "interval_seconds": 300,

--- a/py_modules/unifideck/config/defaults_path.py
+++ b/py_modules/unifideck/config/defaults_path.py
@@ -1,0 +1,44 @@
+"""config/defaults_path.py — locate the bundled config.json.
+
+Companion to :mod:`config.user_config_path`: that one answers "where do
+the user's overrides live", this one answers "where did the defaults
+ship".
+
+Two install layouts are valid in production, and which one you get
+depends on how the plugin was built:
+
+1. ``<plugin>/defaults/config.json`` — local builds
+   (``build-plugin.sh`` without the Decky CLI) and dev syncs, which
+   preserve the source directory layout.
+2. ``<plugin>/config.json`` — Decky CLI builds. Since CLI 0.0.8 the
+   contents of ``defaults/`` are flattened to the install root on first
+   install, so users can edit them and the file survives plugin
+   updates.
+
+The plugin backend has always handled both (``bootstrap.boot``, which
+now delegates here). The launcher process is a separate entry point and
+hardcoded layout 1, so on a CLI-built install — the normal case for
+anyone who did not build locally — its ``ConfigManager`` found no
+defaults at all.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_defaults_config_path(plugin_dir: str | Path) -> str:
+    """Return the bundled config.json path for either install layout.
+
+    Prefers the unflattened layout when both exist, being the more
+    explicit of the two. Returns the unflattened path when neither
+    exists, so the caller still has something to log or hand to
+    ``ConfigManager``, which treats a missing defaults file as degraded
+    mode rather than an error.
+    """
+    nested = Path(plugin_dir) / "defaults" / "config.json"
+    if nested.is_file():
+        return str(nested)
+    flattened = Path(plugin_dir) / "config.json"
+    if flattened.is_file():
+        return str(flattened)
+    return str(nested)

--- a/py_modules/unifideck/launcher/proton/handlers/epic.py
+++ b/py_modules/unifideck/launcher/proton/handlers/epic.py
@@ -214,11 +214,23 @@ def _resolve_epic_language(plan: ProtonLaunchPlan) -> str:
         return override
     try:
         from unifideck.config.config_manager import ConfigManager
+        from unifideck.config.defaults_path import resolve_defaults_config_path
+        from unifideck.config.user_config_path import resolve_user_config_path
         from unifideck.launcher.proton.language_setup import (
             get_unifideck_language,
         )
+        # Both arguments matter, and neither was here before.
+        # ``resolve_defaults_config_path`` finds the bundled config on a
+        # Decky CLI build, which flattens ``defaults/`` to the install
+        # root; the hardcoded nested path found nothing there.
+        # ``user_path`` is what makes this see the language the user
+        # actually PICKED. Without them the merged view was the hardcoded
+        # _FALLBACK alone, so the setting had no effect on Epic titles —
+        # and it still looked right on any machine already in that
+        # language, which is why it survived casual testing.
         config = ConfigManager(
-            str(plan.context.plugin_dir / "defaults" / "config.json"),
+            resolve_defaults_config_path(plan.context.plugin_dir),
+            user_path=resolve_user_config_path(),
         )
         locale_tag = get_unifideck_language(config)
     except Exception as err:

--- a/py_modules/unifideck/launcher/proton/handlers/generic.py
+++ b/py_modules/unifideck/launcher/proton/handlers/generic.py
@@ -49,9 +49,16 @@ async def _amazon_launch(plan: ProtonLaunchPlan) -> int:
     """Amazon launch."""
     try:
         from unifideck.config.config_manager import ConfigManager
+        from unifideck.config.defaults_path import (
+            resolve_defaults_config_path,
+        )
+        from unifideck.config.user_config_path import (
+            resolve_user_config_path,
+        )
         from unifideck.launcher.proton.language_setup import apply_amazon_language
         _cfg = ConfigManager(
-            str(plan.context.plugin_dir / "defaults" / "config.json"),
+            resolve_defaults_config_path(plan.context.plugin_dir),
+            user_path=resolve_user_config_path(),
         )
         apply_amazon_language(str(plan.prefix_path), config=_cfg)
     except Exception as err:

--- a/py_modules/unifideck/launcher/proton/handlers/ubisoft.py
+++ b/py_modules/unifideck/launcher/proton/handlers/ubisoft.py
@@ -337,9 +337,16 @@ def _apply_language_setup(plan: ProtonLaunchPlan) -> None:
     """Apply language setup."""
     try:
         from unifideck.config.config_manager import ConfigManager
+        from unifideck.config.defaults_path import (
+            resolve_defaults_config_path,
+        )
+        from unifideck.config.user_config_path import (
+            resolve_user_config_path,
+        )
         from unifideck.launcher.proton.language_setup import apply_ubisoft_language
         _cfg = ConfigManager(
-            str(plan.context.plugin_dir / "defaults" / "config.json"),
+            resolve_defaults_config_path(plan.context.plugin_dir),
+            user_path=resolve_user_config_path(),
         )
         apply_ubisoft_language(
             str(plan.prefix_path),

--- a/py_modules/unifideck/utils/locale.py
+++ b/py_modules/unifideck/utils/locale.py
@@ -8,14 +8,23 @@ edit to config.json, and this module picks it up automatically
 on the next plugin start.
 
 Resolution priority:
-  1. User preference → ConfigManager key 'ui.language'
-     (only if the saved value is a tag present in
+  1. User preference → ConfigManager keys 'ui.locale' (written
+     by the frontend language selector) and 'ui.language'
+     (legacy key). The value 'auto' is ignored so that the
+     explicit user choice wins over the Steam UI language.
+     Only if the saved value is a tag present in
      i18n.locales; unknown saved tags are silently ignored
-     and we fall through to system detection)
-  2. System POSIX → locale.getlocale() → mapped to the first
+     and we fall through to system detection.
+  2. Steam's own UI language → registry.vdf (see
+     utils/steam_language.py). Ahead of the POSIX locale
+     because SteamOS ships LANG=en_US.UTF-8 and never updates
+     it, so on a Deck the POSIX locale says nothing about the
+     language the user actually reads. This is what makes
+     'auto' resolve the same way the frontend resolves it.
+  3. System POSIX → locale.getlocale() → mapped to the first
      i18n.locales entry whose tag begins with the same 2-
      letter prefix (case-insensitive)
-  3. Source fallback → LocaleConfig.source.tag
+  4. Source fallback → LocaleConfig.source.tag
 """
 from __future__ import annotations
 
@@ -26,6 +35,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .config_helpers import get_cfg
+from .steam_language import detect_steam_locale
 
 if TYPE_CHECKING:
     from unifideck.config import ConfigManager
@@ -33,7 +43,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Config keys used by this module.
-_USER_LANGUAGE_KEY = "ui.language"
+_USER_LANGUAGE_KEYS = ("ui.locale", "ui.language")
+# Value "auto" means the frontend hasn't fixed a language yet —
+# the frontend resolves "auto" from the Steam UI language, but the
+# backend resolves it from POSIX locale, causing a mismatch.
+# Ignore it and fall through to system detection.
+_AUTO = "auto"
 
 # The locale_config module lives in scripts/ which is a sibling
 # of py_modules/. It's not on the default Python path so we add
@@ -123,6 +138,26 @@ def get_locale_config(config: ConfigManager | None) -> Any | None:
         return None
 
 
+# The winning tier, as last reported by ``_resolved``. This chain stayed
+# broken for a long time because it was unobservable: logs showed which
+# language was used, never where it came from, so "English again" looked
+# identical whether the user's choice was ignored, Steam was unreadable or
+# the machine really was English. Reporting the tier at INFO makes one log
+# line answer that. Deduplicated because ``get_unifideck_locale`` runs on
+# every store request and market lookup, and a per-call line would drown
+# the log it is meant to clarify.
+_last_reported: tuple[str, str] | None = None
+
+
+def _resolved(tag: str, source: str) -> str:
+    """Report the winning tier once per distinct outcome, then return it."""
+    global _last_reported
+    if _last_reported != (tag, source):
+        _last_reported = (tag, source)
+        logger.info("[locale] resolved %s (source: %s)", tag, source)
+    return tag
+
+
 def get_unifideck_locale(config: ConfigManager | None) -> str:
     """Return the BCP-47 locale tag to use for UI and store APIs.
 
@@ -134,40 +169,39 @@ def get_unifideck_locale(config: ConfigManager | None) -> str:
     """
     lc = get_locale_config(config)
     # ─── 1. Explicit user preference ──────────────────────────
-    saved = get_cfg(config, _USER_LANGUAGE_KEY, None)
-    if isinstance(saved, str) and saved:
+    # Check both 'ui.locale' (written by frontend) and 'ui.language'
+    # (legacy). Skip 'auto' — it causes frontend/backend divergence.
+    saved = None
+    for key in _USER_LANGUAGE_KEYS:
+        val = get_cfg(config, key, None)
+        if isinstance(val, str) and val and val != _AUTO:
+            saved = val
+            break
+    if saved:
         # Normalise: accept both 'fr-FR' and 'fr_FR' for
         # compatibility with POSIX-style values.
         normalised = saved.replace("_", "-")
         if lc is not None and lc.get(normalised) is not None:
-            logger.debug(
-                "[locale] user preference: %s", normalised,
-            )
-            return normalised
+            return _resolved(normalised, "user preference")
         if lc is None:
             # No canonical list available — trust the saved
             # value as-is. This is the degraded path.
-            logger.debug(
-                "[locale] user preference (unvalidated): %s",
-                normalised,
-            )
-            return normalised
+            return _resolved(normalised, "user preference, unvalidated")
         logger.debug(
             "[locale] user preference '%s' not in "
             "i18n.locales, falling back to system", saved,
         )
-    # ─── 2. System POSIX locale ───────────────────────────────
+    # ─── 2. Steam's own UI language ───────────────────────────
+    steam = detect_steam_locale(lc)
+    if steam:
+        return _resolved(steam, "Steam UI language")
+    # ─── 3. System POSIX locale ───────────────────────────────
     system = _detect_system_locale(lc)
     if system:
-        logger.debug("[locale] system: %s", system)
-        return system
-    # ─── 3. Source fallback ───────────────────────────────────
+        return _resolved(system, "system POSIX locale")
+    # ─── 4. Source fallback ───────────────────────────────────
     if lc is not None:
-        source_tag = str(lc.source.tag)
-        logger.debug(
-            "[locale] source fallback: %s", source_tag,
-        )
-        return source_tag
+        return _resolved(str(lc.source.tag), "i18n.locales source")
     # Final degraded fallback: hardcoded en-US only when the
     # config system is completely broken.
     logger.warning(
@@ -202,9 +236,14 @@ def _detect_system_locale(lc: Any) -> str | None:
 
     Returns a tag from lc.all_tags whose 2-letter prefix
     matches the POSIX lang code, or None on any failure.
+
+    ``lc`` is None on every installed plugin — ``scripts/`` is not
+    packaged — so bailing out on it made this tier dead in production
+    and sent the whole chain to the hardcoded ``en-US`` at the bottom.
+    Without the canonical list the POSIX value is normalised and
+    trusted as-is, the same degraded treatment tier 1 gives a saved
+    preference it cannot validate.
     """
-    if lc is None:
-        return None
     try:
         lang_tuple = _locale.getlocale()
     except (ValueError, TypeError) as e:
@@ -217,6 +256,10 @@ def _detect_system_locale(lc: Any) -> str | None:
     prefix = lang_tuple[0].split("_")[0].lower()
     if not prefix:
         return None
+    if lc is None:
+        # 'es_ES' → 'es-ES'; a bare 'es' stays 'es'. i18next resolves
+        # either onto its closest bundle.
+        return lang_tuple[0].replace("_", "-")
     # Find the first entry in the canonical list whose tag
     # starts with this prefix. Order matches config.json,
     # which is also the UI dropdown order.

--- a/py_modules/unifideck/utils/steam_language.py
+++ b/py_modules/unifideck/utils/steam_language.py
@@ -1,0 +1,130 @@
+"""utils/steam_language.py — the UI language the user picked *in Steam*.
+
+Sits between "explicit Unifideck preference" and "POSIX locale" in
+:func:`utils.locale.get_unifideck_locale`, because on a Steam Deck the
+POSIX locale is not the user's language.
+
+SteamOS ships ``LANG=en_US.UTF-8`` and never changes it: the language a
+Deck user actually picks lives in Steam's own settings and is not
+exported to the environment. So ``ui.locale = "auto"`` — the shipped
+default — resolved to English for every user whose Steam is in anything
+else, and every store CLI we drive (``legendary --language``,
+``gogdl --lang``) inherited that. Confirmed on a device whose Steam runs
+in Spanish: ``LANG`` was ``en_US.UTF-8`` and Epic titles launched with
+``-epiclocale=en``.
+
+Steam records it in ``registry.vdf`` as a lowercase English word
+(``spanish``, ``koreana``, ``schinese``), which is Steam's own API
+language code, not a BCP-47 tag — hence the map below. It is the only
+table here: which tags are *supported* still comes from
+``i18n.locales``, so this module cannot drift from the shipped locale
+list. A Steam language with no matching entry there resolves to None and
+the caller falls through to POSIX exactly as before.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# registry.vdf lives under the ``~/.steam`` root (a symlink), NOT under the
+# resolved steam_root, and moves under Flatpak. Same probe list as
+# ``steam.current_user._REGISTRY_CANDIDATES`` — duplicated rather than
+# imported because ``utils`` is a lower layer than ``steam`` and must not
+# depend on it.
+_REGISTRY_CANDIDATES = (
+    "~/.steam/registry.vdf",
+    "~/.steam/steam/registry.vdf",
+    "~/.var/app/com.valvesoftware.Steam/.steam/registry.vdf",
+)
+# Steam writes the key as ``language``; match case-insensitively because
+# the casing has varied across client versions.
+_LANGUAGE_RE = re.compile(r'"language"\s+"([^"]*)"', re.IGNORECASE)
+
+# Steam API language code → BCP-47. Only codes that can map onto a real
+# locale are listed; anything else falls through to POSIX. ``latam`` is
+# Steam's Latin-American Spanish, folded onto es-ES because that is the
+# only Spanish the plugin ships — a deliberate approximation, and better
+# than dropping a Spanish-speaking user into English.
+_STEAM_LANGUAGE_TAGS: dict[str, str] = {
+    "english": "en-US",
+    "french": "fr-FR",
+    "german": "de-DE",
+    "spanish": "es-ES",
+    "latam": "es-ES",
+    "italian": "it-IT",
+    "brazilian": "pt-BR",
+    "portuguese": "pt-BR",
+    "dutch": "nl-NL",
+    "polish": "pl-PL",
+    "russian": "ru-RU",
+    "ukrainian": "uk-UA",
+    "turkish": "tr-TR",
+    "japanese": "ja-JP",
+    "koreana": "ko-KR",
+    "schinese": "zh-CN",
+    "tchinese": "zh-TW",
+    "arabic": "ar-SA",
+}
+
+
+def read_steam_language() -> str | None:
+    """Steam's configured UI language as its own code, or None.
+
+    Pure read: no validation against the supported locales, so a caller
+    can log what Steam actually said even when it maps to nothing.
+    """
+    for candidate in _REGISTRY_CANDIDATES:
+        path = Path(candidate).expanduser()
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        match = _LANGUAGE_RE.search(text)
+        if match and match.group(1).strip():
+            return match.group(1).strip().lower()
+    return None
+
+
+def detect_steam_locale(lc: Any) -> str | None:
+    """Map Steam's UI language onto a supported ``i18n.locales`` tag.
+
+    Returns None — so the caller falls through to the POSIX locale —
+    when Steam's setting is unreadable, unknown to the map, or maps to a
+    tag this build does not ship.
+
+    ``lc`` may legitimately be None: ``scripts/locale_config.py`` is not
+    packaged into the plugin — neither ``build-plugin.sh`` nor the Decky
+    CLI stages ``scripts/`` — so on an installed plugin there is no
+    canonical list to validate against, and that is the normal case, not
+    an edge one. The mapping is then trusted as-is, exactly as tier 1
+    trusts an unvalidated saved preference. Returning None here instead
+    is what made this tier dead on every real install.
+    """
+    steam_language = read_steam_language()
+    if not steam_language:
+        return None
+    tag = _STEAM_LANGUAGE_TAGS.get(steam_language)
+    if not tag:
+        logger.debug(
+            "[locale] Steam language '%s' has no BCP-47 mapping",
+            steam_language,
+        )
+        return None
+    if lc is None:
+        logger.debug(
+            "[locale] Steam language '%s' → %s (unvalidated: no "
+            "i18n.locales available)", steam_language, tag,
+        )
+        return tag
+    if lc.get(tag) is None:
+        logger.debug(
+            "[locale] Steam language '%s' maps to %s, which this build "
+            "does not ship", steam_language, tag,
+        )
+        return None
+    logger.debug("[locale] Steam language '%s' → %s", steam_language, tag)
+    return tag

--- a/tests/unit/test_epic_launch_language.py
+++ b/tests/unit/test_epic_launch_language.py
@@ -27,6 +27,7 @@ Two layers, matching legendary's own precedence
 """
 from __future__ import annotations
 
+import json
 import types
 from pathlib import Path
 from typing import Any
@@ -199,3 +200,60 @@ def test_rewriting_replaces_rather_than_duplicates() -> None:
     text = _config_text()
     assert text.count("language = ") == 1
     assert "language = de" in text
+
+
+# --------------------------------------------------------------------------
+# The language the user PICKED has to reach the game
+#
+# _resolve_epic_language built ConfigManager with no ``user_path``, so the
+# merged view never included the user's own config file: it saw only
+# defaults/config.json and resolved from the machine instead. On a Steam Deck
+# — LANG=en_US.UTF-8, always — that meant English for everyone.
+#
+# The tests above stub ConfigManager out entirely, so they cannot see this.
+# These drive the real one with the machine pinned to a language the user did
+# NOT choose, so a fallback can never masquerade as success.
+# --------------------------------------------------------------------------
+def _real_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, user_locale: str | None,
+) -> Path:
+    """Lay down defaults + user config; return the plugin dir. Pins LANG."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir(parents=True)
+    repo_defaults = Path(__file__).resolve().parents[2] / "defaults/config.json"
+    # The Decky CLI layout: defaults/config.json flattened to the install
+    # root. This is what a plugin installed from a CLI-built zip looks
+    # like, and the hardcoded nested path found nothing in it.
+    (plugin_dir / "config.json").write_text(
+        repo_defaults.read_text(encoding="utf-8"), encoding="utf-8",
+    )
+    user_cfg = tmp_path / "user_config.json"
+    if user_locale is not None:
+        user_cfg.write_text(
+            json.dumps({"ui": {"locale": user_locale}}), encoding="utf-8",
+        )
+    monkeypatch.setenv("UNIFIDECK_USER_CONFIG", str(user_cfg))
+    monkeypatch.setenv("HOME", str(tmp_path))       # no registry.vdf here
+    # Pin what the resolver sees as the machine's locale. Patching
+    # ``getlocale`` rather than ``LANG``: Python reads the process locale
+    # set at startup, so setting the env mid-test proves nothing.
+    import unifideck.utils.locale as locale_module
+    monkeypatch.setattr(
+        locale_module._locale, "getlocale", lambda: ("en_US", "UTF-8"),
+    )
+    monkeypatch.delenv("EPIC_LANG", raising=False)
+    return plugin_dir
+
+
+def test_honours_the_language_picked_in_the_unifideck_ui(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = _real_config(tmp_path, monkeypatch, "es-ES")
+    assert _resolve_epic_language(_plan(plugin_dir)) == "es"
+
+
+def test_falls_back_to_the_machine_when_the_user_picked_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir = _real_config(tmp_path, monkeypatch, None)
+    assert _resolve_epic_language(_plan(plugin_dir)) == "en"

--- a/tests/unit/test_locale_resolution.py
+++ b/tests/unit/test_locale_resolution.py
@@ -1,0 +1,280 @@
+"""Locale resolution: the user's choice, then Steam's language, then POSIX.
+
+The bug these cover: SteamOS ships ``LANG=en_US.UTF-8`` and never updates
+it, so with the shipped default (``ui.locale = "auto"``) resolution fell
+through to English for every Deck user whose Steam is in another
+language — and every store CLI inherited it.
+
+Each test pins the POSIX locale to a language the user did NOT choose,
+so a fallback can never masquerade as success. It is pinned by patching
+``locale.getlocale`` rather than the ``LANG`` environment variable:
+Python reads the process locale set at startup, so changing the env
+mid-test would have no effect and the assertion would prove nothing.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from unifideck.config.config_manager import ConfigManager
+from unifideck.utils.locale import get_unifideck_locale
+from unifideck.utils.steam_language import (
+    detect_steam_locale,
+    read_steam_language,
+)
+
+_REGISTRY_TEMPLATE = """"Registry"
+{{
+\t"HKCU"
+\t{{
+\t\t"Software"
+\t\t{{
+\t\t\t"Valve"
+\t\t\t{{
+\t\t\t\t"Steam"
+\t\t\t\t{{
+\t\t\t\t\t"language"\t\t"{language}"
+\t\t\t\t\t"AutoLoginUser"\t\t"someone"
+\t\t\t\t}}
+\t\t\t}}
+\t\t}}
+\t}}
+}}
+"""
+
+
+@pytest.fixture(autouse=True)
+def _english_machine(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """A machine in English with no Steam settings, as SteamOS ships."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _set_posix_locale(monkeypatch, "en_US")
+
+
+def _set_posix_locale(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """Pin what ``_detect_system_locale`` sees as the machine's locale."""
+    import unifideck.utils.locale as locale_module
+    monkeypatch.setattr(
+        locale_module._locale, "getlocale", lambda: (value, "UTF-8"),
+    )
+
+
+def _write_registry(tmp_path: Path, language: str) -> None:
+    """Lay down a registry.vdf carrying Steam's UI language."""
+    registry = tmp_path / ".steam" / "registry.vdf"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        _REGISTRY_TEMPLATE.format(language=language), encoding="utf-8",
+    )
+
+
+def _config(tmp_path: Path, user_locale: str | None) -> ConfigManager:
+    """A ConfigManager over the real defaults plus an optional override."""
+    defaults = Path(__file__).resolve().parents[2] / "defaults" / "config.json"
+    user_path = tmp_path / "user_config.json"
+    if user_locale is not None:
+        user_path.write_text(
+            json.dumps({"ui": {"locale": user_locale}}), encoding="utf-8",
+        )
+    return ConfigManager(str(defaults), user_path=str(user_path))
+
+
+# ── read_steam_language ────────────────────────────────────────────────
+def test_reads_the_language_key_from_registry_vdf(tmp_path: Path) -> None:
+    _write_registry(tmp_path, "spanish")
+    assert read_steam_language() == "spanish"
+
+
+def test_returns_none_when_there_is_no_registry(tmp_path: Path) -> None:
+    assert read_steam_language() is None
+
+
+def test_returns_none_when_the_key_is_empty(tmp_path: Path) -> None:
+    _write_registry(tmp_path, "")
+    assert read_steam_language() is None
+
+
+# ── detect_steam_locale ────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    ("steam_language", "expected"),
+    [
+        ("spanish", "es-ES"),
+        ("latam", "es-ES"),      # folded: es-ES is the only Spanish shipped
+        ("koreana", "ko-KR"),    # Steam's own spelling
+        ("schinese", "zh-CN"),
+        ("brazilian", "pt-BR"),
+        ("english", "en-US"),
+    ],
+)
+def test_maps_steam_language_codes_to_supported_tags(
+    tmp_path: Path, steam_language: str, expected: str,
+) -> None:
+    _write_registry(tmp_path, steam_language)
+    lc = _config(tmp_path, None)
+    from unifideck.utils.locale import get_locale_config
+    assert detect_steam_locale(get_locale_config(lc)) == expected
+
+
+def test_unknown_steam_language_falls_through(tmp_path: Path) -> None:
+    """Steam ships languages this plugin does not — they must not crash."""
+    _write_registry(tmp_path, "vietnamese")
+    from unifideck.utils.locale import get_locale_config
+    assert detect_steam_locale(get_locale_config(_config(tmp_path, None))) is None
+
+
+def test_maps_without_a_canonical_list_to_validate_against(
+    tmp_path: Path,
+) -> None:
+    """``lc`` is None on every installed plugin — see the degraded-mode
+    block below. The mapping must still apply, unvalidated."""
+    _write_registry(tmp_path, "spanish")
+    assert detect_steam_locale(None) == "es-ES"
+
+
+# ── the full chain ─────────────────────────────────────────────────────
+def test_steam_language_wins_over_the_posix_locale(tmp_path: Path) -> None:
+    """The whole point: LANG says English, Steam says Spanish."""
+    _write_registry(tmp_path, "spanish")
+    assert get_unifideck_locale(_config(tmp_path, None)) == "es-ES"
+
+
+def test_the_users_explicit_choice_still_wins_over_steam(
+    tmp_path: Path,
+) -> None:
+    """Steam is a better guess than LANG, never better than an answer."""
+    _write_registry(tmp_path, "german")
+    assert get_unifideck_locale(_config(tmp_path, "es-ES")) == "es-ES"
+
+
+def test_posix_applies_when_steam_says_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No registry.vdf (non-Steam host, Flatpak elsewhere) — POSIX wins."""
+    _set_posix_locale(monkeypatch, "it_IT")
+    assert get_unifideck_locale(_config(tmp_path, None)) == "it-IT"
+
+
+# ── degraded mode: what an installed plugin actually runs ───────────────
+# ``get_locale_config`` returns None on an installed plugin, and that is the
+# designed behaviour rather than a fault: ``scripts/`` is build tooling that
+# the Decky CLI does not package, and ``locale_config.py`` is the one module
+# in it that runtime code imports. ``_import_locale_config`` says as much —
+# None "signals no schema validation available and the caller falls through
+# to its default behaviour". Tier 1 honoured that; the tiers below returned
+# None instead, which sent the whole chain to the hardcoded en-US at the
+# bottom. These tests pin the degraded path, because it is the normal one in
+# production.
+def _degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make get_locale_config return None, as on an installed plugin."""
+    import unifideck.utils.locale as locale_module
+    monkeypatch.setattr(
+        locale_module, "get_locale_config", lambda _config: None,
+    )
+
+
+def test_steam_language_still_applies_without_the_canonical_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_registry(tmp_path, "spanish")
+    _degraded(monkeypatch)
+    assert get_unifideck_locale(_config(tmp_path, None)) == "es-ES"
+
+
+def test_posix_still_applies_without_the_canonical_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No Steam setting, no locale list: the machine's language, not en-US."""
+    _set_posix_locale(monkeypatch, "it_IT")
+    _degraded(monkeypatch)
+    assert get_unifideck_locale(_config(tmp_path, None)) == "it-IT"
+
+
+def test_explicit_choice_wins_in_degraded_mode_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_registry(tmp_path, "german")
+    _degraded(monkeypatch)
+    assert get_unifideck_locale(_config(tmp_path, "es-ES")) == "es-ES"
+
+
+# ── the log has to say WHERE the language came from ─────────────────────
+# The chain stayed broken for a long time because it was unobservable: the
+# logs showed which language was used, never which tier chose it, so
+# "English again" looked the same whether the user's choice was ignored,
+# Steam was unreadable, or the machine really was English.
+@pytest.fixture(autouse=True)
+def _forget_last_reported() -> None:
+    """The INFO line is deduplicated; tests must not inherit each other's."""
+    import unifideck.utils.locale as locale_module
+    locale_module._last_reported = None
+
+
+def test_reports_which_tier_chose_the_language(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    _write_registry(tmp_path, "spanish")
+    with caplog.at_level("INFO", logger="unifideck.utils.locale"):
+        assert get_unifideck_locale(_config(tmp_path, None)) == "es-ES"
+    assert "resolved es-ES (source: Steam UI language)" in caplog.text
+
+
+def test_reports_the_user_preference_tier_too(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    _write_registry(tmp_path, "german")
+    with caplog.at_level("INFO", logger="unifideck.utils.locale"):
+        assert get_unifideck_locale(_config(tmp_path, "es-ES")) == "es-ES"
+    assert "resolved es-ES (source: user preference)" in caplog.text
+
+
+def test_the_line_is_not_repeated_for_an_unchanged_outcome(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """It runs on every store request — one line per outcome, not per call."""
+    _write_registry(tmp_path, "spanish")
+    config = _config(tmp_path, None)
+    with caplog.at_level("INFO", logger="unifideck.utils.locale"):
+        for _ in range(5):
+            get_unifideck_locale(config)
+    assert caplog.text.count("resolved es-ES") == 1
+
+
+# ── the packaged layout ────────────────────────────────────────────────
+# A Decky CLI build flattens defaults/config.json to the install root:
+# build.rs::zip_path strips the "defaults" prefix off every entry.
+# bootstrap.boot has always handled both layouts; the launcher hardcoded
+# the nested one, so on a CLI-built install — anyone who did not build
+# locally — its ConfigManager found no defaults at all.
+from unifideck.config.defaults_path import resolve_defaults_config_path
+
+
+def test_finds_the_defaults_in_the_source_layout(tmp_path: Path) -> None:
+    nested = tmp_path / "defaults" / "config.json"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("{}", encoding="utf-8")
+    assert resolve_defaults_config_path(tmp_path) == str(nested)
+
+
+def test_finds_the_defaults_in_the_decky_cli_layout(tmp_path: Path) -> None:
+    flattened = tmp_path / "config.json"
+    flattened.write_text("{}", encoding="utf-8")
+    assert resolve_defaults_config_path(tmp_path) == str(flattened)
+
+
+def test_prefers_the_source_layout_when_both_exist(tmp_path: Path) -> None:
+    nested = tmp_path / "defaults" / "config.json"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("{}", encoding="utf-8")
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+    assert resolve_defaults_config_path(tmp_path) == str(nested)
+
+
+def test_returns_the_nested_path_when_neither_exists(tmp_path: Path) -> None:
+    """ConfigManager treats a missing defaults file as degraded mode, so a
+    path it can log is more useful than None."""
+    assert resolve_defaults_config_path(tmp_path) == str(
+        tmp_path / "defaults" / "config.json",
+    )

--- a/tests/unit/test_store_launch_language.py
+++ b/tests/unit/test_store_launch_language.py
@@ -1,0 +1,163 @@
+"""Amazon and Ubisoft must launch in the user's language too.
+
+The Epic path has its own suite (``test_epic_launch_language.py``). These
+cover the other two stores whose handlers build a ``ConfigManager`` of
+their own inside the launcher process, because the same two defects hit
+all three:
+
+* the bundled ``config.json`` was looked up at ``<plugin>/defaults/`` only,
+  which does not exist on a Decky CLI install (the CLI flattens
+  ``defaults/`` to the plugin root), so nothing but the hardcoded
+  ``_FALLBACK`` was merged;
+* no ``user_path`` was passed, so the language the user picked was never
+  read whatever the layout.
+
+Both tests drive the *real* ``ConfigManager`` over a fixture laid out the
+way an installed plugin is, with the machine pinned to a language the
+user did not choose — so a fallback can never masquerade as success.
+"""
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from unifideck.launcher.proton.infrastructure.core import ProtonLaunchPlan
+from unifideck.utils.locale import get_unifideck_locale
+
+
+def _installed_plugin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, user_locale: str | None,
+) -> Path:
+    """Lay down the packaged layout + user config; return the plugin dir."""
+    plugin_dir = tmp_path / "plugin"
+    plugin_dir.mkdir(parents=True)
+    repo_defaults = Path(__file__).resolve().parents[2] / "defaults/config.json"
+    # The Decky CLI layout: defaults/config.json flattened to the install
+    # root. This is what a plugin installed from a CLI-built zip looks
+    # like, and the hardcoded nested path found nothing in it.
+    (plugin_dir / "config.json").write_text(
+        repo_defaults.read_text(encoding="utf-8"), encoding="utf-8",
+    )
+    user_cfg = tmp_path / "user_config.json"
+    if user_locale is not None:
+        user_cfg.write_text(
+            json.dumps({"ui": {"locale": user_locale}}), encoding="utf-8",
+        )
+    monkeypatch.setenv("UNIFIDECK_USER_CONFIG", str(user_cfg))
+    monkeypatch.setenv("HOME", str(tmp_path))       # no registry.vdf here
+    # Pin what the resolver sees as the machine's locale. Patching
+    # ``getlocale`` rather than ``LANG``: Python reads the process locale
+    # set at startup, so setting the env mid-test proves nothing.
+    import unifideck.utils.locale as locale_module
+    monkeypatch.setattr(
+        locale_module._locale, "getlocale", lambda: ("en_US", "UTF-8"),
+    )
+    return plugin_dir
+
+
+def _plan(plugin_dir: Path, work_dir: Path, store: str) -> ProtonLaunchPlan:
+    """A minimal launch plan (same shape as test_epic_launch_language)."""
+    return ProtonLaunchPlan(
+        context=types.SimpleNamespace(
+            game_id="abc123", store=store,
+            exe_path=work_dir / "game.exe",
+            work_dir=work_dir,
+            plugin_dir=plugin_dir,
+        ),
+        state=types.SimpleNamespace(wrappers=[], game_args=[], umu_id=None),
+        python_bin=Path("/usr/bin/python3"),
+        umu_wrapper=plugin_dir / "bin/umu/umu/umu-run",
+        prefix_path=work_dir / "prefix",
+        env={},
+        on_process_start=None,
+    )
+
+
+def _capture_config(
+    monkeypatch: pytest.MonkeyPatch, func_name: str,
+) -> list[Any]:
+    """Record the ConfigManager each handler hands to language setup.
+
+    The handlers swallow every exception around language setup — a launch
+    must never be blocked by it — so assertions have to happen outside the
+    captured call, not inside it.
+    """
+    seen: list[Any] = []
+    import unifideck.launcher.proton.language_setup as ls
+
+    def _record(*_args: Any, config: Any = None, **_kw: Any) -> bool:
+        seen.append(config)
+        return True
+
+    monkeypatch.setattr(ls, func_name, _record)
+    return seen
+
+
+# ── Ubisoft ────────────────────────────────────────────────────────────
+def test_ubisoft_honours_the_language_picked_in_the_unifideck_ui(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unifideck.launcher.proton.handlers.ubisoft import _apply_language_setup
+
+    plugin_dir = _installed_plugin(tmp_path, monkeypatch, "es-ES")
+    seen = _capture_config(monkeypatch, "apply_ubisoft_language")
+
+    _apply_language_setup(_plan(plugin_dir, tmp_path, "ubisoft"))
+
+    assert len(seen) == 1
+    assert get_unifideck_locale(seen[0]) == "es-ES"
+
+
+def test_ubisoft_falls_back_to_the_machine_when_nothing_was_picked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unifideck.launcher.proton.handlers.ubisoft import _apply_language_setup
+
+    plugin_dir = _installed_plugin(tmp_path, monkeypatch, None)
+    seen = _capture_config(monkeypatch, "apply_ubisoft_language")
+
+    _apply_language_setup(_plan(plugin_dir, tmp_path, "ubisoft"))
+
+    assert get_unifideck_locale(seen[0]) == "en-US"
+
+
+# ── Amazon ─────────────────────────────────────────────────────────────
+async def test_amazon_honours_the_language_picked_in_the_unifideck_ui(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import unifideck.launcher.proton.handlers.generic as generic
+
+    plugin_dir = _installed_plugin(tmp_path, monkeypatch, "es-ES")
+    seen = _capture_config(monkeypatch, "apply_amazon_language")
+
+    async def _no_launch(*_args: Any, **_kw: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(generic, "run_umu_with_retry", _no_launch)
+
+    await generic._amazon_launch(_plan(plugin_dir, tmp_path, "amazon"))
+
+    assert len(seen) == 1
+    assert get_unifideck_locale(seen[0]) == "es-ES"
+
+
+async def test_amazon_falls_back_to_the_machine_when_nothing_was_picked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import unifideck.launcher.proton.handlers.generic as generic
+
+    plugin_dir = _installed_plugin(tmp_path, monkeypatch, None)
+    seen = _capture_config(monkeypatch, "apply_amazon_language")
+
+    async def _no_launch(*_args: Any, **_kw: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(generic, "run_umu_with_retry", _no_launch)
+
+    await generic._amazon_launch(_plan(plugin_dir, tmp_path, "amazon"))
+
+    assert get_unifideck_locale(seen[0]) == "en-US"


### PR DESCRIPTION
> [!NOTE]
> The language a user picks never reached the games. Inside the launcher
> process, `get_unifideck_locale` returned `en-US` for everyone: its
> `ConfigManager` was built with a defaults path that does not exist on a Decky
> CLI install and no user path at all, so the merged view was the hardcoded
> `_FALLBACK` — whose `ui.language` key then short-circuited tier 1. This fixes
> that, adds Steam's own UI language above the POSIX locale, and makes the
> winning tier visible in the log.

> [!IMPORTANT]
> No public API change. `get_unifideck_locale` keeps its signature and its
> contract. Users who never picked a language may now get their Steam language
> instead of English — the intended behaviour of the shipped
> `ui.locale = "auto"`. An explicit choice still wins over everything.

## 1 — The launcher could not find the packaged defaults

### Why
Two install layouts are valid, writing the plugin's install directory as `{plugin}`: `{plugin}/defaults/config.json` for local builds, and `{plugin}/config.json` for Decky CLI builds. The flattening is the CLI's own doing — `src/cli/plugin/build.rs::zip_path` runs `name.strip_prefix("defaults")` on every entry, so `defaults/config.json` is stored at the plugin root. `bootstrap.boot._resolve_defaults_path` handles both layouts and documents why.

The launcher process is a separate entry point and never used it. All three per-store language handlers hardcode the nested layout:

```python
ConfigManager(str(plan.context.plugin_dir / "defaults" / "config.json"))
```

On a CLI-built install — anyone who did not build locally — that file is not there, so `ConfigManager` merged nothing but `_FALLBACK`. None of the three passed `user_path` either, so the user's own config was not read whatever the layout. A support bundle from a plugin installed the ordinary way reports `defaults_config: False` with `flattened_config: True`.

### How
`bootstrap.boot`'s resolver moves to `config/defaults_path.py` as `resolve_defaults_config_path`, next to the existing `user_config_path`; `bootstrap.boot` delegates to it, unchanged in behaviour. The Epic, Amazon and Ubisoft handlers now call it and pass `user_path=resolve_user_config_path()`.

## 2 — `ui.language` is not a user preference

### Why
`_FALLBACK` declares `ui = {"language": "en-US"}`. Nothing writes that key: the frontend selector saves `ui.locale` (`rpc/mixins/ui.py:166`) and `defaults/config.json` declares only `ui.locale`. But tier 1 read `ui.language`, and a fallback value is indistinguishable from a real choice — so tier 1 always hit and always returned `en-US`, whatever the layers above it said. `get_cfg`'s docstring asks that a default "match the value declared for `key` in `defaults/config.json`"; this one had no declaration at all.

### How
`_FALLBACK["ui"]` becomes `{"locale": "auto"}`, matching the schema. Tier 1 reads `ui.locale` first, `ui.language` second so legacy user files keep working, and skips the literal `"auto"` — that means "no explicit choice", not a tag.

## 3 — Only tier 1 honoured the designed degraded path

### Why
`get_locale_config` returns None when the `i18n` section is absent (what fix 1 was causing) or when `scripts/locale_config.py` cannot be imported. The second is the normal case in production, and by design rather than by accident: `scripts/` is build and dev tooling, the Decky CLI packages only `dist/`, `bin/`, `defaults/` and `py_modules/` plus a fixed list of root files, and 14 of the 15 scripts are never imported by `py_modules/`. `locale_config.py` is the one exception — a runtime dependency that happens to live with the build tools.

The code already anticipates this. `_import_locale_config` documents that None "signals no schema validation available and the caller falls through to its default behaviour", and `ConfigManager` skips validation "rather than fail". Tier 1 honours that contract: with no canonical list it trusts the saved value unvalidated. `_detect_system_locale` and the new Steam tier did not — they returned None on the very condition the design says to carry on through, so resolution fell past them to the hardcoded `en-US` at the bottom: `[locale] no config available, using hardcoded en-US`, seen on device.

### How
All tiers now degrade alike: with no canonical list the resolved tag is normalised and trusted rather than discarded. Validation still runs whenever the list is available.

## 4 — Steam's UI language, ahead of the POSIX locale

### Why
SteamOS ships `LANG=en_US.UTF-8` and never updates it; the language a Deck user picks lives in Steam's settings and is not exported to the environment. The frontend already sidesteps this — `i18n/translations.ts:129` resolves `"auto"` from `navigator.language`, which in Steam's webview is Steam's UI language — so the panel rendered in one language while the backend launched games in English. The two halves of the plugin disagreed about what `"auto"` means.

### How
New `utils/steam_language.py` reads `language` from `registry.vdf` (the same three candidate paths `steam/current_user.py` already probes — duplicated rather than imported, because `utils` is a lower layer than `steam` and must not depend on it) and maps Steam's API language codes to BCP-47. Which tags are *supported* still comes from `i18n.locales` when it is available, so the module cannot drift from the shipped list.

## 5 — The log now says which tier won

### Why
This stayed hidden for a long time because resolution was unobservable: the logs showed which language was used, never where it came from, so "English again" looked identical whether the user's choice was unreachable, Steam was unreadable, or the machine really was English.

### How
One INFO line per distinct outcome — `[locale] resolved es-ES (source: Steam UI language)`. Deduplicated, because resolution runs on every store request and market lookup and a per-call line would drown the log it exists to clarify.

## Verification
- [x] Lint clean (`ruff check py_modules/ main.py`)
- [x] Types clean (`mypy py_modules/unifideck/` — 515 files)
- [x] Volumetry clean (files / functions / locals / nesting / fan-out)
- [x] Import smoke test passes
- [x] Test suite: 1653 passed
- [x] Every fix verified load-bearing — each was reverted on its own and a dedicated test went red. The three handlers are covered separately: Epic in `test_epic_launch_language.py`, Amazon and Ubisoft in `test_store_launch_language.py`
- [x] The published 0.7.3 release zip carries no `scripts/` directory, matching what `src/cli/plugin/build.rs` packages — and 14 of the 15 scripts are never imported from `py_modules/`, so that is the right call
- [x] Confirmed on hardware — a Steam Deck and a Steam Machine, both SteamOS 3.8.16 with the Steam UI in a non-English language and `LANG=en_US.UTF-8`. Before, `ui.locale = "auto"` logged `[locale] no config available, using hardcoded en-US` and every Epic title launched with `-epiclocale=en`. After, both tiers were exercised and reported themselves, and the chosen language reached all three of the handlers this touches:

      [locale] resolved es-ES (source: user preference, unvalidated)
        → [launcher.proton.epic] language es-ES → -epiclocale=es
      [locale] resolved es-ES (source: Steam UI language)
        → [launcher.proton.epic] language es-ES → -epiclocale=es
      [locale] resolved es-ES (source: Steam UI language)
        → [language_setup.amazon] wrote locale=es-ES to {prefix}/user.reg
      [locale] resolved es-ES (source: Steam UI language)
        → [language_setup.ubisoft] wrote locale=es-ES to {prefix}/user.reg
        → [language_setup.ubisoft] UPC Language=es written

      The Epic run also reaches the game process itself: the argv in the
      game log carries `-epiclocale=es` among the Epic Portal parameters.

The per-store tests build their fixture in the Decky CLI layout, so they reproduce what an installed plugin looks like rather than a source checkout, and they pin the machine to a language the user did not pick so a fallback cannot masquerade as success. The locale tests pin the POSIX locale by patching `locale.getlocale`, not by setting `LANG` — Python reads the process locale fixed at startup, so an env var set mid-test would prove nothing.

## Files changed
- `py_modules/unifideck/config/defaults_path.py` — new; resolves the bundled config across both install layouts
- `py_modules/unifideck/bootstrap/boot.py` — `_resolve_defaults_path` delegates to it
- `py_modules/unifideck/launcher/proton/handlers/epic.py` — resolved defaults path + `user_path`
- `py_modules/unifideck/launcher/proton/handlers/generic.py` — same, for Amazon's language setup
- `py_modules/unifideck/launcher/proton/handlers/ubisoft.py` — same, for Ubisoft's language setup
- `py_modules/unifideck/config/config_manager.py` — `_FALLBACK["ui"]` declares `locale`, not the unwritten `language`
- `py_modules/unifideck/utils/locale.py` — tier 1 reads `ui.locale` and skips `"auto"`; new tier 2 asks Steam; the POSIX tier degrades instead of giving up; the winning tier is reported
- `py_modules/unifideck/utils/steam_language.py` — new; reads and maps Steam's UI language
- `tests/unit/test_locale_resolution.py` — new; layout resolution, tier order, Steam mapping, degraded mode, the reported source
- `tests/unit/test_epic_launch_language.py` — two tests driving the real `ConfigManager` in the packaged layout
- `tests/unit/test_store_launch_language.py` — new; the same, for Amazon and Ubisoft
