### PR TITLE
fix: keep game sidecars out of GOG setup helpers

### DIFF
--- a/py_modules/unifideck/launcher/proton/compat/gog_setup/common.py
+++ b/py_modules/unifideck/launcher/proton/compat/gog_setup/common.py
@@ -136,6 +136,13 @@ async def run_wine(
     "already installed", so callers treat failures as non-fatal.
     """
     env = dict(plan.env)
+    # ``PROTON_REMOTE_DEBUG_CMD`` is a game-side sidecar (for example a
+    # CheatDeck trainer), not part of the GOG setup helper. If it reaches
+    # ``scriptinterpreter.exe``, Proton starts the sidecar before the helper
+    # and the helper can wait on that unrelated Wine process indefinitely.
+    # Keep the rest of the launch environment, including
+    # ``PRESSURE_VESSEL_FILESYSTEMS_RW`` for filesystem access.
+    env.pop("PROTON_REMOTE_DEBUG_CMD", None)
     env["GAMEID"] = "umu-0"
     env["STORE"] = "gog"
     env["PROTON_VERB"] = "run"

--- a/tests/unit/test_gog_setup_common.py
+++ b/tests/unit/test_gog_setup_common.py
@@ -1,0 +1,45 @@
+"""GOG setup subprocess environment boundaries."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from unifideck.launcher.proton.compat.gog_setup import common
+
+
+async def test_run_wine_does_not_start_sidecar_for_setup_helper(monkeypatch):
+    """A CheatDeck sidecar belongs to the game, not ``scriptinterpreter``."""
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, env, stdout, stderr):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["stdout"] = stdout
+        captured["stderr"] = stderr
+
+        class Process:
+            async def wait(self) -> int:
+                return 0
+
+        return Process()
+
+    monkeypatch.setattr(common.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(common, "escape_argv", lambda argv, env, cwd: argv)
+
+    plan = SimpleNamespace(
+        env={
+            "PROTON_REMOTE_DEBUG_CMD": "/home/deck/Games/Trainers/trainer.exe",
+            "PRESSURE_VESSEL_FILESYSTEMS_RW": "/home/deck/Games/Trainers",
+            "PROTONPATH": "/home/deck/.steam/compatibilitytools.d/GE-Proton11-5",
+        },
+        python_bin="/usr/bin/python3",
+        umu_wrapper="/plugin/bin/umu/umu-run",
+    )
+
+    assert await common.run_wine(plan, "scriptinterpreter.exe", ["/VERYSILENT"])
+
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "PROTON_REMOTE_DEBUG_CMD" not in env
+    assert env["PRESSURE_VESSEL_FILESYSTEMS_RW"] == "/home/deck/Games/Trainers"
+    assert env["PROTONPATH"].endswith("GE-Proton11-5")
+    assert plan.env["PROTON_REMOTE_DEBUG_CMD"].endswith("trainer.exe")

--- a/tests/unit/test_gog_setup_common.py
+++ b/tests/unit/test_gog_setup_common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from unifideck.launcher.proton.compat.gog_setup import common
+from unifideck.launcher.proton.infrastructure import container_escape
 
 
 async def test_run_wine_does_not_start_sidecar_for_setup_helper(monkeypatch):
@@ -22,7 +23,11 @@ async def test_run_wine_does_not_start_sidecar_for_setup_helper(monkeypatch):
 
         return Process()
 
-    monkeypatch.setattr(common.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        common.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
     monkeypatch.setattr(common, "escape_argv", lambda argv, env, cwd: argv)
 
     plan = SimpleNamespace(
@@ -43,3 +48,47 @@ async def test_run_wine_does_not_start_sidecar_for_setup_helper(monkeypatch):
     assert env["PRESSURE_VESSEL_FILESYSTEMS_RW"] == "/home/deck/Games/Trainers"
     assert env["PROTONPATH"].endswith("GE-Proton11-5")
     assert plan.env["PROTON_REMOTE_DEBUG_CMD"].endswith("trainer.exe")
+
+
+async def test_run_wine_does_not_forward_sidecar_through_pressure_vessel(monkeypatch):
+    """The escaped command must omit the game sidecar as well as its env."""
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, env, stdout, stderr):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["stdout"] = stdout
+        captured["stderr"] = stderr
+
+        class Process:
+            async def wait(self) -> int:
+                return 0
+
+        return Process()
+
+    monkeypatch.setattr(common.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(container_escape, "in_pressure_vessel", lambda: True)
+    monkeypatch.setattr(
+        container_escape.shutil,
+        "which",
+        lambda name: "/usr/bin/steam-runtime-launch-client",
+    )
+    monkeypatch.delenv("PROTON_REMOTE_DEBUG_CMD", raising=False)
+    monkeypatch.delenv("PRESSURE_VESSEL_FILESYSTEMS_RW", raising=False)
+
+    plan = SimpleNamespace(
+        env={
+            "PROTON_REMOTE_DEBUG_CMD": "/home/deck/Games/Trainers/trainer.exe",
+            "PRESSURE_VESSEL_FILESYSTEMS_RW": "/home/deck/Games/Trainers",
+            "PROTONPATH": "/home/deck/.steam/compatibilitytools.d/GE-Proton11-5",
+        },
+        python_bin="python3",
+        umu_wrapper="/plugin/bin/umu/umu-run",
+    )
+
+    assert await common.run_wine(plan, "scriptinterpreter.exe", ["/VERYSILENT"])
+
+    cmd = captured["cmd"]
+    assert isinstance(cmd, tuple)
+    assert not any(arg.startswith("PROTON_REMOTE_DEBUG_CMD=") for arg in cmd)
+    assert "PRESSURE_VESSEL_FILESYSTEMS_RW=/home/deck/Games/Trainers" in cmd


### PR DESCRIPTION
## What changed

`run_wine` now removes `PROTON_REMOTE_DEBUG_CMD` from the environment used by `scriptinterpreter.exe`. The variable belongs to the final game process; if it reaches the GOG setup helper, Proton starts the CheatDeck trainer during setup and can wait indefinitely on that unrelated Wine process.

Other environment variables remain unchanged, including `PRESSURE_VESSEL_FILESYSTEMS_RW`.

## Tests

Added a regression test that captures the actual subprocess environment and verifies:

- the sidecar command is absent;
- filesystem sharing is preserved;
- the Proton path is preserved;
- the original plan environment is not mutated.
- the escaped pressure-vessel command also omits the sidecar while preserving
  the filesystem-sharing assignment.

Commits: `f45a052`, `b2b356e`  
Branch: `fix/sanitize-gog-helper-sidecar`  
Base: `staging`

## Validation

- focused regression: 2 passed;
- focused existing Python tests: 16 passed, 6 Windows path failures in `test_container_escape.py` caused by POSIX path assumptions;
- Python compilation: passed;
- JavaScript test suite: 111 passed, 10 baseline failures caused by missing `react/jsx-dev-runtime` resolution;
- build/typecheck: blocked by the baseline `SiAmazongames` export mismatch in `src/components/shared/StoreIcon.tsx`.
