### PR TITLE
fix(ui): make the Downloads Update button react to the gamepad

### DIFF
--- a/src/components/play/play.css.test.ts
+++ b/src/components/play/play.css.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Every `unifideck-*-btn` class a component puts on a button must have a rule
+ * behind it, and that rule must include a focus state.
+ *
+ * The bug that prompted this: `unifideck-download-update-btn` was applied to
+ * the Update button in the Downloads tab and styled nowhere. It read to the
+ * user as a dead button: with no focus rule the gamepad got no feedback at
+ * all when it reached the button, so the only way to press it was the
+ * trackpad. It was focusable the whole time; nothing on screen said so.
+ *
+ * A class name is a string on both sides, so nothing but a test connects
+ * them.
+ */
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return walk(full);
+    return /\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry) ? [full] : [];
+  });
+}
+
+const BUTTON_CLASS = /"(unifideck-[a-z0-9-]+-btn)"/g;
+
+// Read as text rather than imported: play.css.ts pulls in @decky/ui, which
+// needs a React runtime this suite deliberately does not have.
+const CSS = readFileSync(join(__dirname, "play.css.ts"), "utf-8");
+
+const used = new Set<string>();
+for (const file of walk(join(__dirname, "..", ".."))) {
+  const source = readFileSync(file, "utf-8");
+  if (file.endsWith("play.css.ts")) continue;
+  for (const [, name] of source.matchAll(BUTTON_CLASS)) used.add(name);
+}
+
+describe("button classes used by components", () => {
+  it("finds the classes at all, so an empty pass is not a pass", () => {
+    expect(used.size).toBeGreaterThan(2);
+  });
+
+  // Selectors are often grouped (".a,\n.b,\n.c {"), so a class counts as
+  // styled when it appears as a selector at all, not only when it opens its
+  // own block.
+  const selector = (name: string) => new RegExp(`\\.${name}[\\s,:.{]`);
+
+  it.each([...used])("%s is styled", (name) => {
+    expect(CSS).toMatch(selector(name));
+  });
+
+  it.each([...used])("%s reacts to gamepad focus", (name) => {
+    // Steam puts `.gpfocus` on the focused element. Without a rule that
+    // mentions it, the button gives the user nothing to see and reads as
+    // disabled — which is exactly how the Downloads Update button shipped.
+    expect(CSS).toMatch(new RegExp(`\\.${name}\\.gpfocus`));
+  });
+});

--- a/src/components/play/play.css.ts
+++ b/src/components/play/play.css.ts
@@ -370,6 +370,34 @@ export const PLAY_FOCUS_CSS = `
   z-index: 1;
 }
 
+/* Update REPLACES Play on a row with a pending update, and it was the only
+ * one of the three buttons whose class had no rules behind it — so it alone
+ * had no focus state, and gave the user nothing to see when the gamepad
+ * reached it. It was focusable the whole time (same DialogButton, same nav
+ * grid as Play and Uninstall), but with no visible change it reads as
+ * disabled, and the trackpad becomes the only way to press it.
+ *
+ * The fill stays where it is: the row sets it inline and that works. Only the
+ * focus treatment was missing, and it matches Play's so the two behave alike
+ * under the thumbstick. */
+.unifideck-download-update-btn {
+  transition: filter 0.15s ease, box-shadow 0.15s ease !important;
+}
+.unifideck-download-update-btn:hover,
+.unifideck-download-update-btn:focus,
+.unifideck-download-update-btn:focus-within,
+.unifideck-download-update-btn.gpfocus {
+  filter: brightness(1.25) !important;
+  box-shadow:
+    0 0 0 3px #ffffff,
+    0 0 0 6px rgba(0, 0, 0, 0.7) !important;
+  transform: scale(1.05);
+  /* position needed for z-index to apply, so the ring paints over the
+     neighbouring button instead of being clipped by it. */
+  position: relative;
+  z-index: 1;
+}
+
 /* Uninstall sits in the same nav grid, so it needs an equally clear focus
  * state — it had none at all, being a bare Secondary DialogButton. Steam's
  * own convention for a focused neutral button is an inverted fill, which


### PR DESCRIPTION
> [!NOTE]
> On a Downloads row with a pending update, the Update button that replaces
> Play carries the class `unifideck-download-update-btn`, and in 0.7.4 that
> class has no rules behind it anywhere — the only one of the three buttons in
> that row without any. So it alone has no focus state, and gives the user
> nothing to see when the gamepad reaches it.

It is focusable the whole time: the same `DialogButton`, in the same
`flow-children="grid"` nav container as Play and Uninstall. But with no visible
change it reads as disabled.

## The fix

Adds the focus treatment Play already has — a solid white ring over a dark
outer ring, plus a small scale-up — so the two behave alike under the
thumbstick. That combination is what `unifideck-download-play-btn` settled on
after a first attempt (a brightness bump and a thin translucent ring) proved
nearly invisible at arm's length on a handheld; the comment already in the file
records why.

The rules go into `PLAY_FOCUS_CSS`, which `DownloadsTab.tsx:147` already
injects — the same block that styles Play and Uninstall on those rows.

<img width="1280" height="720" alt="photo_2026-08-23_14-45-42" src="https://github.com/user-attachments/assets/45655678-5cb5-423e-b2c1-d291b76c6053" />

The fill is deliberately left alone: the row sets it inline and that works.
Only the focus state was missing.

## The test

`play.css.test.ts` walks every component under `src/`, collects the
`unifideck-*-btn` classes they apply, and asserts each one is styled and
mentions `.gpfocus`. A class name is a string on both sides — the component
writes it, the stylesheet answers it — so nothing but a test connects them,
which is how this one went unnoticed. It covers ten classes, so the same
mistake in any future button is caught at the source.

It reads the stylesheet as text rather than importing it: `play.css.ts` pulls
in `@decky/ui`, which needs a React runtime the suite does not have.

## Verification

- [x] `tsc --noEmit`, ESLint, Prettier and `scripts/lint_rtl.py` all clean
- [x] `play.css.test.ts`: 21 assertions passing (ten button classes × styled +
      gamepad-focus, plus a guard so the walker finding nothing cannot pass
      silently)
- [x] Load-bearing: restoring the 0.7.4 `play.css.ts` turns it red on exactly
      the two `unifideck-download-update-btn` assertions, leaving the other 19
      green
- [x] Confirmed on a Steam Deck running 0.7.4: the focus ring now appears when
      the thumbstick reaches the button, and the trackpad path is unchanged
- [x] Adds only — no existing line is modified

## Files changed

- `src/components/play/play.css.ts` — the missing focus rules
- `src/components/play/play.css.test.ts` — new; every button class is styled and answers `.gpfocus`